### PR TITLE
Ignore session clashes if they are in different events

### DIFF
--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -9,7 +9,9 @@ export async function POST(req: Request) {
   const params = (await req.json()) as SessionParams;
   const session = prepareToInsert(params);
   console.log(session);
-  const existingSessions = await getSessions();
+  const existingSessions = (await getSessions()).filter(
+    (s) => !session.Event || session.Event[0] === s.Event
+  );
   const sessionValid = validateSession(session, existingSessions);
   if (sessionValid) {
     try {

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -14,7 +14,11 @@ export async function POST(req: Request) {
   }
   const session = prepareToInsert(params);
   const allSessions = await getSessions();
-  const prevSession = allSessions.find((ses) => ses.ID === params.id)!;
+  const prevSession = allSessions.find((ses) => ses.ID === params.id);
+  if (prevSession === undefined) {
+    const msg = `Cannot find session with ID ${params.id}`;
+    return new Response(msg, { status: 404 });
+  }
   if (!prevSession["Attendee scheduled"] || prevSession.Blocker) {
     return new Response("Cannot edit via web app", { status: 400 });
   }

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -13,7 +13,9 @@ export async function POST(req: Request) {
     return new Response("Session ID is required", { status: 400 });
   }
   const session = prepareToInsert(params);
-  const allSessions = await getSessions();
+  const allSessions = (await getSessions()).filter(
+    (s) => !session.Event || session.Event[0] === s.Event
+  );
   const prevSession = allSessions.find((ses) => ses.ID === params.id);
   if (prevSession === undefined) {
     const msg = `Cannot find session with ID ${params.id}`;

--- a/db/sessions.ts
+++ b/db/sessions.ts
@@ -18,47 +18,22 @@ export type Session = {
   Blocker: boolean;
   proposal: string[]; // always has 1 or 0 values (Airtable returns an array regardless)
 };
-export async function getSessions() {
-  const sessions: Session[] = [];
-  await getBase()<Session>("Sessions")
-    .select({
-      fields: [
-        "Title",
-        "Description",
-        "Start time",
-        "End time",
-        "Hosts",
-        "Host name",
-        "Host email",
-        "Location",
-        "Location name",
-        "Capacity",
-        "Num RSVPs",
-        "Attendee scheduled",
-        "Blocker",
-        "proposal",
-      ],
-      filterByFormula: `AND({Start time}, {End time}, {Location})`,
-    })
-    .eachPage(function page(records, fetchNextPage) {
-      records.forEach(function (record) {
-        sessions.push({
-          ...record.fields,
-          ID: record.id,
-          "Attendee scheduled": !!record.fields["Attendee scheduled"],
-        });
-      });
-      fetchNextPage();
-    });
-  return sessions;
+
+const isScheduledFilter = "AND({Start time}, {End time}, {Location})";
+
+export function getSessions() {
+  return getSessionsByFormula(isScheduledFilter);
 }
 
-export async function getSessionsByEvent(eventName: string) {
-  const sessions: Session[] = [];
-  const isScheduledFilter = "AND({Start time}, {End time}, {Location})";
+export function getSessionsByEvent(eventName: string) {
   const filterFormula = CONSTS.MULTIPLE_EVENTS
     ? `AND({Event name} = "${eventName}", ${isScheduledFilter})`
     : isScheduledFilter;
+  return getSessionsByFormula(filterFormula);
+}
+
+async function getSessionsByFormula(filterFormula: string) {
+  const sessions: Session[] = [];
   await getBase()<Session>("Sessions")
     .select({
       fields: [

--- a/db/sessions.ts
+++ b/db/sessions.ts
@@ -16,7 +16,9 @@ export type Session = {
   "Num RSVPs": number;
   "Attendee scheduled": boolean;
   Blocker: boolean;
+  // TODO: wrong type - this might be undefined (#278) - I believe that it always has 1 element or is undefined. The next comment is wrong.
   proposal: string[]; // always has 1 or 0 values (Airtable returns an array regardless)
+  Event?: string;
 };
 
 const isScheduledFilter = "AND({Start time}, {End time}, {Location})";
@@ -51,6 +53,7 @@ async function getSessionsByFormula(filterFormula: string) {
         "Attendee scheduled",
         "Blocker",
         "proposal",
+        "Event",
       ],
       filterByFormula: filterFormula,
     })
@@ -61,6 +64,7 @@ async function getSessionsByFormula(filterFormula: string) {
           ID: record.id,
           "Attendee scheduled": !!record.fields["Attendee scheduled"],
           Blocker: !!record.fields["Blocker"],
+          Event: record.fields.Event?.[0],
         });
       });
       fetchNextPage();


### PR DESCRIPTION
The bug was happening when either creating or updating a session. Hardcode `getAvailableStartTimes` in session-form.tsx to disable client-side validation for clashes if you want to check that server-side validation still works. https://github.com/LWCW-Europe/scheduling-app/issues/277 - should hopefully cl*se that, but needs to be checked after deployment.

Also contains two unrelated commits that bring minor improvements.