### PR TITLE
feat: improve textual session display to shorten desc and open modal

### DIFF
--- a/app/[eventSlug]/day-text.tsx
+++ b/app/[eventSlug]/day-text.tsx
@@ -14,8 +14,9 @@ export function DayText(props: {
   day: Day;
   search: string;
   rsvps: RSVP[];
+  eventSlug: string;
 }) {
-  const { day, locations, search, rsvps } = props;
+  const { day, locations, search, rsvps, eventSlug } = props;
   const searchParams = useSearchParams();
   const { user: currentUser } = useContext(UserContext);
   const locParams = searchParams?.getAll("loc");
@@ -73,6 +74,7 @@ export function DayText(props: {
                 locations={locations.filter((loc) =>
                   session["Location name"].includes(loc.Name)
                 )}
+                eventSlug={eventSlug}
               />
             ))}
           </>

--- a/app/[eventSlug]/event.tsx
+++ b/app/[eventSlug]/event.tsx
@@ -25,6 +25,8 @@ export function EventDisplay() {
 
   if (!event) return <div>No event data available</div>;
 
+  const eventSlug = eventNameToSlug(event.Name);
+
   const daysForEvent = days.filter(
     (day) =>
       !CONSTS.MULTIPLE_EVENTS ||
@@ -106,6 +108,7 @@ export function EventDisplay() {
                 search={search}
                 locations={locationsForEvent}
                 rsvps={view === "rsvp" ? rsvps : []}
+                eventSlug={eventSlug}
               />
             )}
           </div>

--- a/app/[eventSlug]/session-text.tsx
+++ b/app/[eventSlug]/session-text.tsx
@@ -3,16 +3,71 @@ import { DateTime } from "luxon";
 import { Session } from "@/db/sessions";
 import { Location } from "@/db/locations";
 import { getEndTimeMinusBreak } from "@/utils/utils";
+import { useRouter } from "next/navigation";
+import { useState, useContext } from "react";
+import { useSearchParams } from "next/navigation";
+import { UserContext, EventContext } from "../context";
+import { CheckCircleIcon, AcademicCapIcon } from "@heroicons/react/24/solid";
 
 export function SessionText(props: {
   session: Session;
   locations: Location[];
+  eventSlug: string;
 }) {
-  const { session, locations } = props;
+  const { session, locations, eventSlug } = props;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user: currentUser } = useContext(UserContext);
+  const { rsvpdForSession } = useContext(EventContext);
+  const [showFullDescription, setShowFullDescription] = useState(false);
   const formattedHostNames = session["Host name"]?.join(", ") ?? "No hosts";
+
+  // Determine user status for this session
+  const rsvpd = currentUser ? rsvpdForSession(session.ID + "") : false;
+  const isHost = currentUser && session.Hosts?.includes(currentUser);
+
+  const description = session.Description || "";
+  const isLongDescription = description.length > 200;
+  const displayDescription =
+    isLongDescription && !showFullDescription
+      ? description.substring(0, 200) + "..."
+      : description;
+
+  const handleTitleClick = () => {
+    // Preserve current search parameters including view
+    const currentParams = new URLSearchParams(searchParams.toString());
+    const url = `/${eventSlug}/view-session?sessionID=${session.ID}&${currentParams.toString()}`;
+    router.push(url);
+  };
+
   return (
-    <div className="px-1.5 rounded h-full min-h-10 pt-5 pb-8">
-      <h1 className="font-bold leading-tight">{session.Title}</h1>
+    <div className="px-1.5 rounded h-full min-h-10 pt-5 pb-8 relative">
+      <div className="flex items-start gap-2">
+        <h1
+          className="font-bold leading-tight cursor-pointer hover:text-blue-600 transition-colors flex-1"
+          onClick={handleTitleClick}
+        >
+          {session.Title}
+        </h1>
+        <div className="flex gap-1">
+          {isHost && (
+            <div
+              className="flex items-center"
+              title="You are hosting this session"
+            >
+              <AcademicCapIcon className="h-4 w-4" />
+            </div>
+          )}
+          {rsvpd && (
+            <div
+              className="flex items-center"
+              title="You have RSVP'd to this session"
+            >
+              <CheckCircleIcon className="h-4 w-4" />
+            </div>
+          )}
+        </div>
+      </div>
       <div className="flex flex-col sm:flex-row justify-between mt-2 sm:items-center gap-2">
         <div className="flex gap-2 text-sm text-gray-500">
           <div className="flex gap-1">
@@ -35,7 +90,17 @@ export function SessionText(props: {
           ))}
         </div>
       </div>
-      <p className="text-sm whitespace-pre-line mt-2">{session.Description}</p>
+      <p className="text-sm whitespace-pre-line mt-2">
+        {displayDescription}
+        {isLongDescription && (
+          <button
+            onClick={() => setShowFullDescription(!showFullDescription)}
+            className="ml-2 text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
+          >
+            {showFullDescription ? "Show less" : "Show more"}
+          </button>
+        )}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
By default long sessions descriptions are now shortened and on title click the session details modal is opened.

Also display icons to signal whether the current user RSVPd or is the host.

closes #249