### PR TITLE
Fix UI bug when 13 or more locations are shown in the same event.

### DIFF
--- a/app/[eventSlug]/day-grid.tsx
+++ b/app/[eventSlug]/day-grid.tsx
@@ -93,10 +93,10 @@ export function DayGrid(props: {
             ref={scrollableDivRef}
           >
             <div
-              className={clsx(
-                "grid divide-x divide-gray-100 w-full overflow-visible",
-                `grid-cols-[repeat(${numLocations},minmax(120px,2fr))]`
-              )}
+              className="grid divide-x divide-gray-100 w-full overflow-visible"
+              style={{
+                gridTemplateColumns: `repeat(${numLocations}, minmax(120px, 2fr))`,
+              }}
             >
               {includedLocations.map((loc) => (
                 <Tooltip
@@ -133,10 +133,10 @@ export function DayGrid(props: {
               ))}
             </div>
             <div
-              className={clsx(
-                "grid divide-x divide-gray-100 relative w-full",
-                `grid-cols-[repeat(${numLocations},minmax(120px,2fr))]`
-              )}
+              className="grid divide-x divide-gray-100 relative w-full"
+              style={{
+                gridTemplateColumns: `repeat(${numLocations}, minmax(120px, 2fr))`,
+              }}
             >
               {/* <NowBar start={start} end={end} /> */}
               {includedLocations.map((location) => {


### PR DESCRIPTION
It turns out that Tailwind CSS only supports up to 12 for x in `grid-cols-[repeat(x, foo)]`: https://v3.tailwindcss.com/docs/grid-template-columns