### PR TITLE
feat: add DB-level ON DELETE CASCADE via migration, enforce foreign keys

### DIFF
--- a/db/container.ts
+++ b/db/container.ts
@@ -56,6 +56,11 @@ export function getRepositories(): Repositories {
   if (!_repositories) {
     const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
     _sqlite = new Database(url.replace(/^file:/, ""));
+    // Enforce foreign keys on every connection. better-sqlite3 happens to
+    // compile SQLite with SQLITE_DEFAULT_FOREIGN_KEYS=1, but set it explicitly
+    // so our ON DELETE CASCADE / SET NULL behaviour never depends on that
+    // build default. Migrations toggle it off and back on below.
+    _sqlite.pragma("foreign_keys = ON");
     const db = drizzle(_sqlite, { schema });
     const migrationsFolder = path.join(process.cwd(), "drizzle");
     try {
@@ -82,5 +87,7 @@ export function serializeDb(): Buffer {
 
 export function restoreDb(snapshot: Buffer): void {
   _sqlite = new Database(snapshot);
+  // Enforce foreign keys on every connection (see getRepositories).
+  _sqlite.pragma("foreign_keys = ON");
   _repositories = buildRepositories(_sqlite);
 }

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -49,6 +49,10 @@ export interface EventsRepository {
   findById(id: string): Promise<Event | undefined>;
   findByName(name: string): Promise<Event | undefined>;
   create(data: Omit<Event, "id">): Promise<Event>;
+  update(
+    id: string,
+    patch: Partial<Omit<Event, "id">>
+  ): Promise<Event | undefined>;
 }
 
 // ── Guests ────────────────────────────────────────────────────────────────────

--- a/db/repositories/sqlite/events.ts
+++ b/db/repositories/sqlite/events.ts
@@ -4,6 +4,8 @@ import { nanoid } from "nanoid";
 import * as schema from "../../schema";
 import type { Event, EventsRepository } from "../interfaces";
 
+type EventRow = typeof schema.events.$inferInsert;
+
 type DB = BetterSQLite3Database<typeof schema>;
 
 function rowToEvent(row: typeof schema.events.$inferSelect): Event {
@@ -86,5 +88,45 @@ export class SqliteEventsRepository implements EventsRepository {
       })
       .run();
     return { id, ...data };
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<Event, "id">>
+  ): Promise<Event | undefined> {
+    const existing = await this.findById(id);
+    if (!existing) return undefined;
+
+    const set: Partial<EventRow> = {};
+    if (patch.name !== undefined) set.name = patch.name;
+    if (patch.description !== undefined) set.description = patch.description;
+    if (patch.website !== undefined) set.website = patch.website;
+    if (patch.start !== undefined) set.start = patch.start.toISOString();
+    if (patch.end !== undefined) set.end = patch.end.toISOString();
+    if ("proposalPhaseStart" in patch)
+      set.proposalPhaseStart = patch.proposalPhaseStart?.toISOString() ?? null;
+    if ("proposalPhaseEnd" in patch)
+      set.proposalPhaseEnd = patch.proposalPhaseEnd?.toISOString() ?? null;
+    if ("votingPhaseStart" in patch)
+      set.votingPhaseStart = patch.votingPhaseStart?.toISOString() ?? null;
+    if ("votingPhaseEnd" in patch)
+      set.votingPhaseEnd = patch.votingPhaseEnd?.toISOString() ?? null;
+    if ("schedulingPhaseStart" in patch)
+      set.schedulingPhaseStart =
+        patch.schedulingPhaseStart?.toISOString() ?? null;
+    if ("schedulingPhaseEnd" in patch)
+      set.schedulingPhaseEnd = patch.schedulingPhaseEnd?.toISOString() ?? null;
+    if (patch.maxSessionDuration !== undefined)
+      set.maxSessionDuration = patch.maxSessionDuration;
+    if (patch.timezone !== undefined) set.timezone = patch.timezone;
+    if ("icon" in patch) set.icon = patch.icon ?? null;
+
+    this.db
+      .update(schema.events)
+      .set(set)
+      .where(eq(schema.events.id, id))
+      .run();
+
+    return { ...existing, ...patch };
   }
 }

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -75,19 +75,8 @@ export class SqliteGuestsRepository implements GuestsRepository {
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction((tx) => {
-      tx.delete(schema.votes).where(eq(schema.votes.guestId, id)).run();
-      tx.delete(schema.rsvps).where(eq(schema.rsvps.guestId, id)).run();
-      tx.delete(schema.proposalHosts)
-        .where(eq(schema.proposalHosts.guestId, id))
-        .run();
-      tx.delete(schema.sessionHosts)
-        .where(eq(schema.sessionHosts.guestId, id))
-        .run();
-      tx.delete(schema.eventGuests)
-        .where(eq(schema.eventGuests.guestId, id))
-        .run();
-      tx.delete(schema.guests).where(eq(schema.guests.id, id)).run();
-    });
+    // votes, rsvps, proposal_hosts, session_hosts and event_guests are removed
+    // by ON DELETE CASCADE.
+    this.db.delete(schema.guests).where(eq(schema.guests.id, id)).run();
   }
 }

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -101,15 +101,8 @@ export class SqliteLocationsRepository implements LocationsRepository {
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction((tx) => {
-      tx.delete(schema.sessionLocations)
-        .where(eq(schema.sessionLocations.locationId, id))
-        .run();
-      tx.delete(schema.eventLocations)
-        .where(eq(schema.eventLocations.locationId, id))
-        .run();
-      tx.delete(schema.locations).where(eq(schema.locations.id, id)).run();
-    });
+    // session_locations and event_locations are removed by ON DELETE CASCADE.
+    this.db.delete(schema.locations).where(eq(schema.locations.id, id)).run();
   }
 
   async countSessionLinks(id: string): Promise<number> {

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -194,14 +194,11 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction((tx) => {
-      tx.delete(schema.votes).where(eq(schema.votes.proposalId, id)).run();
-      tx.delete(schema.proposalHosts)
-        .where(eq(schema.proposalHosts.proposalId, id))
-        .run();
-      tx.delete(schema.sessionProposals)
-        .where(eq(schema.sessionProposals.id, id))
-        .run();
-    });
+    // votes and proposal_hosts are removed by ON DELETE CASCADE; sessions
+    // referencing this proposal have their proposal_id set to NULL.
+    this.db
+      .delete(schema.sessionProposals)
+      .where(eq(schema.sessionProposals.id, id))
+      .run();
   }
 }

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -245,15 +245,8 @@ export class SqliteSessionsRepository implements SessionsRepository {
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction((tx) => {
-      tx.delete(schema.rsvps).where(eq(schema.rsvps.sessionId, id)).run();
-      tx.delete(schema.sessionHosts)
-        .where(eq(schema.sessionHosts.sessionId, id))
-        .run();
-      tx.delete(schema.sessionLocations)
-        .where(eq(schema.sessionLocations.sessionId, id))
-        .run();
-      tx.delete(schema.sessions).where(eq(schema.sessions.id, id)).run();
-    });
+    // rsvps, session_hosts and session_locations are removed by ON DELETE
+    // CASCADE.
+    this.db.delete(schema.sessions).where(eq(schema.sessions.id, id)).run();
   }
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -34,10 +34,10 @@ export const eventGuests = sqliteTable(
   {
     eventId: text("event_id")
       .notNull()
-      .references(() => events.id),
+      .references(() => events.id, { onDelete: "cascade" }),
     guestId: text("guest_id")
       .notNull()
-      .references(() => guests.id),
+      .references(() => guests.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.eventId, t.guestId] })]
 );
@@ -60,10 +60,10 @@ export const eventLocations = sqliteTable(
   {
     eventId: text("event_id")
       .notNull()
-      .references(() => events.id),
+      .references(() => events.id, { onDelete: "cascade" }),
     locationId: text("location_id")
       .notNull()
-      .references(() => locations.id),
+      .references(() => locations.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.eventId, t.locationId] })]
 );
@@ -76,14 +76,14 @@ export const days = sqliteTable("days", {
   endBookings: text("end_bookings").notNull(),
   eventId: text("event_id")
     .notNull()
-    .references(() => events.id),
+    .references(() => events.id, { onDelete: "cascade" }),
 });
 
 export const sessionProposals = sqliteTable("session_proposals", {
   id: text("id").primaryKey(),
   eventId: text("event_id")
     .notNull()
-    .references(() => events.id),
+    .references(() => events.id, { onDelete: "cascade" }),
   title: text("title").notNull(),
   description: text("description"),
   durationMinutes: integer("duration_minutes"),
@@ -95,10 +95,10 @@ export const proposalHosts = sqliteTable(
   {
     proposalId: text("proposal_id")
       .notNull()
-      .references(() => sessionProposals.id),
+      .references(() => sessionProposals.id, { onDelete: "cascade" }),
     guestId: text("guest_id")
       .notNull()
-      .references(() => guests.id),
+      .references(() => guests.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.proposalId, t.guestId] })]
 );
@@ -117,10 +117,12 @@ export const sessions = sqliteTable("sessions", {
     .default(false),
   blocker: integer("blocker", { mode: "boolean" }).notNull().default(false),
   closed: integer("closed", { mode: "boolean" }).notNull().default(false),
-  proposalId: text("proposal_id").references(() => sessionProposals.id),
+  proposalId: text("proposal_id").references(() => sessionProposals.id, {
+    onDelete: "set null",
+  }),
   eventId: text("event_id")
     .notNull()
-    .references(() => events.id),
+    .references(() => events.id, { onDelete: "cascade" }),
 });
 
 export const sessionHosts = sqliteTable(
@@ -128,10 +130,10 @@ export const sessionHosts = sqliteTable(
   {
     sessionId: text("session_id")
       .notNull()
-      .references(() => sessions.id),
+      .references(() => sessions.id, { onDelete: "cascade" }),
     guestId: text("guest_id")
       .notNull()
-      .references(() => guests.id),
+      .references(() => guests.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.sessionId, t.guestId] })]
 );
@@ -141,10 +143,10 @@ export const sessionLocations = sqliteTable(
   {
     sessionId: text("session_id")
       .notNull()
-      .references(() => sessions.id),
+      .references(() => sessions.id, { onDelete: "cascade" }),
     locationId: text("location_id")
       .notNull()
-      .references(() => locations.id),
+      .references(() => locations.id, { onDelete: "cascade" }),
   },
   (t) => [primaryKey({ columns: [t.sessionId, t.locationId] })]
 );
@@ -153,19 +155,19 @@ export const rsvps = sqliteTable("rsvps", {
   id: text("id").primaryKey(),
   sessionId: text("session_id")
     .notNull()
-    .references(() => sessions.id),
+    .references(() => sessions.id, { onDelete: "cascade" }),
   guestId: text("guest_id")
     .notNull()
-    .references(() => guests.id),
+    .references(() => guests.id, { onDelete: "cascade" }),
 });
 
 export const votes = sqliteTable("votes", {
   id: text("id").primaryKey(),
   proposalId: text("proposal_id")
     .notNull()
-    .references(() => sessionProposals.id),
+    .references(() => sessionProposals.id, { onDelete: "cascade" }),
   guestId: text("guest_id")
     .notNull()
-    .references(() => guests.id),
+    .references(() => guests.id, { onDelete: "cascade" }),
   choice: text("choice").notNull(),
 });

--- a/drizzle/0005_cascade_fks.sql
+++ b/drizzle/0005_cascade_fks.sql
@@ -1,0 +1,125 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_days` (
+	`id` text PRIMARY KEY NOT NULL,
+	`start` text NOT NULL,
+	`end` text NOT NULL,
+	`start_bookings` text NOT NULL,
+	`end_bookings` text NOT NULL,
+	`event_id` text NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_days`("id", "start", "end", "start_bookings", "end_bookings", "event_id") SELECT "id", "start", "end", "start_bookings", "end_bookings", "event_id" FROM `days`;--> statement-breakpoint
+DROP TABLE `days`;--> statement-breakpoint
+ALTER TABLE `__new_days` RENAME TO `days`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_event_guests` (
+	`event_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	PRIMARY KEY(`event_id`, `guest_id`),
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_event_guests`("event_id", "guest_id") SELECT "event_id", "guest_id" FROM `event_guests`;--> statement-breakpoint
+DROP TABLE `event_guests`;--> statement-breakpoint
+ALTER TABLE `__new_event_guests` RENAME TO `event_guests`;--> statement-breakpoint
+CREATE TABLE `__new_event_locations` (
+	`event_id` text NOT NULL,
+	`location_id` text NOT NULL,
+	PRIMARY KEY(`event_id`, `location_id`),
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_event_locations`("event_id", "location_id") SELECT "event_id", "location_id" FROM `event_locations`;--> statement-breakpoint
+DROP TABLE `event_locations`;--> statement-breakpoint
+ALTER TABLE `__new_event_locations` RENAME TO `event_locations`;--> statement-breakpoint
+CREATE TABLE `__new_proposal_hosts` (
+	`proposal_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	PRIMARY KEY(`proposal_id`, `guest_id`),
+	FOREIGN KEY (`proposal_id`) REFERENCES `session_proposals`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_proposal_hosts`("proposal_id", "guest_id") SELECT "proposal_id", "guest_id" FROM `proposal_hosts`;--> statement-breakpoint
+DROP TABLE `proposal_hosts`;--> statement-breakpoint
+ALTER TABLE `__new_proposal_hosts` RENAME TO `proposal_hosts`;--> statement-breakpoint
+CREATE TABLE `__new_rsvps` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_rsvps`("id", "session_id", "guest_id") SELECT "id", "session_id", "guest_id" FROM `rsvps`;--> statement-breakpoint
+DROP TABLE `rsvps`;--> statement-breakpoint
+ALTER TABLE `__new_rsvps` RENAME TO `rsvps`;--> statement-breakpoint
+CREATE TABLE `__new_session_hosts` (
+	`session_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	PRIMARY KEY(`session_id`, `guest_id`),
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_session_hosts`("session_id", "guest_id") SELECT "session_id", "guest_id" FROM `session_hosts`;--> statement-breakpoint
+DROP TABLE `session_hosts`;--> statement-breakpoint
+ALTER TABLE `__new_session_hosts` RENAME TO `session_hosts`;--> statement-breakpoint
+CREATE TABLE `__new_session_locations` (
+	`session_id` text NOT NULL,
+	`location_id` text NOT NULL,
+	PRIMARY KEY(`session_id`, `location_id`),
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`location_id`) REFERENCES `locations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_session_locations`("session_id", "location_id") SELECT "session_id", "location_id" FROM `session_locations`;--> statement-breakpoint
+DROP TABLE `session_locations`;--> statement-breakpoint
+ALTER TABLE `__new_session_locations` RENAME TO `session_locations`;--> statement-breakpoint
+CREATE TABLE `__new_session_proposals` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`duration_minutes` integer,
+	`created_time` text NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_session_proposals`("id", "event_id", "title", "description", "duration_minutes", "created_time") SELECT "id", "event_id", "title", "description", "duration_minutes", "created_time" FROM `session_proposals`;--> statement-breakpoint
+DROP TABLE `session_proposals`;--> statement-breakpoint
+ALTER TABLE `__new_session_proposals` RENAME TO `session_proposals`;--> statement-breakpoint
+CREATE TABLE `__new_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`start_time` text,
+	`end_time` text,
+	`capacity` integer DEFAULT 0 NOT NULL,
+	`attendee_scheduled` integer DEFAULT false NOT NULL,
+	`blocker` integer DEFAULT false NOT NULL,
+	`closed` integer DEFAULT false NOT NULL,
+	`proposal_id` text,
+	`event_id` text NOT NULL,
+	FOREIGN KEY (`proposal_id`) REFERENCES `session_proposals`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_sessions`("id", "title", "description", "start_time", "end_time", "capacity", "attendee_scheduled", "blocker", "closed", "proposal_id", "event_id") SELECT "id", "title", "description", "start_time", "end_time", "capacity", "attendee_scheduled", "blocker", "closed", "proposal_id", "event_id" FROM `sessions`;--> statement-breakpoint
+DROP TABLE `sessions`;--> statement-breakpoint
+ALTER TABLE `__new_sessions` RENAME TO `sessions`;--> statement-breakpoint
+CREATE TABLE `__new_votes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`proposal_id` text NOT NULL,
+	`guest_id` text NOT NULL,
+	`choice` text NOT NULL,
+	FOREIGN KEY (`proposal_id`) REFERENCES `session_proposals`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_votes`("id", "proposal_id", "guest_id", "choice") SELECT "id", "proposal_id", "guest_id", "choice" FROM `votes`;--> statement-breakpoint
+DROP TABLE `votes`;--> statement-breakpoint
+ALTER TABLE `__new_votes` RENAME TO `votes`;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,837 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a9057659-439e-423b-b758-52df7b01276d",
+  "prevId": "1b51c98c-d0b2-448b-87d7-c89c52514d9f",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attendee_scheduled": {
+          "name": "attendee_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782260306200,
       "tag": "0004_curious_richard_fisk",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1782331084625,
+      "tag": "0005_cascade_fks",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -19,6 +19,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function openDb() {
   const url = process.env.DATABASE_URL ?? "file:./data.db";
   const sqlite = new Database(url.replace(/^file:/, ""));
+  // Enforce foreign keys on every connection; the migration below toggles it
+  // off and back on.
+  sqlite.pragma("foreign_keys = ON");
   const db = drizzle(sqlite, { schema });
   try {
     sqlite.pragma("foreign_keys = OFF");

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -10,6 +10,9 @@ import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 
 const dbUrl = process.env.DATABASE_URL ?? "file:./data.db";
 const sqlite = new Database(dbUrl.replace(/^file:/, ""));
+// Enforce foreign keys on every connection; the migration below toggles it
+// off and back on.
+sqlite.pragma("foreign_keys = ON");
 const db = drizzle(sqlite);
 
 const migrationsFolder = path.join(

--- a/tests/e2e/reset-database.ts
+++ b/tests/e2e/reset-database.ts
@@ -45,6 +45,9 @@ if (process.env.NODE_ENV === "production" || dbUrl.includes("prod")) {
 
 function openDb() {
   const sqlite = new Database(dbUrl.replace(/^file:/, ""));
+  // Enforce foreign keys on every connection; the migration below toggles it
+  // off and back on.
+  sqlite.pragma("foreign_keys = ON");
   const db = drizzle(sqlite, { schema });
   const migrationsFolder = path.join(
     path.dirname(fileURLToPath(import.meta.url)),

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -1,0 +1,75 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("events repo", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", "0123456789abcdef0123456789abcdef");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("update", () => {
+    it("updates event fields", async () => {
+      const event = await createEvent({ name: "Original" });
+      const updated = await getRepositories().events.update(event.id, {
+        name: "Updated",
+        description: "New description",
+      });
+      expect(updated).toMatchObject({
+        id: event.id,
+        name: "Updated",
+        description: "New description",
+      });
+      const fetched = await getRepositories().events.findById(event.id);
+      expect(fetched?.name).toBe("Updated");
+    });
+
+    it("returns undefined for unknown id", async () => {
+      const result = await getRepositories().events.update("no-such-id", {
+        name: "X",
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("preserves unpatched fields", async () => {
+      const event = await createEvent({ name: "Keep" });
+      await getRepositories().events.update(event.id, {
+        description: "Patched",
+      });
+      const fetched = await getRepositories().events.findById(event.id);
+      expect(fetched?.name).toBe("Keep");
+    });
+  });
+});

--- a/tests/integration/delete-proposal.test.ts
+++ b/tests/integration/delete-proposal.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createProposal,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { VoteChoice } from "@/db/repositories/interfaces";
+import { deleteProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
+
+describe("deleteProposal", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => resetTestDb());
+
+  it("cascade-deletes votes and host links and nulls the session's proposalId, leaving other data intact", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    const voter = await createGuest({ name: "Voter" });
+
+    const proposal = await createProposal(event.id, [host.id]);
+    const otherProposal = await createProposal(event.id, [host.id]);
+
+    await repos.votes.create({
+      proposalId: proposal.id,
+      guestId: voter.id,
+      choice: VoteChoice.interested,
+    });
+    await repos.votes.create({
+      proposalId: otherProposal.id,
+      guestId: voter.id,
+      choice: VoteChoice.maybe,
+    });
+
+    const session = await createSession(event.id, { hostIds: [host.id] });
+    await repos.sessions.update(session.id, { proposalId: proposal.id });
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toEqual({ success: true });
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
+
+    // The voter's vote for the deleted proposal is gone, the other remains.
+    const votesAfter = await repos.votes.listByGuestAndEvent(
+      voter.id,
+      event.id
+    );
+    expect(votesAfter.map((v) => v.proposalId)).toEqual([otherProposal.id]);
+
+    // The session survives but no longer references the deleted proposal.
+    const sessionAfter = await repos.sessions.findById(session.id);
+    expect(sessionAfter).toBeDefined();
+    expect(sessionAfter?.proposalId).toBeUndefined();
+
+    // Host guest and the other proposal are untouched.
+    expect(await repos.guests.findById(host.id)).toBeDefined();
+    const otherAfter = await repos.sessionProposals.findById(otherProposal.id);
+    expect(otherAfter?.hosts.map((h) => h.id)).toEqual([host.id]);
+  });
+});


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [225417d](https://github.com/LWCW-Europe/schellingboard/pull/442/commits/225417d299c303f044038eb0bc364dc6c82b2897).

PRs:
* #449
* #448
* #446
* #475
* #445
* #474
* #444
* ➡️ #442 (this PR, depends on the ones below ⬇️)
* #441

---

## Description

Define ON DELETE CASCADE (and SET NULL for sessions.proposal_id) on the
schema's foreign keys and recreate the affected tables via migration.

These clauses only take effect when SQLite's foreign_keys pragma is on.
better-sqlite3 already compiles SQLite with SQLITE_DEFAULT_FOREIGN_KEYS=1,
so it is on by default here -- but we set it explicitly on every connection
rather than depend on that build default, since the cascade behaviour is
correctness-critical and would silently break if the default ever changed.
Migrations are the one exception: foreign_keys is toggled off around
migrate() (and restored in a finally) because Drizzle's table-rebuild
migrations would otherwise abort -- see commit f1a84170.

With the database doing the cascading, the manual multi-step deletes in the
locations, guests, session-proposals and sessions repositories become
redundant: each delete() now issues a single statement and lets the DB
remove the dependent rows.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).
