### PR TITLE
feat: switch time format from am/pm to 24h, add TIME_FORMAT constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Upgraded to Next.js 16, React 19, Tailwind CSS v4, and headlessui v2
+- Times now display in 24-hour format
 
 ### Fixed
 

--- a/app/[eventSlug]/day-grid.tsx
+++ b/app/[eventSlug]/day-grid.tsx
@@ -2,7 +2,7 @@
 import { LocationCol } from "./location-col";
 import clsx from "clsx";
 import { useSearchParams } from "next/navigation";
-import { getNumHalfHours } from "@/utils/utils";
+import { getNumHalfHours, TIME_FORMAT } from "@/utils/utils";
 import { useSafeLayoutEffect } from "@/utils/hooks";
 import { useRef, useState, useContext } from "react";
 import Image from "next/image";
@@ -175,7 +175,7 @@ export function DayGrid(props: {
             <div className="bg-gradient-to-r from-transparent to-white h-full absolute right-0 w-3" />
           )}
           {!scrolledToLeftEnd && (
-            <div className="bg-gradient-to-l from-transparent to-white h-full absolute left-14 w-3" />
+            <div className="bg-gradient-to-l from-transparent to-white h-full absolute left-8 w-3" />
           )}
         </div>
       )}
@@ -189,7 +189,7 @@ function TimestampCol(props: { start: Date; end: Date; timezone: string }) {
   return (
     <div
       className={clsx(
-        "grid h-full min-w-14 border-r border-t border-gray-100",
+        "grid h-full min-w-8 border-r border-t border-gray-100",
         `grid-rows-[repeat(${numHalfHours},44px)]`
       )}
     >
@@ -200,7 +200,7 @@ function TimestampCol(props: { start: Date; end: Date; timezone: string }) {
         >
           {DateTime.fromMillis(start.getTime() + i * 30 * 60 * 1000)
             .setZone(timezone)
-            .toFormat("h:mm a")}
+            .toFormat(TIME_FORMAT)}
         </div>
       ))}
     </div>

--- a/app/[eventSlug]/proposals/[proposalId]/view/view-proposal.tsx
+++ b/app/[eventSlug]/proposals/[proposalId]/view/view-proposal.tsx
@@ -21,6 +21,7 @@ import type {
 import { VotingButtons } from "@/app/[eventSlug]/proposals/voting-buttons";
 import { VoteChoice } from "@/app/votes";
 import { DateTime } from "luxon";
+import { TIME_FORMAT } from "@/utils/utils";
 
 export function ViewProposal(props: {
   proposal: SessionProposal;
@@ -213,7 +214,7 @@ export function ViewProposal(props: {
                 at{" "}
                 {DateTime.fromJSDate(sessions[0].startTime ?? new Date())
                   .setZone(event.timezone)
-                  .toFormat("h:mm a")}{" "}
+                  .toFormat(TIME_FORMAT)}{" "}
                 in {sessions[0].locations[0]?.name}
               </Link>
               .
@@ -230,7 +231,7 @@ export function ViewProposal(props: {
                     >
                       {DateTime.fromJSDate(session.startTime ?? new Date())
                         .setZone(event.timezone)
-                        .toFormat("EEEE h:mm a")}{" "}
+                        .toFormat(`EEEE ${TIME_FORMAT}`)}{" "}
                       in {session.locations[0]?.name}
                     </Link>
                   </li>

--- a/app/[eventSlug]/session-block.tsx
+++ b/app/[eventSlug]/session-block.tsx
@@ -11,7 +11,11 @@ import { useContext, useState } from "react";
 import { CurrentUserModal, ConfirmationModal } from "../modals";
 import { UserContext, EventContext } from "../context";
 import { sessionsOverlap } from "../session_utils";
-import { eventNameToSlug, getEndTimeMinusBreak } from "@/utils/utils";
+import {
+  eventNameToSlug,
+  getEndTimeMinusBreak,
+  TIME_FORMAT,
+} from "@/utils/utils";
 import { LockIcon } from "../lock-icon";
 
 export function SessionBlock(props: {
@@ -160,9 +164,11 @@ function SessionInfoDisplay({
           <span>
             {DateTime.fromJSDate(session.startTime ?? new Date())
               .setZone(timezone)
-              .toFormat("h:mm a")}{" "}
+              .toFormat(TIME_FORMAT)}{" "}
             -{" "}
-            {getEndTimeMinusBreak(session).setZone(timezone).toFormat("h:mm a")}
+            {getEndTimeMinusBreak(session)
+              .setZone(timezone)
+              .toFormat(TIME_FORMAT)}
           </span>
         </div>
       </div>

--- a/app/[eventSlug]/session-form.tsx
+++ b/app/[eventSlug]/session-form.tsx
@@ -17,6 +17,7 @@ import {
   eventNameToSlug,
   formatDuration,
   subtractBreakFromDuration,
+  TIME_FORMAT,
 } from "@/utils/utils";
 import { MyListbox, type Option } from "./select";
 import type {
@@ -224,7 +225,8 @@ export function SessionForm(props: {
     .map((hostClashes) => {
       const { id, sessionClashes, rsvpClashes } = hostClashes;
       const hostName = hosts.find((host) => host.id === id)!.name;
-      const formatTime = (d: DateTime) => d.setZone(timezone).toFormat("HH:mm");
+      const formatTime = (d: DateTime) =>
+        d.setZone(timezone).toFormat(TIME_FORMAT);
       const displayInterval = (ses: Session) =>
         `from ${formatTime(DateTime.fromJSDate(ses.startTime ?? new Date()))} to ${formatTime(getEndTimeMinusBreak(ses))}`;
       const sessionErrors = sessionClashes.map(
@@ -572,7 +574,7 @@ function getAvailableStartTimes(
     t += 30 * 60 * 1000
   ) {
     const dt = DateTime.fromMillis(t).setZone(timezone);
-    const formattedTime = dt.toFormat("h:mm a");
+    const formattedTime = dt.toFormat(TIME_FORMAT);
     const minutesFromMidnight = dt.hour * 60 + dt.minute;
     if (locationSelected) {
       const sessionNow = sortedSessions.find(

--- a/app/[eventSlug]/session-text.tsx
+++ b/app/[eventSlug]/session-text.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { DateTime } from "luxon";
 import type { Session, Location } from "@/db/repositories/interfaces";
-import { getEndTimeMinusBreak } from "@/utils/utils";
+import { getEndTimeMinusBreak, TIME_FORMAT } from "@/utils/utils";
 import { useRouter } from "next/navigation";
 import { useState, useContext } from "react";
 import { useSearchParams } from "next/navigation";
@@ -82,11 +82,11 @@ export function SessionText(props: {
               ,{" "}
               {DateTime.fromJSDate(session.startTime ?? new Date())
                 .setZone(timezone)
-                .toFormat("h:mm a")}{" "}
+                .toFormat(TIME_FORMAT)}{" "}
               -{" "}
               {getEndTimeMinusBreak(session)
                 .setZone(timezone)
-                .toFormat("h:mm a")}
+                .toFormat(TIME_FORMAT)}
             </span>
           </div>
           •<span>{formattedHostNames}</span>

--- a/app/[eventSlug]/view-session/view-session.tsx
+++ b/app/[eventSlug]/view-session/view-session.tsx
@@ -8,7 +8,7 @@ import { PencilIcon } from "@heroicons/react/24/outline";
 import { CheckCircleIcon, AcademicCapIcon } from "@heroicons/react/24/solid";
 
 import type { Event, Guest, Session, Rsvp } from "@/db/repositories/interfaces";
-import { getEndTimeMinusBreak } from "@/utils/utils";
+import { getEndTimeMinusBreak, TIME_FORMAT } from "@/utils/utils";
 import { UserContext, EventContext } from "../../context";
 import { CurrentUserModal, ConfirmationModal } from "../../modals";
 import { sessionsOverlap } from "../../session_utils";
@@ -257,11 +257,11 @@ export function ViewSession(props: {
           <span>
             {DateTime.fromJSDate(session.startTime ?? new Date())
               .setZone(event.timezone)
-              .toFormat("EEEE h:mm a")}{" "}
+              .toFormat(`EEEE ${TIME_FORMAT}`)}{" "}
             -{" "}
             {getEndTimeMinusBreak(session)
               .setZone(event.timezone)
-              .toFormat("h:mm a")}
+              .toFormat(TIME_FORMAT)}
           </span>
         </div>
         <div className="flex gap-2">

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -2,6 +2,10 @@ import { Day } from "@/db/repositories/interfaces";
 import type { Session } from "@/db/repositories/interfaces";
 import { DateTime } from "luxon";
 
+export const TIME_FORMAT = "HH:mm";
+// Note: if you want to change this to am/pm, the timestamp column in day-grid.tsx,
+// needs to be wider (see https://github.com/LWCW-Europe/schellingboard/pull/402/changes)
+
 export const getPercentThroughDay = (now: Date, start: Date, end: Date) =>
   ((now.getTime() - start.getTime()) / (end.getTime() - start.getTime())) * 100;
 


### PR DESCRIPTION
Most of the UI used am/pm, except session-form.tsx clash message which used 24h. Now all replaced with TIME_FORMAT (which is 24h).

The shorter labels allow to shrink the timestamp column on the schedule grid to save space on mobile.

The change is presentational, but the formatted string in session-form is also the value of the start-time picker and gets sent to the server as startTimeString. parseSessionTime still parses it correctly because its hand-rolled split-on-`[: ]` happens to accept "HH:mm" as well — and as a side effect, picking midnight in the form now produces 00:00 instead of 12:00 (a pre-existing bug pinned by tests/unit/parse-session-time.test.ts).

Added TODOs for removing the parser.