### PR TITLE
Fix RSVPing from mobile

### DIFF
--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -155,7 +155,7 @@ export function RealSessionCard(props: {
     if (!rsvpd && overlappingSession) {
       setClashingSession(overlappingSession);
       setConfirmRSVPModalOpen(true);
-    } else if (currentUser && !onMobile) {
+    } else if (currentUser) {
       doRsvp();
     } else {
       setUserModalOpen(true);


### PR DESCRIPTION
It was impossible to (un-)RSVP from mobile because clicking on a session block brought up the user select modal, but clicking the button did nothing. This commit just makes mobile behave the same as non-mobile; in upstream, clicking on a session block brings up the user select modal on mobile, too, though the modal's RSVP button was not bugged there.

Closes https://github.com/LWCW-Europe/scheduling-app/issues/250

