### PR TITLE
fix: move event slug helpers to utils.ts file to avoid API key error

### DIFF
--- a/app/[eventSlug]/page.tsx
+++ b/app/[eventSlug]/page.tsx
@@ -1,5 +1,6 @@
 import { EventPhase, getCurrentPhase } from "../utils/events";
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import EventPage from "./event-page";
 import { redirect } from "next/navigation";
 

--- a/app/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,6 +1,7 @@
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "@/app/[eventSlug]/session-proposal-form";
 import { notFound } from "next/navigation";
 

--- a/app/[eventSlug]/proposals/[proposalId]/page.tsx
+++ b/app/[eventSlug]/proposals/[proposalId]/page.tsx
@@ -2,7 +2,8 @@ import { notFound } from "next/navigation";
 
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import { ViewProposal } from "./view-proposal";
 
 export default async function ViewProposalPage({

--- a/app/[eventSlug]/proposals/new/page.tsx
+++ b/app/[eventSlug]/proposals/new/page.tsx
@@ -1,5 +1,6 @@
 import { getGuestsByEvent } from "@/db/guests";
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "../../session-proposal-form";
 
 export default async function NewProposalPage({

--- a/app/[eventSlug]/proposals/page.tsx
+++ b/app/[eventSlug]/proposals/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 
 import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 import { getGuestsByEvent } from "@/db/guests";
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import { ProposalTable } from "./proposal-table";
 import { ProposalActionBar } from "./proposal-action-bar";
 import { UserSelect } from "@/app/user-select";

--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -14,7 +14,7 @@ import { CurrentUserModal, ConfirmationModal } from "../modals";
 import { UserContext, EventContext } from "../context";
 import { sessionsOverlap } from "../session_utils";
 import { useScreenWidth } from "@/utils/hooks";
-import { eventNameToSlug } from "@/db/events";
+import { eventNameToSlug } from "@/utils/utils";
 
 export function SessionBlock(props: {
   eventName: string;

--- a/app/[eventSlug]/session-form-page.tsx
+++ b/app/[eventSlug]/session-form-page.tsx
@@ -1,4 +1,5 @@
-import { eventSlugToName, getEventByName } from "@/db/events";
+import { getEventByName } from "@/db/events";
+import { eventSlugToName } from "@/utils/utils";
 import { SessionForm } from "./session-form";
 import { Suspense } from "react";
 import { getDaysByEvent } from "@/db/days";

--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -19,7 +19,7 @@ import { ConfirmDeletionModal } from "../modals";
 import { UserContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { parseSessionTime } from "../api/session-form-utils";
-import { eventNameToSlug } from "@/db/events";
+import { eventNameToSlug } from "@/utils/utils";
 
 interface ErrorResponse {
   message: string;

--- a/app/summary-page.tsx
+++ b/app/summary-page.tsx
@@ -6,7 +6,8 @@ import {
 } from "@heroicons/react/16/solid";
 import { DateTime } from "luxon";
 import Link from "next/link";
-import { Event, eventNameToSlug } from "@/db/events";
+import { Event } from "@/db/events";
+import { eventNameToSlug } from "@/utils/utils";
 import { CONSTS } from "@/utils/constants";
 
 export default function SummaryPage(props: { events: Event[] }) {

--- a/db/events.ts
+++ b/db/events.ts
@@ -169,11 +169,3 @@ export async function getEventByName(name: string) {
     return events[0];
   });
 }
-
-export function eventNameToSlug(name: string): string {
-  return name.replace(/ /g, "-");
-}
-
-export function eventSlugToName(slug: string): string {
-  return slug.replace(/-/g, " ");
-}

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -18,3 +18,11 @@ export const dateOnDay = (date: Date, day: Day) => {
     date.getTime() <= new Date(day.End).getTime()
   );
 };
+
+export function eventNameToSlug(name: string): string {
+  return name.replace(/ /g, "-");
+}
+
+export function eventSlugToName(slug: string): string {
+  return slug.replace(/-/g, " ");
+}


### PR DESCRIPTION
The UI was sometimes displaying an error, presumably because when importing events.ts it was importing base, which requires the API key and it was not loaded. Probably this was happening only in client code, I did not try to debug it in detail once I figured out which commit was the originator of the error.