### PR TITLE
fix: weight 'interested' as 4x 'maybe' for sorting

### DIFF
--- a/app/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/[eventSlug]/proposals/proposal-table.tsx
@@ -181,7 +181,7 @@ export function ProposalTable({
       cmp = getVoteOrder(a.id) - getVoteOrder(b.id);
     } else if (key === "votes") {
       const voteNum = (p: SessionProposal) =>
-        p.interestedVotesCount * 3 + p.maybeVotesCount;
+        p.interestedVotesCount * 4 + p.maybeVotesCount;
       cmp = voteNum(a) - voteNum(b);
     }
     return direction === "asc" ? cmp : -cmp;


### PR DESCRIPTION
This depends a lot on the specifics and is somewhat subjective but thinking
about it some more it seems plausible to me that a person who voted
'interested' is four times as likely to attend as one who voted 'maybe'.
Sorting by total votes is supposed to give hosts a sense of the (relative)
popularity of their proposal.

Only the most recent commit in this PR is relevant, the previous one belongs to #220. This PR should be rebased once that one is merged.