### PR TITLE
fix: change column title from 'Your votes' to 'Your vote'

### DIFF
--- a/app/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/[eventSlug]/proposals/proposal-table.tsx
@@ -347,7 +347,7 @@ export function ProposalTable({
                 scope="col"
                 className="w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
               >
-                Your votes
+                Your vote
               </th>
               <th
                 scope="col"


### PR DESCRIPTION
The user casts one vote per proposal so plural would be incorrect.