### PR TITLE
Add created time, add sorting in proposal table, sort by created time by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You also need to add a SessionProposals table to your Airtable base:
   - `hosts`: Link to another record (Guests),
     "Allow linking to multiple records" **checked**
   - `title`: Single line text (Primary field)
+  - `createdTime`: Created time
 
 ## Development
 

--- a/app/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/[eventSlug]/proposals/proposal-table.tsx
@@ -25,6 +25,11 @@ import type { Event } from "@/db/events";
 
 const ITEMS_PER_PAGE = 10;
 
+type SortConfig = {
+  key: keyof SessionProposal;
+  direction: "asc" | "desc";
+};
+
 export function ProposalTable({
   guests,
   proposals: paramProposals,
@@ -45,6 +50,10 @@ export function ProposalTable({
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(1);
   const [myProposals, setMyProposals] = useState(false);
+  const [sortConfig, setSortConfig] = useState<SortConfig>({
+    key: "createdTime",
+    direction: "desc",
+  });
   const { user: currentUserId } = useContext(UserContext);
   const router = useRouter();
   const filteredProposals = initialProposals.filter((pr) => {
@@ -88,6 +97,36 @@ export function ProposalTable({
   const searchResults = searchQuery.trim()
     ? fuse.search(searchQuery).map((res) => res.item)
     : filteredProposals;
+  searchResults.sort((a, b) => {
+    const { key, direction } = sortConfig;
+
+    let cmp = 0;
+    if (key === "title") {
+      cmp = a[key].localeCompare(b[key]);
+    } else if (key === "hosts") {
+      // Missing or empty values are always last
+      if (a[key].length === 0 && b[key].length === 0) {
+        return 0;
+      } else if (a[key].length === 0) {
+        return -1;
+      } else if (b[key].length === 0) {
+        return 1;
+      }
+
+      const hostNames = (hosts: string[]) =>
+        guests
+          .filter((g) => hosts.includes(g.ID))
+          .map((g) => g.Name)
+          .sort()
+          .join("");
+      cmp = hostNames(a.hosts).localeCompare(hostNames(b.hosts));
+    } else if (key === "durationMinutes") {
+      cmp = (a[key] || 0) - (b[key] || 0);
+    } else if (key === "createdTime") {
+      cmp = new Date(a[key]).getTime() - new Date(b[key]).getTime();
+    }
+    return direction === "asc" ? cmp : -cmp;
+  });
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);
@@ -152,6 +191,16 @@ export function ProposalTable({
     } else {
       return currentUserId && hosts.includes(currentUserId);
     }
+  };
+
+  const handleSort = (key: keyof SessionProposal) => {
+    let direction: "asc" | "desc" = "asc";
+
+    if (sortConfig.key === key && sortConfig.direction === "asc") {
+      direction = "desc";
+    }
+
+    setSortConfig({ key, direction });
   };
 
   return (
@@ -251,16 +300,30 @@ export function ProposalTable({
           <thead className="bg-gray-50">
             <tr>
               <th
+                onClick={() => handleSort("title")}
                 scope="col"
-                className="w-[20%] text-left px-4 lg:px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className={`w-[20%] text-left px-4 lg:px-6 py-3 text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
+                  ${sortConfig.key === "title" ? "text-gray-900 font-semibold" : "text-gray-500"}`}
               >
                 Title
+                {sortConfig.key === "title"
+                  ? sortConfig.direction === "asc"
+                    ? " ↓"
+                    : " ↑"
+                  : " ↑↓"}
               </th>
               <th
+                onClick={() => handleSort("hosts")}
                 scope="col"
-                className="w-[15%] px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className={`w-[15%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
+                  ${sortConfig.key === "hosts" ? "text-gray-900 font-semibold" : "text-gray-500"}`}
               >
                 Host(s)
+                {sortConfig.key === "hosts"
+                  ? sortConfig.direction === "asc"
+                    ? " ↓"
+                    : " ↑"
+                  : " ↑↓"}
               </th>
               <th
                 scope="col"
@@ -269,10 +332,17 @@ export function ProposalTable({
                 Description
               </th>
               <th
+                onClick={() => handleSort("durationMinutes")}
                 scope="col"
-                className="w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className={`w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
+                  ${sortConfig.key === "durationMinutes" ? "text-gray-900 font-semibold" : "text-gray-500"}`}
               >
                 Duration
+                {sortConfig.key === "durationMinutes"
+                  ? sortConfig.direction === "asc"
+                    ? " ↓"
+                    : " ↑"
+                  : " ↑↓"}
               </th>
               <th
                 scope="col"

--- a/db/sessionProposals.ts
+++ b/db/sessionProposals.ts
@@ -7,6 +7,7 @@ export type SessionProposal = {
   description?: string;
   hosts: string[];
   durationMinutes?: number;
+  createdTime: string;
 };
 
 export type NewProposalInput = {
@@ -21,7 +22,14 @@ export async function getSessionProposalsByEvent(event: string) {
   const proposals: SessionProposal[] = [];
   await base("SessionProposals")
     .select({
-      fields: ["event", "title", "description", "hosts", "durationMinutes"],
+      fields: [
+        "event",
+        "title",
+        "description",
+        "hosts",
+        "durationMinutes",
+        "createdTime",
+      ],
       filterByFormula: `{event} = "${event}"`,
     })
     .eachPage(function page(records, fetchNextPage) {


### PR DESCRIPTION
Notes:
- Created time is not visible to the user
- By default the table is sorted by created time, but that's not obvious
- When any other sorting is applied, the only way to go back to the default sorting is to refresh the page

Closes https://github.com/LWCW-Europe/scheduling-app/issues/110