### PR TITLE
Fix button for removing guests from SelectHosts

### DIFF
--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -532,13 +532,15 @@ export function SelectHosts(props: {
                       className="py-1 px-2 bg-gray-100 rounded text-nowrap text-sm flex items-center gap-1"
                     >
                       {host.Name}
-                      <button
-                        onClick={() =>
-                          setHosts(hosts.filter((h) => h !== host))
-                        }
+                      <span
+                        onClick={(e) => {
+                          setHosts(hosts.filter((h) => h !== host));
+                          e.stopPropagation();
+                        }}
+                        role="button"
                       >
-                        <XMarkIcon className="h-3 w-3 text-gray-400" />
-                      </button>
+                        <XMarkIcon className="h-4 w-4 text-gray-400 hover:text-gray-700" />
+                      </span>
                     </span>
                   ))}
                 </>


### PR DESCRIPTION
Changes:
- Changed from button to span to fix JS error (as per #175) - if you inspect the HTML, you can see that this element has a button as a parent.
- Fixed that when the X is clicked, the select always gets opened - I think this was unintentional? It was bad when setting hosts. When selecting a user, it was bad if you want to be not logged in as anyone, and if you want to switch to another user and you click the X then this behaviour was good, but if you want to switch to another user, you should instead be selecting one from the select. So I think it's better this way.
- Made it slightly clearer and larger. I actually recommend increasing to h-5 w-5, even though it's a bit ugly - especially for users with small phones.

Closes https://github.com/LWCW-Europe/scheduling-app/issues/175