### PR TITLE
feat: Add title and description tooltips to proposal table cells

### DIFF
--- a/app/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/[eventSlug]/proposals/proposal-table.tsx
@@ -295,7 +295,10 @@ export function ProposalTable({
                 className="hover:bg-gray-200 cursor-pointer"
                 onClick={() => visitViewPage(proposal)}
               >
-                <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                <td
+                  className="px-4 lg:px-6 py-4 whitespace-nowrap"
+                  title={proposal.title}
+                >
                   <div className="text-sm font-medium text-gray-900 truncate">
                     {proposal.title}
                   </div>
@@ -310,7 +313,10 @@ export function ProposalTable({
                       .join(", ") || "-"}
                   </div>
                 </td>
-                <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                <td
+                  className="px-4 lg:px-6 py-4 whitespace-nowrap"
+                  title={proposal.description}
+                >
                   <div className="text-sm text-gray-500 truncate">
                     {proposal.description || "-"}
                   </div>


### PR DESCRIPTION
This adds a small usability improvement.

Currently, the title and description are truncated which makes it hard to read through every item in the list:
<img width="1035" height="496" alt="Screenshot 2025-08-05 at 15 32 25" src="https://github.com/user-attachments/assets/b367bf64-9716-453f-9c9d-47aae9496633" />

With this change, it's possible to hover over the title and description to see the full title or description without having to open the proposals page:

<img width="1158" height="357" alt="Screenshot 2025-08-05 at 15 33 00" src="https://github.com/user-attachments/assets/82a7bb4f-89e4-4a2f-948b-f2d80b0580d1" />
