### PR TITLE
Session form - use values that are already in context instead of fetching them all before the page loads

### DIFF
--- a/app/[eventSlug]/@modal/(.)view-session/modal.tsx
+++ b/app/[eventSlug]/@modal/(.)view-session/modal.tsx
@@ -4,20 +4,10 @@ import { createPortal } from "react-dom";
 import { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
-import type { Event } from "@/db/events";
-import type { Guest } from "@/db/guests";
-import type { Session } from "@/db/sessions";
-import type { RSVP } from "@/db/rsvps";
 import { ViewSession } from "../../view-session/view-session";
 
-export function SessionModal(props: {
-  session: Session;
-  guests: Guest[];
-  rsvps: RSVP[];
-  eventSlug: string;
-  event: Event;
-}) {
-  const { session, guests, rsvps, eventSlug, event } = props;
+export function SessionModal(props: { eventSlug: string }) {
+  const { eventSlug } = props;
 
   const router = useRouter();
 
@@ -77,11 +67,7 @@ export function SessionModal(props: {
           </svg>
         </button>
         <ViewSession
-          session={session}
-          guests={guests}
-          rsvps={rsvps}
           eventSlug={eventSlug}
-          event={event}
           showBackBtn={false}
           isInModal={true}
           onCloseModal={onDismiss}

--- a/app/[eventSlug]/@modal/(.)view-session/page.tsx
+++ b/app/[eventSlug]/@modal/(.)view-session/page.tsx
@@ -1,47 +1,10 @@
-import { notFound } from "next/navigation";
-
-import { eventSlugToName } from "@/utils/utils";
-import { getEventByName } from "@/db/events";
-import { getGuestsByEvent } from "@/db/guests";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getRSVPsBySession } from "@/db/rsvps";
 import { SessionModal } from "./modal";
 
-export default async function SessionModalPage({
+export default function SessionModalPage({
   params,
-  searchParams,
 }: {
   params: { eventSlug: string };
-  searchParams: { sessionID: string };
 }) {
   const { eventSlug } = params;
-  const { sessionID } = searchParams;
-
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getEventByName(eventName);
-
-  if (!event) {
-    return <div>Event not found</div>;
-  }
-
-  const [sessions, guests, rsvps] = await Promise.all([
-    getSessionsByEvent(eventName),
-    getGuestsByEvent(event.Name),
-    getRSVPsBySession(sessionID),
-  ]);
-  const session = sessions.find((p) => p.ID === sessionID);
-
-  if (!session) {
-    notFound();
-  }
-
-  return (
-    <SessionModal
-      session={session}
-      guests={guests}
-      rsvps={rsvps}
-      eventSlug={eventSlug}
-      event={event}
-    />
-  );
+  return <SessionModal eventSlug={eventSlug} />;
 }

--- a/app/[eventSlug]/layout-content.tsx
+++ b/app/[eventSlug]/layout-content.tsx
@@ -4,7 +4,7 @@ import { getEventByName } from "@/db/events";
 import { getDaysByEvent } from "@/db/days";
 import { getSessionsByEvent } from "@/db/sessions";
 import { getLocations } from "@/db/locations";
-import { getGuests } from "@/db/guests";
+import { getGuestsByEvent } from "@/db/guests";
 import { getRSVPsByUser } from "@/db/rsvps";
 import { EventProviderWrapper } from "./event-provider-wrapper";
 
@@ -29,7 +29,7 @@ export async function EventLayoutContent({
     getDaysByEvent(event.Name),
     getSessionsByEvent(event.Name),
     getLocations(),
-    getGuests(),
+    getGuestsByEvent(event.Name),
     getRSVPsByUser(currentUser),
   ]);
 

--- a/app/[eventSlug]/session-form-page.tsx
+++ b/app/[eventSlug]/session-form-page.tsx
@@ -1,65 +1,15 @@
 import { Suspense } from "react";
-import { cookies } from "next/headers";
 
-import { getEventByName } from "@/db/events";
 import { eventSlugToName } from "@/utils/utils";
 import { SessionForm } from "./session-form";
-import { getDaysByEvent } from "@/db/days";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getGuestsByEvent } from "@/db/guests";
-import { getBookableLocations } from "@/db/locations";
-import { CONSTS } from "@/utils/constants";
-import { getSessionProposalsByEvent } from "@/db/sessionProposals";
 
-export async function renderSessionForm(props: {
-  params: { eventSlug: string };
-}) {
+export function renderSessionForm(props: { params: { eventSlug: string } }) {
   const { eventSlug } = props.params;
-  const currentUser = cookies().get("user")?.value;
   const eventName = eventSlugToName(eventSlug);
-  const [event, days, sessions, guests, locations, allProposals] =
-    await Promise.all([
-      getEventByName(eventName),
-      getDaysByEvent(eventName),
-      getSessionsByEvent(eventName),
-      getGuestsByEvent(eventName),
-      getBookableLocations(),
-      getSessionProposalsByEvent(eventName),
-    ]);
-  days.forEach((day) => {
-    const dayStartMillis = new Date(day.Start).getTime();
-    const dayEndMillis = new Date(day.End).getTime();
-    day.Sessions = sessions.filter((s) => {
-      const sessionStartMillis = new Date(s["Start time"]).getTime();
-      const sessionEndMillis = new Date(s["End time"]).getTime();
-      return (
-        dayStartMillis <= sessionStartMillis && dayEndMillis >= sessionEndMillis
-      );
-    });
-  });
-  const filteredLocations = locations.filter(
-    (location) =>
-      location.Bookable &&
-      (!CONSTS.MULTIPLE_EVENTS ||
-        (event["Location names"] &&
-          event["Location names"].includes(location.Name)))
-  );
-  const currentUserProposals = allProposals.filter(
-    (p) => currentUser && p.hosts.includes(currentUser)
-  );
-  const hostlessProposals = allProposals.filter((p) => p.hosts.length === 0);
-  const proposals = currentUserProposals.concat(hostlessProposals);
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <div className="max-w-2xl mx-auto pb-24">
-        <SessionForm
-          eventName={eventName}
-          days={days}
-          locations={filteredLocations}
-          sessions={sessions}
-          guests={guests}
-          proposals={proposals}
-        />
+        <SessionForm eventName={eventName} />
       </div>
     </Suspense>
   );

--- a/app/[eventSlug]/view-session/page.tsx
+++ b/app/[eventSlug]/view-session/page.tsx
@@ -1,50 +1,15 @@
-import { notFound } from "next/navigation";
-
-import { getGuestsByEvent } from "@/db/guests";
-import { getEventByName } from "@/db/events";
-import { eventSlugToName } from "@/utils/utils";
-import { getSessionsByEvent } from "@/db/sessions";
-import { getRSVPsBySession } from "@/db/rsvps";
 import { ViewSession } from "./view-session";
 
-export default async function ViewSessionPage({
+export default function ViewSessionPage({
   params,
-  searchParams,
 }: {
   params: { eventSlug: string };
   searchParams: { sessionID: string };
 }) {
   const { eventSlug } = params;
-  const { sessionID } = searchParams;
-
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getEventByName(eventName);
-
-  if (!event) {
-    return <div>Event not found</div>;
-  }
-
-  const [sessions, guests, rsvps] = await Promise.all([
-    getSessionsByEvent(eventName),
-    getGuestsByEvent(event.Name),
-    getRSVPsBySession(sessionID),
-  ]);
-  const session = sessions.find((p) => p.ID === sessionID);
-
-  if (!session) {
-    notFound();
-  }
-
   return (
     <div className="container mx-auto px-4 py-8">
-      <ViewSession
-        session={session}
-        guests={guests}
-        rsvps={rsvps}
-        eventSlug={eventSlug}
-        event={event}
-        showBackBtn={true}
-      />
+      <ViewSession eventSlug={eventSlug} showBackBtn={true} />
     </div>
   );
 }

--- a/app/api/get-proposals/route.ts
+++ b/app/api/get-proposals/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getSessionProposalsByEvent } from "@/db/sessionProposals";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const eventName = searchParams.get("eventName");
+
+  if (!eventName) {
+    return NextResponse.json(
+      { error: "eventName parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const proposals = await getSessionProposalsByEvent(eventName);
+    return NextResponse.json(proposals);
+  } catch (error) {
+    console.error("Error fetching RSVPs:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch RSVPs" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/rsvps-for-session/route.ts
+++ b/app/api/rsvps-for-session/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRSVPsBySession } from "@/db/rsvps";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const sessionId = searchParams.get("session");
+
+  if (!sessionId) {
+    return NextResponse.json(
+      { error: "Session parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const rsvps = await getRSVPsBySession(sessionId);
+    return NextResponse.json(rsvps);
+  } catch (error) {
+    console.error("Error fetching RSVPs:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch RSVPs" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Use the values that are already in context instead of fetching them all before the page loads

Note: the reason why I deleted the .forEach of locations is because the context already does that exact thing, so we are now reusing that code which was previously duplicated.

Depends on: https://github.com/LWCW-Europe/scheduling-app/pull/303