### PR TITLE
Prevent overlap between title and eye/pencil icon

### DIFF
--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -254,7 +254,7 @@ export function RealSessionCard(props: {
       >
         <p
           className={clsx(
-            "font-medium text-xs leading-[1.15] text-left",
+            "font-medium text-xs leading-[1.15] text-left pr-3",
             numHalfHours > 1 ? "line-clamp-2" : "line-clamp-1"
           )}
         >


### PR DESCRIPTION
Note: if neither icon is present then there will be a bit of unused space where the icon is located. I think that's ok because then that space is "reserved" for the icon - the UI is more consistent. If you disagree with that decision, the fix is simple - only add the pr-3 conditionally (if neither icon is present).

Closes https://github.com/LWCW-Europe/scheduling-app/issues/202