### PR TITLE
fix: drop bogus .next/dev/dev/types include from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,9 +37,8 @@
     "**/*.tsx",
     "**/*.js",
     ".next/types/**/*.ts",
-    "db",
     ".next/dev/types/**/*.ts",
-    ".next/dev/dev/types/**/*.ts"
+    "db",
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
The doubled `dev/dev` path was an artifact of Next's tsconfig
auto-management and matched nothing.

<!-- jip:pushed-commit=4ec3537ef9f6d4946967a61010e3e04ce811d59d -->