### PR TITLE
ci: add AIRTABLE env vars to build job to prevent it from failing

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -34,6 +34,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
+        env:
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+          AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
         run: bun run build
 
   check-with-prettier:


### PR DESCRIPTION
    Error: An API key is required to connect to Airtable. Please set AIRTABLE_API_KEY environment variable.
        at a (/home/runner/work/scheduling-app/scheduling-app/.next/server/chunks/11.js:10:1968)
        at /home/runner/work/scheduling-app/scheduling-app/.next/server/chunks/11.js:10:3519
        at l (/home/runner/work/scheduling-app/scheduling-app/.next/server/chunks/11.js:10:2605)
        at d (/home/runner/work/scheduling-app/scheduling-app/.next/server/chunks/11.js:10:3478)
        at h (/home/runner/work/scheduling-app/scheduling-app/.next/server/app/page.js:1:5446)
        at eh (/home/runner/work/scheduling-app/scheduling-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:134660)
        at e (/home/runner/work/scheduling-app/scheduling-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:137545)
        at ek (/home/runner/work/scheduling-app/scheduling-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:138019)
        at Array.toJSON (/home/runner/work/scheduling-app/scheduling-app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:135629)
        at stringify (<anonymous>) {
      digest: '3940492227'
    }