### PR TITLE
feat: enforce 5-10 minute breaks at the end of sessions

### DIFF
--- a/app/[eventSlug]/proposal.tsx
+++ b/app/[eventSlug]/proposal.tsx
@@ -4,16 +4,10 @@ import Link from "next/link";
 
 import type { Guest } from "@/db/guests";
 import type { SessionProposal } from "@/db/sessionProposals";
-
-export function displayDuration(duration: number) {
-  if (duration === 30) {
-    return "30 minutes";
-  } else {
-    const numHours = duration / 60;
-    const hoursStr = numHours === 1 ? "hour" : "hours";
-    return `${numHours} ${hoursStr}`;
-  }
-}
+import {
+  getAdjustedDuration,
+  formatDurationLong,
+} from "@/utils/session-breaks";
 
 export function Proposal(props: {
   eventSlug: string;
@@ -45,7 +39,8 @@ export function Proposal(props: {
       <p className="mb-3 whitespace-pre-line">{proposal.description}</p>
       {proposal.durationMinutes && (
         <p className="text-sm text-gray-600 mb-4">
-          Duration: {displayDuration(proposal.durationMinutes)}
+          Duration:{" "}
+          {formatDurationLong(getAdjustedDuration(proposal.durationMinutes))}
         </p>
       )}
     </>

--- a/app/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/[eventSlug]/proposals/proposal-table.tsx
@@ -23,6 +23,10 @@ import {
   dateStartDescription,
 } from "@/app/utils/events";
 import type { Event } from "@/db/events";
+import {
+  getAdjustedDuration,
+  formatDurationShort,
+} from "@/utils/session-breaks";
 
 import { VotingButtons } from "./voting-buttons";
 import { VoteChoice } from "@/app/votes";
@@ -236,12 +240,8 @@ export function ProposalTable({
 
   const formatDuration = (minutes?: number) => {
     if (!minutes) return "";
-    if (minutes < 60) return `${minutes}m`;
-    const hours = Math.floor(minutes / 60);
-    const remainingMinutes = minutes % 60;
-    return remainingMinutes > 0
-      ? `${hours}h ${remainingMinutes}m`
-      : `${hours}h`;
+    const adjustedMinutes = getAdjustedDuration(minutes);
+    return formatDurationShort(adjustedMinutes);
   };
 
   const canEdit = (hosts: string[]) => {

--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -15,6 +15,7 @@ import { UserContext, EventContext } from "../context";
 import { sessionsOverlap } from "../session_utils";
 import { useScreenWidth } from "@/utils/hooks";
 import { eventNameToSlug } from "@/utils/utils";
+import { getAdjustedSessionTimes } from "@/utils/session-breaks";
 
 export function SessionBlock(props: {
   eventName: string;
@@ -177,35 +178,38 @@ export function RealSessionCard(props: {
     "Num RSVPs"
   ];
 
-  const SessionInfoDisplay = () => (
-    <>
-      <h1 className="text-lg font-bold leading-tight">{session.Title}</h1>
-      <p className="text-xs text-gray-500 mb-2 mt-1">
-        Hosted by {formattedHostNames}
-      </p>
-      <p className="text-sm whitespace-pre-line">{session.Description}</p>
-      <div className="flex justify-between mt-2 gap-4 text-xs text-gray-500">
-        <div className="flex gap-1">
-          <UserIcon className="h-4 w-4" />
-          <span>
-            {numRSVPs} RSVPs (max capacity {session.Capacity})
-          </span>
+  const SessionInfoDisplay = () => {
+    const { adjustedEndTime } = getAdjustedSessionTimes(session);
+    return (
+      <>
+        <h1 className="text-lg font-bold leading-tight">{session.Title}</h1>
+        <p className="text-xs text-gray-500 mb-2 mt-1">
+          Hosted by {formattedHostNames}
+        </p>
+        <p className="text-sm whitespace-pre-line">{session.Description}</p>
+        <div className="flex justify-between mt-2 gap-4 text-xs text-gray-500">
+          <div className="flex gap-1">
+            <UserIcon className="h-4 w-4" />
+            <span>
+              {numRSVPs} RSVPs (max capacity {session.Capacity})
+            </span>
+          </div>
+          <div className="flex gap-1">
+            <ClockIcon className="h-4 w-4" />
+            <span>
+              {DateTime.fromISO(session["Start time"])
+                .setZone("America/Los_Angeles")
+                .toFormat("h:mm a")}{" "}
+              -{" "}
+              {DateTime.fromJSDate(adjustedEndTime)
+                .setZone("America/Los_Angeles")
+                .toFormat("h:mm a")}
+            </span>
+          </div>
         </div>
-        <div className="flex gap-1">
-          <ClockIcon className="h-4 w-4" />
-          <span>
-            {DateTime.fromISO(session["Start time"])
-              .setZone("America/Los_Angeles")
-              .toFormat("h:mm a")}{" "}
-            -{" "}
-            {DateTime.fromISO(session["End time"])
-              .setZone("America/Los_Angeles")
-              .toFormat("h:mm a")}
-          </span>
-        </div>
-      </div>
-    </>
-  );
+      </>
+    );
+  };
   return (
     <Tooltip
       content={onMobile ? undefined : <SessionInfoDisplay />}

--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -23,6 +23,10 @@ import { UserContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { parseSessionTime } from "../api/session-form-utils";
 import { eventNameToSlug } from "@/utils/utils";
+import {
+  formatDurationLong,
+  getAdjustedDuration,
+} from "@/utils/session-breaks";
 
 interface ErrorResponse {
   message: string;
@@ -616,32 +620,27 @@ function SelectDuration(props: {
   maxDuration?: number;
 }) {
   const { duration, setDuration, maxDuration } = props;
-  const durations = [
-    { value: 30, label: "30 minutes" },
-    { value: 60, label: "1 hour" },
-    { value: 90, label: "1.5 hours" },
-    { value: 120, label: "2 hours" },
-  ];
+  const durations = [30, 60, 90, 120];
   const availableDurations = maxDuration
-    ? durations.filter(({ value }) => value <= maxDuration)
+    ? durations.filter((value) => value <= maxDuration)
     : durations;
   return (
     <fieldset>
       <div className="space-y-4">
-        {availableDurations.map(({ value, label }) => (
+        {availableDurations.map((value) => (
           <div key={value} className="flex items-center">
             <input
-              id={label}
+              id={`duration-${value}`}
               type="radio"
               checked={value === duration}
               onChange={() => setDuration(value)}
               className="h-4 w-4 border-gray-300 text-rose-400 focus:ring-rose-400"
             />
             <label
-              htmlFor={label}
+              htmlFor={`duration-${value}`}
               className="ml-3 block text-sm font-medium leading-6 text-gray-900"
             >
-              {label}
+              {formatDurationLong(getAdjustedDuration(value))}
             </label>
           </div>
         ))}

--- a/app/[eventSlug]/session-proposal-form.tsx
+++ b/app/[eventSlug]/session-proposal-form.tsx
@@ -14,16 +14,12 @@ import { SessionProposal } from "@/db/sessionProposals";
 import { SelectHosts } from "@/app/[eventSlug]/session-form";
 import { ConfirmDeletionModal } from "../modals";
 import { Guest } from "@/db/guests";
+import {
+  formatDurationLong,
+  getAdjustedDuration,
+} from "@/utils/session-breaks";
 
-const DURATION_OPTIONS = [
-  { value: undefined, label: "Undecided" },
-  { value: 30, label: "30 minutes" },
-  { value: 60, label: "1 hour" },
-  { value: 90, label: "1.5 hours" },
-  { value: 120, label: "2 hours" },
-  { value: 150, label: "2.5 hours" },
-  { value: 180, label: "3 hours" },
-];
+const DURATION_OPTIONS = [undefined, 30, 60, 90, 120];
 
 export function SessionProposalForm(props: {
   eventID: string;
@@ -173,7 +169,7 @@ export function SessionProposalForm(props: {
           <label className="font-medium">Duration</label>
           <fieldset>
             <div className="grid gap-3">
-              {DURATION_OPTIONS.map(({ value, label }) => (
+              {DURATION_OPTIONS.map((value) => (
                 <div key={value ?? "undecided"} className="flex items-center">
                   <input
                     id={`duration-${value ?? "undecided"}`}
@@ -186,7 +182,9 @@ export function SessionProposalForm(props: {
                     htmlFor={`duration-${value ?? "undecided"}`}
                     className="ml-3 block text-sm font-medium leading-6 text-gray-900"
                   >
-                    {label}
+                    {value
+                      ? formatDurationLong(getAdjustedDuration(value))
+                      : "Undecided"}
                   </label>
                 </div>
               ))}

--- a/app/[eventSlug]/session-text.tsx
+++ b/app/[eventSlug]/session-text.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { DateTime } from "luxon";
 import { Session } from "@/db/sessions";
 import { Location } from "@/db/locations";
+import { getAdjustedSessionTimes } from "@/utils/session-breaks";
 
 export function SessionText(props: {
   session: Session;
@@ -9,6 +10,7 @@ export function SessionText(props: {
 }) {
   const { session, locations } = props;
   const formattedHostNames = session["Host name"]?.join(", ") ?? "No hosts";
+  const { adjustedEndTime } = getAdjustedSessionTimes(session);
   return (
     <div className="px-1.5 rounded h-full min-h-10 pt-5 pb-8">
       <h1 className="font-bold leading-tight">{session.Title}</h1>
@@ -21,7 +23,7 @@ export function SessionText(props: {
                 .setZone("America/Los_Angeles")
                 .toFormat("h:mm a")}{" "}
               -{" "}
-              {DateTime.fromISO(session["End time"])
+              {DateTime.fromJSDate(adjustedEndTime)
                 .setZone("America/Los_Angeles")
                 .toFormat("h:mm a")}
             </span>

--- a/app/[eventSlug]/view-session/view-session.tsx
+++ b/app/[eventSlug]/view-session/view-session.tsx
@@ -6,6 +6,7 @@ import { DateTime } from "luxon";
 import type { Event } from "@/db/events";
 import type { Guest } from "@/db/guests";
 import type { Session } from "@/db/sessions";
+import { getAdjustedSessionTimes } from "@/utils/session-breaks";
 
 export function ViewSession(props: {
   session: Session;
@@ -23,6 +24,7 @@ export function ViewSession(props: {
     showBackBtn,
     isInModal = false,
   } = props;
+
   return (
     <div
       className={`${isInModal ? "w-full p-6" : "max-w-2xl mx-auto"} pb-12 break-words overflow-hidden`}
@@ -54,7 +56,7 @@ export function ViewSession(props: {
             .setZone("America/Los_Angeles")
             .toFormat("h:mm a")}{" "}
           -{" "}
-          {DateTime.fromISO(session["End time"])
+          {DateTime.fromJSDate(getAdjustedSessionTimes(session).adjustedEndTime)
             .setZone("America/Los_Angeles")
             .toFormat("h:mm a")}
         </span>

--- a/utils/session-breaks.ts
+++ b/utils/session-breaks.ts
@@ -1,0 +1,71 @@
+import type { Session } from "@/db/sessions";
+
+/**
+ * Calculate adjusted duration by subtracting break time
+ * Rule: ≤60 minutes subtract 5 minutes, >60 minutes subtract 10 minutes
+ */
+export function getAdjustedDuration(originalMinutes: number): number {
+  return originalMinutes <= 60 ? originalMinutes - 5 : originalMinutes - 10;
+}
+
+/**
+ * Format duration minutes into a short string (e.g., "25m", "1h 20m")
+ */
+export function formatDurationShort(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+/**
+ * Format duration minutes into a long string (e.g., "25 minutes", "1 hour 20 minutes")
+ */
+export function formatDurationLong(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes} minutes`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  const hoursStr = hours === 1 ? "hour" : "hours";
+
+  if (remainingMinutes === 0) {
+    return `${hours} ${hoursStr}`;
+  } else {
+    return `${hours} ${hoursStr} ${remainingMinutes} minutes`;
+  }
+}
+
+/**
+ * Calculate the adjusted end time for a session, accounting for enforced breaks.
+ * Rule: ≤60 minutes subtract 5 minutes, >60 minutes subtract 10 minutes
+ *
+ * Note: This is only used for DISPLAY purposes on existing sessions.
+ */
+export function getAdjustedSessionTimes(session: Session): {
+  startTime: Date;
+  endTime: Date;
+  adjustedEndTime: Date;
+  adjustedDurationMinutes: number;
+  breakMinutes: number;
+} {
+  const startTime = new Date(session["Start time"]);
+  const endTime = new Date(session["End time"]);
+  const originalDurationMs = endTime.getTime() - startTime.getTime();
+  const originalDurationMinutes = originalDurationMs / (1000 * 60);
+
+  const breakMinutes = originalDurationMinutes <= 60 ? 5 : 10;
+  const adjustedEndTime = new Date(
+    endTime.getTime() - breakMinutes * 60 * 1000
+  );
+  const adjustedDurationMinutes = getAdjustedDuration(originalDurationMinutes);
+
+  return {
+    startTime,
+    endTime,
+    adjustedEndTime,
+    adjustedDurationMinutes,
+    breakMinutes,
+  };
+}


### PR DESCRIPTION
Sessions that are up to and including 60 minutes are shortened by 5 minutes and those that are longer than that get shortened by 10 minutes.

For simplicity this is implemented by displaying the shortened session times everywhere where the times are visible to the user. In the database everything is still stored with the full duration (including break). In particular, this avoids any issues with overlapping sessions (even though that should not happen anyway because start time should always be the full hour or half past).

closes #82