### PR TITLE
Do not consider sessions from the next day in the durations validation

### DIFF
--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -473,11 +473,15 @@ function getAvailableStartTimes(
   location?: string
 ) {
   const locationSelected = !!location;
-  const filteredSessions = locationSelected
-    ? sessions.filter(
-        (s) => s["Location name"][0] === location && s.ID != currentSession.ID
-      )
-    : sessions;
+  const filteredSessions = (
+    locationSelected
+      ? sessions.filter(
+          (s) => s["Location name"][0] === location && s.ID != currentSession.ID
+        )
+      : sessions
+  ).filter(
+    (s) => new Date(s["Start time"]).getTime() < new Date(day.End).getTime()
+  );
   const sortedSessions = filteredSessions.sort(
     (a, b) =>
       new Date(a["Start time"]).getTime() - new Date(b["Start time"]).getTime()


### PR DESCRIPTION
This is a bug which occurs when a Day spans more than one calendar day: the validation for session duration considers sessions from the next calendar day, even though they are from a different Day, resulting in permitting booking beyond the Day's EndBookings time.

Closes https://github.com/LWCW-Europe/scheduling-app/issues/257