### PR TITLE
fix: stale sessions in router client cache

### DIFF
--- a/app/(site)/[eventSlug]/session-actions.ts
+++ b/app/(site)/[eventSlug]/session-actions.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+// Sessions are mutated through the /api/{add,update,delete}-session route
+// handlers, but we also need to purge the client-side Router Cache.
+// This thin server action does just that.
+//
+// The session list is fetched in the shared [eventSlug] layout, so we
+// revalidate the layout: this invalidates it and every page beneath it.
+//
+// revalidatePath is synchronous, but a "use server" action must be async to be
+// callable from the client, hence the eslint exception.
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function revalidateEvent(eventSlug: string) {
+  revalidatePath(`/${eventSlug}`, "layout");
+}

--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -94,10 +94,11 @@ export function BookableSessionCard(props: {
   return (
     <div className={`row-span-${numHalfHours} my-0.5 min-h-10`}>
       <Link
+        aria-label="Add session"
         className="rounded font-roboto h-full w-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center"
         href={`/${eventSlug}/add-session?location=${location.name}&time=${timeParam}&day=${dayParam}`}
       >
-        <PlusIcon className="h-4 w-4 text-gray-400" />
+        <PlusIcon aria-hidden="true" className="h-4 w-4 text-gray-400" />
       </Link>
     </div>
   );

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -32,6 +32,7 @@ import { ConfirmDeletionModal } from "../modals";
 import { UserContext, EventContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { buildSessionInterval } from "@/app/api/session-form-utils";
+import { revalidateEvent } from "./session-actions";
 
 interface ErrorResponse {
   message: string;
@@ -272,6 +273,7 @@ export function SessionForm(props: {
     });
     if (res.ok) {
       const actionType = sessionID ? "updated" : "added";
+      await revalidateEvent(eventNameToSlug(eventName));
       router.push(
         `/${eventNameToSlug(eventName)}/add-session/confirmation?actionType=${actionType}`
       );
@@ -306,6 +308,7 @@ export function SessionForm(props: {
     });
     if (res.ok) {
       console.log("Session deleted successfully");
+      await revalidateEvent(eventNameToSlug(eventName));
       router.push(
         `/${eventNameToSlug(eventName)}/edit-session/deletion-confirmation`
       );

--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+
+test("a newly added session appears on the overview", async ({ page }) => {
+  await login(page);
+
+  await page.goto("/Conference-Gamma");
+  await expect(
+    page.getByRole("heading", { name: /Conference Gamma Schedule/ })
+  ).toBeVisible();
+
+  // Reach the form the way a real user does: click a free "+" slot in the grid.
+  // We don't care which slot, so take the first.
+  await page.getByRole("link", { name: "Add session" }).first().click();
+  await expect(
+    page.getByRole("heading", { name: /Add a session/i })
+  ).toBeVisible();
+
+  const sessionTitle = "Yak shaving";
+  await page.getByRole("textbox").first().fill(sessionTitle);
+
+  // Add a host via the combobox (a host is required to enable Submit).
+  const hostsSection = page
+    .locator("div")
+    .filter({ hasText: /^Hosts/ })
+    .first();
+  await hostsSection.getByRole("button").first().click();
+  await page.keyboard.type("Alice Test");
+  await page.getByRole("option", { name: /Alice Test/i }).click();
+  await page.keyboard.press("Escape");
+
+  const submit = page.getByRole("button", { name: "Submit" });
+  await expect(submit).toBeEnabled();
+  await submit.click();
+
+  // Lands on the confirmation page.
+  await expect(
+    page.getByRole("heading", { name: /Session added/i })
+  ).toBeVisible();
+
+  // Click the in-app "Back to schedule" link. This is the client-side
+  // navigation that previously served a stale (pre-mutation) overview.
+  await page.getByRole("link", { name: /Back to schedule/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /Conference Gamma Schedule/ })
+  ).toBeVisible();
+
+  // The new session must be visible WITHOUT reloading (see #253).
+  await expect(page.getByText(sessionTitle)).toBeVisible();
+});


### PR DESCRIPTION
The proper solution would be to convert session CRUD API routes to server actions, similar to how proposals or admin UI currently work. However, I tried (asking an agent) and it looks like a large change and I'm not that invested. So as a small workaround, we add just one tiny server action that calls revalidatePath(), and invoke it in addition to the API calls.

It looks like it fixes #253, but it doesn't fully. There is a lingering staleness bug of a different nature, but it will remain a mystery until the followup commit.

---

Along the way, make the "+" slots easier to locate in e2e tests by adding a label.

The interstitial page "session added, go back to schedule" is completely unnecessary and lives on borrowed time, but this particular change spares it to limit scope.