### PR TITLE
feat: session block clicks open details and 'RSVP count' clicks rsvp

### DIFF
--- a/app/[eventSlug]/@modal/(.)view-session/modal.tsx
+++ b/app/[eventSlug]/@modal/(.)view-session/modal.tsx
@@ -81,6 +81,7 @@ export function SessionModal(props: {
           event={event}
           showBackBtn={false}
           isInModal={true}
+          onCloseModal={onDismiss}
         />
       </div>
     </div>,

--- a/app/[eventSlug]/event-page.tsx
+++ b/app/[eventSlug]/event-page.tsx
@@ -1,53 +1,10 @@
 import { EventDisplay } from "./event";
 import { Suspense } from "react";
-import { cookies } from "next/headers";
-import { getDaysByEvent } from "@/db/days";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getLocations } from "@/db/locations";
-import { getGuests } from "@/db/guests";
-import { getRSVPsByUser } from "@/db/rsvps";
-import { Event } from "@/db/events";
-import { EventProvider } from "../context";
 
-export default async function EventPage(props: { event: Event }) {
-  const { event } = props;
-  const cookieStore = cookies();
-  const currentUser = cookieStore.get("user")?.value;
-  const [days, sessions, locations, guests, rsvps] = await Promise.all([
-    getDaysByEvent(event.Name),
-    getSessionsByEvent(event.Name),
-    getLocations(),
-    getGuests(),
-    getRSVPsByUser(currentUser),
-  ]);
-
-  days.forEach((day) => {
-    const dayStartMillis = new Date(day.Start).getTime();
-    const dayEndMillis = new Date(day.End).getTime();
-    day.Sessions = sessions.filter((s) => {
-      const sessionStartMillis = new Date(s["Start time"]).getTime();
-      const sessionEndMillis = new Date(s["End time"]).getTime();
-      return (
-        dayStartMillis <= sessionStartMillis && dayEndMillis >= sessionEndMillis
-      );
-    });
-  });
-
-  // Initial event context value
-  const eventContextValue = {
-    event,
-    days,
-    sessions,
-    locations,
-    guests,
-    rsvps,
-  };
-
+export default function EventPage() {
   return (
-    <EventProvider value={eventContextValue}>
-      <Suspense fallback={<div>Loading...</div>}>
-        <EventDisplay />
-      </Suspense>
-    </EventProvider>
+    <Suspense fallback={<div>Loading...</div>}>
+      <EventDisplay />
+    </Suspense>
   );
 }

--- a/app/[eventSlug]/event-provider-wrapper.tsx
+++ b/app/[eventSlug]/event-provider-wrapper.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { EventProvider } from "@/app/context";
+import type { EventContextType } from "@/app/context";
+
+export function EventProviderWrapper({
+  eventContextValue,
+  children,
+}: {
+  eventContextValue: Omit<
+    EventContextType,
+    "localSessions" | "userBusySessions" | "rsvpdForSession" | "updateRsvp"
+  >;
+  children: React.ReactNode;
+}) {
+  return <EventProvider value={eventContextValue}>{children}</EventProvider>;
+}

--- a/app/[eventSlug]/layout-content.tsx
+++ b/app/[eventSlug]/layout-content.tsx
@@ -1,0 +1,63 @@
+import { cookies } from "next/headers";
+import { eventSlugToName } from "@/utils/utils";
+import { getEventByName } from "@/db/events";
+import { getDaysByEvent } from "@/db/days";
+import { getSessionsByEvent } from "@/db/sessions";
+import { getLocations } from "@/db/locations";
+import { getGuests } from "@/db/guests";
+import { getRSVPsByUser } from "@/db/rsvps";
+import { EventProviderWrapper } from "./event-provider-wrapper";
+
+export async function EventLayoutContent({
+  eventSlug,
+  children,
+}: {
+  eventSlug: string;
+  children: React.ReactNode;
+}) {
+  const eventName = eventSlugToName(eventSlug);
+  const event = await getEventByName(eventName);
+
+  if (!event) {
+    return <div>Event not found</div>;
+  }
+
+  const cookieStore = cookies();
+  const currentUser = cookieStore.get("user")?.value;
+
+  const [days, sessions, locations, guests, rsvps] = await Promise.all([
+    getDaysByEvent(event.Name),
+    getSessionsByEvent(event.Name),
+    getLocations(),
+    getGuests(),
+    getRSVPsByUser(currentUser),
+  ]);
+
+  // Prepare the days with sessions
+  days.forEach((day) => {
+    const dayStartMillis = new Date(day.Start).getTime();
+    const dayEndMillis = new Date(day.End).getTime();
+    day.Sessions = sessions.filter((s) => {
+      const sessionStartMillis = new Date(s["Start time"]).getTime();
+      const sessionEndMillis = new Date(s["End time"]).getTime();
+      return (
+        dayStartMillis <= sessionStartMillis && dayEndMillis >= sessionEndMillis
+      );
+    });
+  });
+
+  const eventContextValue = {
+    event,
+    days,
+    sessions,
+    locations,
+    guests,
+    rsvps,
+  };
+
+  return (
+    <EventProviderWrapper eventContextValue={eventContextValue}>
+      {children}
+    </EventProviderWrapper>
+  );
+}

--- a/app/[eventSlug]/layout.tsx
+++ b/app/[eventSlug]/layout.tsx
@@ -1,6 +1,6 @@
-"use client";
-
 import { VotesProvider } from "@/app/context";
+import { Suspense } from "react";
+import { EventLayoutContent } from "./layout-content";
 
 export default function EventLayout({
   modal,
@@ -13,9 +13,13 @@ export default function EventLayout({
 }) {
   return (
     <VotesProvider eventSlug={params.eventSlug}>
-      {modal}
-      {children}
-      <div id="modal-root" />
+      <Suspense fallback={<div>Loading...</div>}>
+        <EventLayoutContent eventSlug={params.eventSlug}>
+          {modal}
+          {children}
+          <div id="modal-root" />
+        </EventLayoutContent>
+      </Suspense>
     </VotesProvider>
   );
 }

--- a/app/[eventSlug]/page.tsx
+++ b/app/[eventSlug]/page.tsx
@@ -16,7 +16,7 @@ export default async function Page(props: { params: { eventSlug: string } }) {
   const phase = getCurrentPhase(event);
 
   if (phase === EventPhase.SCHEDULING) {
-    return <EventPage event={event} />;
+    return <EventPage />;
   } else if (phase === EventPhase.VOTING || phase === EventPhase.PROPOSAL) {
     redirect(`/${eventSlug}/proposals`);
   } else {

--- a/app/[eventSlug]/view-session/view-session.tsx
+++ b/app/[eventSlug]/view-session/view-session.tsx
@@ -2,11 +2,18 @@
 
 import Link from "next/link";
 import { DateTime } from "luxon";
+import { useContext, useState } from "react";
+import { useRouter } from "next/navigation";
+import { PencilIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon, AcademicCapIcon } from "@heroicons/react/24/solid";
 
 import type { Event } from "@/db/events";
 import type { Guest } from "@/db/guests";
 import type { Session } from "@/db/sessions";
 import { getEndTimeMinusBreak } from "@/utils/utils";
+import { UserContext, EventContext } from "../../context";
+import { CurrentUserModal, ConfirmationModal } from "../../modals";
+import { sessionsOverlap } from "../../session_utils";
 
 export function ViewSession(props: {
   session: Session;
@@ -15,6 +22,7 @@ export function ViewSession(props: {
   event: Event;
   showBackBtn: boolean;
   isInModal?: boolean;
+  onCloseModal?: () => void;
 }) {
   const {
     session,
@@ -23,11 +31,115 @@ export function ViewSession(props: {
     event,
     showBackBtn,
     isInModal = false,
+    onCloseModal,
   } = props;
+
+  const { user: currentUser } = useContext(UserContext);
+  const { rsvpdForSession, updateRsvp, userBusySessions } =
+    useContext(EventContext);
+  const router = useRouter();
+  const [isRsvping, setIsRsvping] = useState(false);
+  const [userModalOpen, setUserModalOpen] = useState(false);
+  const [clashingSession, setClashingSession] = useState<Session | null>(null);
+  const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
+
+  // Determine user status for this session
+  const rsvpd = currentUser ? rsvpdForSession(session.ID + "") : false;
+  const isHost = currentUser && session.Hosts?.includes(currentUser);
+  const isEditable = !!isHost && session["Attendee scheduled"];
+
+  const handleRsvp = () => {
+    if (!currentUser) {
+      setUserModalOpen(true);
+      return;
+    }
+
+    // Check for clashing sessions only when RSVPing (not when un-RSVPing)
+    if (!rsvpd) {
+      const overlappingSession = userBusySessions().find((ses) =>
+        sessionsOverlap(session, ses)
+      );
+      if (overlappingSession) {
+        setClashingSession(overlappingSession);
+        setConfirmRSVPModalOpen(true);
+        return;
+      }
+    }
+
+    doRsvp();
+  };
+
+  const doRsvp = () => {
+    if (!currentUser) {
+      return;
+    }
+
+    setIsRsvping(true);
+
+    // Get the current RSVP status at the time of the action
+    const currentRsvpStatus = rsvpdForSession(session.ID + "");
+
+    void updateRsvp(currentUser, session.ID, currentRsvpStatus)
+      .then((result) => {
+        if (!result) {
+          console.error("Failed to update RSVP");
+        }
+      })
+      .finally(() => {
+        setIsRsvping(false);
+      });
+  };
+
+  const handleEditClick = (e: React.MouseEvent) => {
+    if (isInModal && onCloseModal) {
+      e.preventDefault();
+      onCloseModal();
+      // Small delay to allow modal to close before navigation
+      setTimeout(() => {
+        router.push(`/${eventSlug}/edit-session?sessionID=${session.ID}`);
+      }, 100);
+    }
+    // If not in modal, let the Link component handle the navigation normally
+  };
+
   return (
     <div
       className={`${isInModal ? "w-full p-6" : "max-w-2xl mx-auto"} pb-12 break-words overflow-hidden`}
     >
+      <CurrentUserModal
+        close={() => setUserModalOpen(false)}
+        open={userModalOpen}
+        rsvp={handleRsvp}
+        guests={guests}
+        hosts={session.Hosts || []}
+        rsvpd={rsvpd}
+        zIndex="z-[100]"
+        portal={true} // Explicitly portal this modal to escape the session modal
+        sessionInfoDisplay={
+          <div>
+            <h1 className="text-lg font-bold leading-tight">{session.Title}</h1>
+            <p className="text-xs text-gray-500 mb-2 mt-1">
+              Hosted by{" "}
+              {session
+                .Hosts!.map((h) => guests.find((g) => g.ID === h))
+                .map((g) => g?.Name)
+                .join(", ")}
+            </p>
+          </div>
+        }
+      />
+      <ConfirmationModal
+        open={confirmRSVPModalOpen}
+        close={() => setConfirmRSVPModalOpen(false)}
+        confirm={doRsvp}
+        zIndex="z-[100]"
+        portal={true} // Explicitly portal this modal to escape the session modal
+        message={
+          `Warning: that session clashes with ${clashingSession?.Title}, which you ` +
+          `are ${clashingSession?.Hosts?.includes(currentUser || "") ? "hosting" : "attending"}. ` +
+          "Are you sure you want to proceed?"
+        }
+      />
       {showBackBtn && (
         <Link
           className="bg-rose-400 text-white font-semibold py-2 px-4 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
@@ -36,35 +148,93 @@ export function ViewSession(props: {
           Back to {event.Name}
         </Link>
       )}
-      <p className="text-xl font-semibold mb-2 mt-5" id="title">
-        {session.Title}
-      </p>
-      <p className="text-lg font-medium text-gray-700 mb-4">
-        {session
-          .Hosts!.map((h) => guests.find((g) => g.ID === h))
-          .map((g) => g?.Name)
-          .join(", ")}
-      </p>
-      <p className="mb-3 whitespace-pre-line">{session.Description}</p>
-      <div className="flex gap-1 mb-4 font-semibold">
-        {session["Location name"]}
+      {/* Title with status indicators */}
+      <div className="flex items-start gap-2 mb-2 mt-5">
+        <p className="text-xl font-semibold flex-1" id="title">
+          {session.Title}
+        </p>
+        <div className="flex gap-1">
+          {isHost && (
+            <div
+              className="flex items-center"
+              title="You are hosting this session"
+            >
+              <AcademicCapIcon className="h-5 w-5" />
+            </div>
+          )}
+          {rsvpd && (
+            <div
+              className="flex items-center"
+              title="You have RSVP'd to this session"
+            >
+              <CheckCircleIcon className="h-5 w-5" />
+            </div>
+          )}
+        </div>
       </div>
-      <div className="flex gap-1 mb-4">
-        <span>
-          {DateTime.fromISO(session["Start time"])
-            .setZone("America/Los_Angeles")
-            .toFormat("EEEE h:mm a")}{" "}
-          -{" "}
-          {getEndTimeMinusBreak(session)
-            .setZone("America/Los_Angeles")
-            .toFormat("h:mm a")}
-        </span>
+      {/* Action buttons */}
+      <div className="mt-2 mb-6 flex gap-2 flex-wrap">
+        {!isHost && (
+          <button
+            onClick={handleRsvp}
+            disabled={isRsvping}
+            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors disabled:opacity-50"
+          >
+            {isRsvping ? "..." : rsvpd ? "Un-RSVP" : "RSVP"}
+          </button>
+        )}
+
+        {isEditable && (
+          <Link
+            href={`/${eventSlug}/edit-session?sessionID=${session.ID}`}
+            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+            onClick={handleEditClick}
+          >
+            <PencilIcon className="h-3 w-3 mr-1" />
+            Edit
+          </Link>
+        )}
+      </div>{" "}
+      {/* Session details */}
+      <div className="space-y-2 mb-6 text-sm text-gray-700">
+        <div className="flex gap-2">
+          <span className="font-medium">Hosts(s):</span>
+          <span>
+            {session
+              .Hosts!.map((h) => guests.find((g) => g.ID === h))
+              .map((g) => g?.Name)
+              .join(", ")}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <span className="font-medium">Location:</span>
+          <span>{session["Location name"]}</span>
+        </div>
+        <div className="flex gap-2">
+          <span className="font-medium">Time:</span>
+          <span>
+            {DateTime.fromISO(session["Start time"])
+              .setZone("America/Los_Angeles")
+              .toFormat("EEEE h:mm a")}{" "}
+            -{" "}
+            {getEndTimeMinusBreak(session)
+              .setZone("America/Los_Angeles")
+              .toFormat("h:mm a")}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <span className="font-medium">Attendees:</span>
+          <span>{session["Num RSVPs"]}</span>
+        </div>
       </div>
-      <p>
-        {session["Num RSVPs"]} RSVP{session["Num RSVPs"] === 1 ? "" : "s"}
-      </p>
+      {/* Description (potentially long) */}
+      <div className="mb-6">
+        <h3 className="font-semibold mb-2">Description</h3>
+        <p className="whitespace-pre-line">{session.Description}</p>
+      </div>
+      {/* Link to proposal (if exists) */}
       {session.proposal && (
-        <p className="text-sm text-gray-600 mt-5">
+        <p className="text-sm text-gray-600">
           This session was scheduled from a proposal. See it{" "}
           <a
             href={`/${eventSlug}/proposals/${session.proposal[0]}/view`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
 import SummaryPage from "./summary-page";
-import EventPage from "./[eventSlug]/event-page";
 import { getEvents } from "@/db/events";
 import { CONSTS } from "@/utils/constants";
+import { redirect } from "next/navigation";
+import { eventNameToSlug } from "@/utils/utils";
 
 export default async function Home() {
   const events = await getEvents();
@@ -11,6 +12,8 @@ export default async function Home() {
   if (CONSTS.MULTIPLE_EVENTS) {
     return <SummaryPage events={sortedEvents} />;
   } else {
-    return <EventPage event={sortedEvents[0]} />;
+    // Redirect to the single event page instead of rendering EventPage directly
+    const eventSlug = eventNameToSlug(sortedEvents[0].Name);
+    redirect(`/${eventSlug}`);
   }
 }


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [399e33b](https://github.com/LWCW-Europe/scheduling-app/pull/270/commits/399e33baa907d323a83fbc90da93b807095fe613).

PRs:
* #299
* #298
* #297
* #296
* #295
* #294
* ➡️ #270
* #272

---

Now when clicking on the small RSVP count in the lower right corner this means
(un-)rsvp as before but clicking anywhere else opens the session details.

closes #247

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is.
