### PR TITLE
test(e2e): fail tests on browser console.error or uncaught page errors

### DIFF
--- a/tests/e2e/basic-sanity.spec.ts
+++ b/tests/e2e/basic-sanity.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 
 test.describe("Basic Sanity Checks", () => {

--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -1,0 +1,50 @@
+import { test as base, expect, ConsoleMessage } from "@playwright/test";
+
+const ALLOWED_CONSOLE_PATTERNS: RegExp[] = [
+  // Firefox quirk: when a test navigates while a Next.js __nextjs_font
+  // woff2 request is still in flight, Firefox aborts the request and logs
+  // a "downloadable font: download failed" error. Status 2152398850 is
+  // 0x804B0002 = NS_BINDING_ABORTED ("the request was cancelled"), so it's
+  // not a real download failure.
+  /downloadable font: download failed.*__nextjs_font.*status=2152398850/,
+];
+
+function isAllowed(text: string): boolean {
+  return ALLOWED_CONSOLE_PATTERNS.some((re) => re.test(text));
+}
+
+function formatConsoleMessage(msg: ConsoleMessage): string {
+  const loc = msg.location();
+  const where = loc.url ? ` (${loc.url}:${loc.lineNumber})` : "";
+  return `${msg.text()}${where}`;
+}
+
+export const test = base.extend<{ consoleGuard: void }>({
+  consoleGuard: [
+    async ({ page }, use) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+
+      page.on("console", (msg) => {
+        if (msg.type() !== "error") return;
+        const text = formatConsoleMessage(msg);
+        if (isAllowed(text)) return;
+        consoleErrors.push(text);
+      });
+
+      page.on("pageerror", (err) => {
+        const text = err.stack ?? err.message;
+        if (isAllowed(text)) return;
+        pageErrors.push(text);
+      });
+
+      await use();
+
+      expect(consoleErrors, "browser console.error during test").toEqual([]);
+      expect(pageErrors, "uncaught page errors during test").toEqual([]);
+    },
+    { auto: true }, // run for every test, even those that don't explicitly request `consoleGuard`
+  ],
+});
+
+export { expect };

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
 import { loginAndGoto, login } from "./helpers/auth";
 
 test("should auto-focus the title input for new proposals", async ({

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
 import { loginAndGoto, login } from "./helpers/auth";
 
 test("should allow voting on proposals with different choices", async ({


### PR DESCRIPTION
The fixture follows the recipe from
https://playwright.dev/docs/test-fixtures#creating-a-fixture

None of the existing e2e tests exercised the buggy flow, so this guard wouldn't have caught #404 retroactively. But it should catch broadly similar errors going forward.