### PR TITLE
fix: regenerate route types in typecheck to avoid stale-type errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ lint: install
 	bun x eslint --max-warnings 0 .
 
 typecheck: install
+	rm -rf .next/dev/types
+	bun x next typegen
 	bun x tsc --noEmit
 
 lint-watch: install


### PR DESCRIPTION
`make typecheck` ran `tsc` against the dev-server-generated
`.next/dev/types`, which only refreshes while `next dev` runs. After a
route was added/renamed/deleted, the stale validator referenced missing
modules (TS2307), previously requiring `make clean` to fix. Clear the
dev types and regenerate via `next typegen` before type checking.

<!-- jip:pushed-commit=e9a9d77b5b85777a6023f872c20861b1fe23da22 -->