### PR TITLE
Use context values

### DIFF
--- a/app/[eventSlug]/@modal/(.)view-session/modal.tsx
+++ b/app/[eventSlug]/@modal/(.)view-session/modal.tsx
@@ -4,20 +4,10 @@ import { createPortal } from "react-dom";
 import { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
-import type { Event } from "@/db/events";
-import type { Guest } from "@/db/guests";
-import type { Session } from "@/db/sessions";
-import type { RSVP } from "@/db/rsvps";
 import { ViewSession } from "../../view-session/view-session";
 
-export function SessionModal(props: {
-  session: Session;
-  guests: Guest[];
-  rsvps: RSVP[];
-  eventSlug: string;
-  event: Event;
-}) {
-  const { session, guests, rsvps, eventSlug, event } = props;
+export function SessionModal(props: { eventSlug: string }) {
+  const { eventSlug } = props;
 
   const router = useRouter();
 
@@ -77,11 +67,7 @@ export function SessionModal(props: {
           </svg>
         </button>
         <ViewSession
-          session={session}
-          guests={guests}
-          rsvps={rsvps}
           eventSlug={eventSlug}
-          event={event}
           showBackBtn={false}
           isInModal={true}
           onCloseModal={onDismiss}

--- a/app/[eventSlug]/@modal/(.)view-session/page.tsx
+++ b/app/[eventSlug]/@modal/(.)view-session/page.tsx
@@ -1,47 +1,10 @@
-import { notFound } from "next/navigation";
-
-import { eventSlugToName } from "@/utils/utils";
-import { getEventByName } from "@/db/events";
-import { getGuestsByEvent } from "@/db/guests";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getRSVPsBySession } from "@/db/rsvps";
 import { SessionModal } from "./modal";
 
-export default async function SessionModalPage({
+export default function SessionModalPage({
   params,
-  searchParams,
 }: {
   params: { eventSlug: string };
-  searchParams: { sessionID: string };
 }) {
   const { eventSlug } = params;
-  const { sessionID } = searchParams;
-
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getEventByName(eventName);
-
-  if (!event) {
-    return <div>Event not found</div>;
-  }
-
-  const [sessions, guests, rsvps] = await Promise.all([
-    getSessionsByEvent(eventName),
-    getGuestsByEvent(event.Name),
-    getRSVPsBySession(sessionID),
-  ]);
-  const session = sessions.find((p) => p.ID === sessionID);
-
-  if (!session) {
-    notFound();
-  }
-
-  return (
-    <SessionModal
-      session={session}
-      guests={guests}
-      rsvps={rsvps}
-      eventSlug={eventSlug}
-      event={event}
-    />
-  );
+  return <SessionModal eventSlug={eventSlug} />;
 }

--- a/app/[eventSlug]/layout-content.tsx
+++ b/app/[eventSlug]/layout-content.tsx
@@ -4,7 +4,7 @@ import { getEventByName } from "@/db/events";
 import { getDaysByEvent } from "@/db/days";
 import { getSessionsByEvent } from "@/db/sessions";
 import { getLocations } from "@/db/locations";
-import { getGuests } from "@/db/guests";
+import { getGuestsByEvent } from "@/db/guests";
 import { getRSVPsByUser } from "@/db/rsvps";
 import { EventProviderWrapper } from "./event-provider-wrapper";
 
@@ -29,7 +29,7 @@ export async function EventLayoutContent({
     getDaysByEvent(event.Name),
     getSessionsByEvent(event.Name),
     getLocations(),
-    getGuests(),
+    getGuestsByEvent(event.Name),
     getRSVPsByUser(currentUser),
   ]);
 

--- a/app/[eventSlug]/view-session/page.tsx
+++ b/app/[eventSlug]/view-session/page.tsx
@@ -1,50 +1,15 @@
-import { notFound } from "next/navigation";
-
-import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
-import { eventSlugToName } from "@/utils/utils";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getRSVPsBySession } from "@/db/rsvps";
 import { ViewSession } from "./view-session";
 
-export default async function ViewSessionPage({
+export default function ViewSessionPage({
   params,
-  searchParams,
 }: {
   params: { eventSlug: string };
   searchParams: { sessionID: string };
 }) {
   const { eventSlug } = params;
-  const { sessionID } = searchParams;
-
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getEventByName(eventName);
-
-  if (!event) {
-    return <div>Event not found</div>;
-  }
-
-  const [sessions, guests, rsvps] = await Promise.all([
-    getSessionsByEvent(eventName),
-    getGuestsByEvent(event.Name),
-    getRSVPsBySession(sessionID),
-  ]);
-  const session = sessions.find((p) => p.ID === sessionID);
-
-  if (!session) {
-    notFound();
-  }
-
   return (
     <div className="container mx-auto px-4 py-8">
-      <ViewSession
-        session={session}
-        guests={guests}
-        rsvps={rsvps}
-        eventSlug={eventSlug}
-        event={event}
-        showBackBtn={true}
-      />
+      <ViewSession eventSlug={eventSlug} showBackBtn={true} />
     </div>
   );
 }

--- a/app/[eventSlug]/view-session/view-session.tsx
+++ b/app/[eventSlug]/view-session/view-session.tsx
@@ -16,9 +16,6 @@ import { sessionsOverlap } from "../../session_utils";
 import { LockIcon } from "../../lock-icon";
 import { LocationTag } from "../session-text";
 
-// I'm doing this because otherwise the linter complains about EVERYTHING
-//   because of that return statement that happens if the session does not exist.
-/* eslint-disable react-hooks/rules-of-hooks */
 export function ViewSession(props: {
   eventSlug: string;
   showBackBtn: boolean;
@@ -42,15 +39,17 @@ export function ViewSession(props: {
   // Merge server RSVPs with user's optimistic updates
   // If user has an RSVP in context, use that; otherwise use server data
   const [optimisticRsvps, setOptimisticRsvps] = useState<RSVP[]>([]);
-
   const [rsvpsLoading, setRsvpsLoading] = useState(true);
+  const router = useRouter();
+  const [isRsvping, setIsRsvping] = useState(false);
+  const [userModalOpen, setUserModalOpen] = useState(false);
+  const [clashingSession, setClashingSession] = useState<Session | null>(null);
+  const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
 
   const searchParams = useSearchParams();
   const sessionID = searchParams.get("sessionID")!;
   const session = sessions.find((ses) => ses.ID === sessionID);
-  if (!session) {
-    return <div>No session found with this ID</div>;
-  }
+
   useEffect(() => {
     const fetchRsvps = async () => {
       setRsvpsLoading(true);
@@ -73,8 +72,7 @@ export function ViewSession(props: {
     };
 
     void fetchRsvps();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionID]);
+  }, [sessionID, userRsvps]);
 
   useEffect(() => {
     // When context RSVPs change, update our optimistic state
@@ -101,11 +99,10 @@ export function ViewSession(props: {
       }
     }
   }, [userRsvps, currentUser, sessionID]);
-  const router = useRouter();
-  const [isRsvping, setIsRsvping] = useState(false);
-  const [userModalOpen, setUserModalOpen] = useState(false);
-  const [clashingSession, setClashingSession] = useState<Session | null>(null);
-  const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
+
+  if (!session) {
+    return <div>No session found with this ID</div>;
+  }
 
   // Determine user status for this session
   const rsvpd = currentUser ? rsvpdForSession(sessionID + "") : false;

--- a/app/api/rsvps-for-session/route.ts
+++ b/app/api/rsvps-for-session/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRSVPsBySession } from "@/db/rsvps";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const sessionId = searchParams.get("session");
+
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "Session parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const rsvps = await getRSVPsBySession(sessionId);
+    return NextResponse.json(rsvps);
+  } catch (error) {
+    console.error("Error fetching RSVPs:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch RSVPs" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
View session - use the values already in context instead of fetching them

This speeds things up and avoids unnecessary requests. There is also a "loading" indicator while the session's RSVPs are being fetched.