### PR TITLE
nit: correct 'RSVP for' -> 'RSVP to'

### DIFF
--- a/app/modals.tsx
+++ b/app/modals.tsx
@@ -72,7 +72,7 @@ export function CurrentUserModal(props: {
           </button>
           {isDisabled && (
             <div className="absolute bottom-3/4 left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap">
-              Cannot RSVP for your own event
+              Cannot RSVP to your own event
             </div>
           )}
         </div>


### PR DESCRIPTION
Modified regular file app/modals.tsx:
    ...
  72   72:           </button>
  73   73:           {isDisabled && (
  74   74:             <div className="absolute bottom-3/4 left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap">
  75   75:               Cannot RSVP forto your own event
  76   76:             </div>
  77   77:           )}
  78   78:         </div>
    ...