### PR TITLE
Delete all RSVPs correctly when deleting a session

### DIFF
--- a/app/api/delete-session/route.ts
+++ b/app/api/delete-session/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
     // This deletes all RSVPs for the session
     await getBase()("RSVPs")
       .select({
-        filterByFormula: `{Session} = "${id}"`,
+        filterByFormula: `{Session ID} = "${id}"`,
       })
       .eachPage(function page(records, fetchNextPage) {
         const recordIds = records.map((record) => record.getId());


### PR DESCRIPTION
This is an Airtable gotcha.

Should prevent https://github.com/LWCW-Europe/scheduling-app/issues/271 from happening again, but in order to close #271, someone needs to go in the production DB and run a script which deletes all RSVPs which have no session associated with them.

Note: they are easy to spot in Airtable because their Session field is empty (since the session they used to reference is now nonexistent).