### PR TITLE
fix: prevent open redirect in site and admin login

### DIFF
--- a/app/actions/admin-auth.ts
+++ b/app/actions/admin-auth.ts
@@ -5,6 +5,7 @@ import {
   createAdminAuthCookie,
   createAdminLogoutCookie,
   isAdminEnabled,
+  safeRedirectPath,
 } from "@/utils/auth";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
@@ -14,11 +15,10 @@ export async function adminLoginAction(
   formData: FormData
 ) {
   const password = formData.get("password") as string;
-  let redirectTo = (formData.get("redirect") as string) || "/admin";
-  // Only allow same-origin paths ("//host" would be a protocol-relative URL)
-  if (!redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
-    redirectTo = "/admin";
-  }
+  const redirectTo = safeRedirectPath(
+    formData.get("redirect") as string,
+    "/admin"
+  );
 
   if (!isAdminEnabled()) {
     return { error: "Admin access is disabled" };

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -5,6 +5,7 @@ import {
   createAuthCookie,
   createLogoutCookie,
   isPasswordProtectionEnabled,
+  safeRedirectPath,
 } from "@/utils/auth";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
@@ -14,7 +15,7 @@ export async function loginAction(
   formData: FormData
 ) {
   const password = formData.get("password") as string;
-  const redirectTo = (formData.get("redirect") as string) || "/";
+  const redirectTo = safeRedirectPath(formData.get("redirect") as string, "/");
 
   if (!isPasswordProtectionEnabled()) {
     redirect(redirectTo);

--- a/tests/unit/safe-redirect.test.ts
+++ b/tests/unit/safe-redirect.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { safeRedirectPath } from "@/utils/auth";
+
+describe("safeRedirectPath", () => {
+  it("keeps a plain same-origin path", () => {
+    expect(safeRedirectPath("/sessions", "/")).toBe("/sessions");
+  });
+
+  it("preserves query string and hash", () => {
+    expect(safeRedirectPath("/sessions?view=grid#top", "/")).toBe(
+      "/sessions?view=grid#top"
+    );
+  });
+
+  it("returns the fallback for empty/missing values", () => {
+    expect(safeRedirectPath("", "/")).toBe("/");
+    expect(safeRedirectPath(null, "/admin")).toBe("/admin");
+    expect(safeRedirectPath(undefined, "/admin")).toBe("/admin");
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(safeRedirectPath("https://evil.com", "/")).toBe("/");
+  });
+
+  // Open-redirect bypass vectors (see helper doc comment).
+  it.each([
+    ["//evil.com"],
+    ["/\\evil.com"], // backslash → browsers read as "//"
+    ["/\t/evil.com"], // tab stripped → "//"
+    ["////evil.com"],
+    [" //evil.com"],
+    ["/..//evil.com"], // path normalization re-introduces "//"
+    ["/\\/evil.com"],
+    ["/\r//evil.com"],
+  ])("neutralizes off-site vector %j", (vector) => {
+    const result = safeRedirectPath(vector, "/");
+    expect(result.startsWith("//")).toBe(false);
+    expect(/^\/\\/.test(result)).toBe(false);
+  });
+
+  // Reviewer-reported vector: /login?redirect=/%5Cevil.com.
+  // searchParams/formData URL-decode %5C to a backslash before it reaches the
+  // action, and the browser reads "/\evil.com" as "//evil.com".
+  it("neutralizes the %5C (backslash) vector after URL decoding", () => {
+    const decoded = decodeURIComponent("/%5Cevil.com"); // "/\evil.com"
+    expect(safeRedirectPath(decoded, "/")).toBe("/");
+  });
+
+  // The raw, still-encoded form is harmless: %5C stays in the path, so it is a
+  // genuine same-origin path rather than an off-site redirect.
+  it("treats a still-encoded %5C as a same-origin path", () => {
+    expect(safeRedirectPath("/%5Cevil.com", "/")).toBe("/%5Cevil.com");
+  });
+});

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -8,6 +8,42 @@ const ADMIN_SCOPE = "admin";
 const COOKIE_MAX_AGE_SEC = 7 * 24 * 60 * 60;
 const COOKIE_MAX_AGE_MS = COOKIE_MAX_AGE_SEC * 1000;
 
+/**
+ * Returns a safe same-origin redirect path, or `fallback` if `value` could
+ * navigate off-site.
+ *
+ * Attack vector: the post-login redirect target is attacker-controllable via a
+ * crafted link (e.g. `/login?redirect=//evil.com`). Without validation a user
+ * who logs in is then bounced to an external site — a phishing aid. Browsers
+ * also treat `\` and stripped tabs/newlines as `/`, so `/%5Cevil.com` becomes
+ * `//evil.com`, etc.
+ *
+ * We parse the value with the WHATWG URL parser (the `URL` constructor) against
+ * a dummy origin, and accept it only if it stays on that origin and the
+ * normalized path is not itself protocol-relative.
+ *
+ * Best effort only: the browser re-parses the eventual `Location` header with
+ * its own WHATWG implementation, which may differ from ours on edge cases, so
+ * we cannot guarantee every case is covered.
+ */
+export function safeRedirectPath(
+  value: string | null | undefined,
+  fallback: string
+): string {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    const url = new URL(value, "http://x");
+    if (url.origin !== "http://x" || url.pathname.startsWith("//")) {
+      return fallback;
+    }
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return fallback;
+  }
+}
+
 export function isPasswordProtectionEnabled(): boolean {
   return !!process.env.SITE_PASSWORD;
 }


### PR DESCRIPTION
The post-login redirect target is attacker-controllable via a crafted
link (e.g. ?redirect=//evil.com, or ?redirect=/%5Cevil.com which the
browser reads as //evil.com). An unvalidated value bounces users to an
external site after they authenticate.

Add a shared best-effort safeRedirectPath helper that resolves the value
with the WHATWG URL parser and accepts only same-origin paths, and use
it in both the site and admin login actions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- jip:pushed-commit=4c896b9d5cbd5d0dee6eec4874885de3331fd8ee -->