### PR TITLE
fix: stop showing transient error after proposal form submit

### DIFF
--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { getRepositories } from "@/db/container";
 
@@ -34,7 +33,7 @@ export async function createProposal(formData: FormData) {
     console.error("Error creating proposal:", error);
     return { error: "Failed to create proposal" };
   }
-  redirect(`/${eventSlug}/proposals`);
+  return { success: true };
 }
 
 export async function updateProposal(id: string, formData: FormData) {
@@ -63,7 +62,7 @@ export async function updateProposal(id: string, formData: FormData) {
     console.error("Error updating proposal:", error);
     return { error: "Failed to update proposal" };
   }
-  redirect(`/${eventSlug}/proposals`);
+  return { success: true };
 }
 
 export async function deleteProposal(id: string, eventSlug: string) {
@@ -74,5 +73,5 @@ export async function deleteProposal(id: string, eventSlug: string) {
     console.error("Error deleting proposal:", error);
     return { error: "Failed to delete proposal" };
   }
-  redirect(`/${eventSlug}/proposals`);
+  return { success: true };
 }

--- a/app/(site)/[eventSlug]/session-proposal-form.tsx
+++ b/app/(site)/[eventSlug]/session-proposal-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useContext } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { Input } from "./input";
 import { UserContext } from "../context";
@@ -31,6 +32,7 @@ export function SessionProposalForm(props: {
     ),
   ];
   const { user: currentUserId } = useContext(UserContext);
+  const router = useRouter();
 
   const [title, setTitle] = useState(proposal?.title || "");
   const [description, setDescription] = useState(proposal?.description || "");
@@ -70,8 +72,10 @@ export function SessionProposalForm(props: {
         result = await createProposal(formData);
       }
 
-      if (result && "error" in result) {
+      if (result.error) {
         setError(result.error);
+      } else {
+        router.push(`/${eventSlug}/proposals`);
       }
     } catch (err) {
       setError("An unexpected error occurred");
@@ -90,8 +94,10 @@ export function SessionProposalForm(props: {
     try {
       const result = await deleteProposal(proposal.id, eventSlug);
 
-      if (result && "error" in result) {
+      if (result.error) {
         setError(result.error);
+      } else {
+        router.push(`/${eventSlug}/proposals`);
       }
     } catch (err) {
       setError("An unexpected error occurred");


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [3621198](https://github.com/LWCW-Europe/schellingboard/pull/427/commits/3621198bc5a917c25c67f88b463c9540a95d52a0).

PRs:
* #428
* ➡️ #427 (this PR, base of the stack — can be merged first)

---

## Description

Server actions ended with redirect(), which rejects the awaited promise
with NEXT_REDIRECT in production. The form's catch logged it and briefly
showed 'An unexpected error occurred' before navigating. Return a result
instead and navigate client-side.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).
