### PR TITLE
fix: add helpers to convert event.Name to slug and back

### DIFF
--- a/app/[eventSlug]/page.tsx
+++ b/app/[eventSlug]/page.tsx
@@ -1,11 +1,11 @@
 import { EventPhase, getCurrentPhase } from "../utils/events";
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import EventPage from "./event-page";
 import { redirect } from "next/navigation";
 
 export default async function Page(props: { params: { eventSlug: string } }) {
   const { eventSlug } = props.params;
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const event = await getEventByName(eventName);
 
   if (!event) {

--- a/app/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import { SessionProposalForm } from "@/app/[eventSlug]/session-proposal-form";
 import { notFound } from "next/navigation";
 
@@ -12,7 +12,7 @@ export default async function EditProposalPage({
   const { eventSlug, proposalId } = params;
 
   // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const event = await getEventByName(eventName);
 
   if (!event) {

--- a/app/[eventSlug]/proposals/[proposalId]/page.tsx
+++ b/app/[eventSlug]/proposals/[proposalId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import { ViewProposal } from "./view-proposal";
 
 export default async function ViewProposalPage({
@@ -13,7 +13,7 @@ export default async function ViewProposalPage({
   const { eventSlug, proposalId } = params;
 
   // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const event = await getEventByName(eventName);
 
   if (!event) {

--- a/app/[eventSlug]/proposals/new/page.tsx
+++ b/app/[eventSlug]/proposals/new/page.tsx
@@ -1,5 +1,5 @@
 import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import { SessionProposalForm } from "../../session-proposal-form";
 
 export default async function NewProposalPage({
@@ -10,7 +10,7 @@ export default async function NewProposalPage({
   const { eventSlug } = params;
 
   // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const event = await getEventByName(eventName);
 
   if (!event) {

--- a/app/[eventSlug]/proposals/page.tsx
+++ b/app/[eventSlug]/proposals/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import { ProposalTable } from "./proposal-table";
 import { ProposalActionBar } from "./proposal-action-bar";
 import { UserSelect } from "@/app/user-select";
@@ -17,7 +17,7 @@ export default async function ProposalsPage({
   const { eventSlug } = params;
 
   // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const event = await getEventByName(eventName);
 
   if (!event) {

--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -14,6 +14,7 @@ import { CurrentUserModal, ConfirmationModal } from "../modals";
 import { UserContext, EventContext } from "../context";
 import { sessionsOverlap } from "../session_utils";
 import { useScreenWidth } from "@/utils/hooks";
+import { eventNameToSlug } from "@/db/events";
 
 export function SessionBlock(props: {
   eventName: string;
@@ -23,7 +24,7 @@ export function SessionBlock(props: {
   guests: Guest[];
 }) {
   const { eventName, session, location, day, guests } = props;
-  const eventSlug = eventName.replace(/ /g, "-");
+  const eventSlug = eventNameToSlug(eventName);
   const { rsvpdForSession } = useContext(EventContext);
   const { user } = useContext(UserContext);
   const rsvpd = rsvpdForSession(session.ID + (user ? "" : ""));

--- a/app/[eventSlug]/session-form-page.tsx
+++ b/app/[eventSlug]/session-form-page.tsx
@@ -1,4 +1,4 @@
-import { getEventByName } from "@/db/events";
+import { eventSlugToName, getEventByName } from "@/db/events";
 import { SessionForm } from "./session-form";
 import { Suspense } from "react";
 import { getDaysByEvent } from "@/db/days";
@@ -11,7 +11,7 @@ export async function renderSessionForm(props: {
   params: { eventSlug: string };
 }) {
   const { eventSlug } = props.params;
-  const eventName = eventSlug.replace(/-/g, " ");
+  const eventName = eventSlugToName(eventSlug);
   const [event, days, sessions, guests, locations] = await Promise.all([
     getEventByName(eventName),
     getDaysByEvent(eventName),

--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -19,6 +19,7 @@ import { ConfirmDeletionModal } from "../modals";
 import { UserContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { parseSessionTime } from "../api/session-form-utils";
+import { eventNameToSlug } from "@/db/events";
 
 interface ErrorResponse {
   message: string;
@@ -184,10 +185,7 @@ export function SessionForm(props: {
     if (res.ok) {
       const actionType = sessionID ? "updated" : "added";
       router.push(
-        `/${eventName.replace(
-          / /g,
-          "-"
-        )}/add-session/confirmation?actionType=${actionType}`
+        `/${eventNameToSlug(eventName)}/add-session/confirmation?actionType=${actionType}`
       );
       console.log(`Session ${actionType} successfully`);
     } else {
@@ -222,7 +220,7 @@ export function SessionForm(props: {
     if (res.ok) {
       console.log("Session deleted successfully");
       router.push(
-        `/${eventName.replace(/ /g, "-")}/edit-session/deletion-confirmation`
+        `/${eventNameToSlug(eventName)}/edit-session/deletion-confirmation`
       );
     } else {
       let errorMessage = "Failed to delete session";

--- a/app/summary-page.tsx
+++ b/app/summary-page.tsx
@@ -6,7 +6,7 @@ import {
 } from "@heroicons/react/16/solid";
 import { DateTime } from "luxon";
 import Link from "next/link";
-import { Event } from "@/db/events";
+import { Event, eventNameToSlug } from "@/db/events";
 import { CONSTS } from "@/utils/constants";
 
 export default function SummaryPage(props: { events: Event[] }) {
@@ -46,7 +46,7 @@ export default function SummaryPage(props: { events: Event[] }) {
               </div>
               <p className="text-gray-900 mt-2">{event.Description}</p>
               <Link
-                href={`/${event.Name.replace(" ", "-")}`}
+                href={`/${eventNameToSlug(event.Name)}`}
                 className="font-semibold text-rose-400 hover:text-rose-500 flex gap-1 items-center text-sm justify-end mt-2"
               >
                 View schedule

--- a/db/events.ts
+++ b/db/events.ts
@@ -169,3 +169,11 @@ export async function getEventByName(name: string) {
     return events[0];
   });
 }
+
+export function eventNameToSlug(name: string): string {
+  return name.replace(/ /g, "-");
+}
+
+export function eventSlugToName(slug: string): string {
+  return slug.replace(/-/g, " ");
+}


### PR DESCRIPTION
There was one spot where there still was a mistake*, which also happened in the past, so with the new helper I'm hoping to get rid of that.

* In app/summary-page.tsx only the first space was converted to hyphen, breaking the link if the event name contains multiple spaces.