### PR TITLE
fix: inconsistent Drizzle transactions usage

### DIFF
--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -129,9 +129,8 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
   async create(data: SessionProposalCreateInput): Promise<SessionProposal> {
     const id = nanoid();
     const createdTime = new Date().toISOString();
-    this.db.transaction(() => {
-      this.db
-        .insert(schema.sessionProposals)
+    this.db.transaction((tx) => {
+      tx.insert(schema.sessionProposals)
         .values({
           id,
           eventId: data.eventId,
@@ -142,8 +141,7 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
         })
         .run();
       for (const guestId of data.hostIds) {
-        this.db
-          .insert(schema.proposalHosts)
+        tx.insert(schema.proposalHosts)
           .values({ proposalId: id, guestId })
           .run();
       }
@@ -155,7 +153,7 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
     id: string,
     patch: SessionProposalUpdateInput
   ): Promise<SessionProposal> {
-    this.db.transaction(() => {
+    this.db.transaction((tx) => {
       const values: Partial<typeof schema.sessionProposals.$inferInsert> = {};
       if (patch.title !== undefined) values.title = patch.title;
       if (patch.description !== undefined)
@@ -164,28 +162,24 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
         values.durationMinutes = patch.durationMinutes ?? null;
 
       if (Object.keys(values).length > 0) {
-        this.db
-          .update(schema.sessionProposals)
+        tx.update(schema.sessionProposals)
           .set(values)
           .where(eq(schema.sessionProposals.id, id))
           .run();
       }
 
       if (patch.hostIds !== undefined) {
-        this.db
-          .delete(schema.proposalHosts)
+        tx.delete(schema.proposalHosts)
           .where(eq(schema.proposalHosts.proposalId, id))
           .run();
         for (const guestId of patch.hostIds) {
-          this.db
-            .insert(schema.proposalHosts)
+          tx.insert(schema.proposalHosts)
             .values({ proposalId: id, guestId })
             .run();
         }
         // Hosts can't vote for their own proposal; remove their votes.
         if (patch.hostIds.length > 0) {
-          this.db
-            .delete(schema.votes)
+          tx.delete(schema.votes)
             .where(
               and(
                 eq(schema.votes.proposalId, id),
@@ -200,14 +194,12 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction(() => {
-      this.db.delete(schema.votes).where(eq(schema.votes.proposalId, id)).run();
-      this.db
-        .delete(schema.proposalHosts)
+    this.db.transaction((tx) => {
+      tx.delete(schema.votes).where(eq(schema.votes.proposalId, id)).run();
+      tx.delete(schema.proposalHosts)
         .where(eq(schema.proposalHosts.proposalId, id))
         .run();
-      this.db
-        .delete(schema.sessionProposals)
+      tx.delete(schema.sessionProposals)
         .where(eq(schema.sessionProposals.id, id))
         .run();
     });

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -165,9 +165,8 @@ export class SqliteSessionsRepository implements SessionsRepository {
 
   async create(data: SessionCreateInput): Promise<Session> {
     const id = nanoid();
-    this.db.transaction(() => {
-      this.db
-        .insert(schema.sessions)
+    this.db.transaction((tx) => {
+      tx.insert(schema.sessions)
         .values({
           id,
           title: data.title,
@@ -184,14 +183,10 @@ export class SqliteSessionsRepository implements SessionsRepository {
         .run();
 
       for (const guestId of data.hostIds) {
-        this.db
-          .insert(schema.sessionHosts)
-          .values({ sessionId: id, guestId })
-          .run();
+        tx.insert(schema.sessionHosts).values({ sessionId: id, guestId }).run();
       }
       for (const locationId of data.locationIds) {
-        this.db
-          .insert(schema.sessionLocations)
+        tx.insert(schema.sessionLocations)
           .values({ sessionId: id, locationId })
           .run();
       }
@@ -200,7 +195,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
   }
 
   async update(id: string, patch: SessionUpdateInput): Promise<Session> {
-    this.db.transaction(() => {
+    this.db.transaction((tx) => {
       const values: Partial<typeof schema.sessions.$inferInsert> = {};
       if (patch.title !== undefined) values.title = patch.title;
       if (patch.description !== undefined)
@@ -218,34 +213,29 @@ export class SqliteSessionsRepository implements SessionsRepository {
       if ("eventId" in patch) values.eventId = patch.eventId ?? null;
 
       if (Object.keys(values).length > 0) {
-        this.db
-          .update(schema.sessions)
+        tx.update(schema.sessions)
           .set(values)
           .where(eq(schema.sessions.id, id))
           .run();
       }
 
       if (patch.hostIds !== undefined) {
-        this.db
-          .delete(schema.sessionHosts)
+        tx.delete(schema.sessionHosts)
           .where(eq(schema.sessionHosts.sessionId, id))
           .run();
         for (const guestId of patch.hostIds) {
-          this.db
-            .insert(schema.sessionHosts)
+          tx.insert(schema.sessionHosts)
             .values({ sessionId: id, guestId })
             .run();
         }
       }
 
       if (patch.locationIds !== undefined) {
-        this.db
-          .delete(schema.sessionLocations)
+        tx.delete(schema.sessionLocations)
           .where(eq(schema.sessionLocations.sessionId, id))
           .run();
         for (const locationId of patch.locationIds) {
-          this.db
-            .insert(schema.sessionLocations)
+          tx.insert(schema.sessionLocations)
             .values({ sessionId: id, locationId })
             .run();
         }
@@ -255,17 +245,15 @@ export class SqliteSessionsRepository implements SessionsRepository {
   }
 
   async delete(id: string): Promise<void> {
-    this.db.transaction(() => {
-      this.db.delete(schema.rsvps).where(eq(schema.rsvps.sessionId, id)).run();
-      this.db
-        .delete(schema.sessionHosts)
+    this.db.transaction((tx) => {
+      tx.delete(schema.rsvps).where(eq(schema.rsvps.sessionId, id)).run();
+      tx.delete(schema.sessionHosts)
         .where(eq(schema.sessionHosts.sessionId, id))
         .run();
-      this.db
-        .delete(schema.sessionLocations)
+      tx.delete(schema.sessionLocations)
         .where(eq(schema.sessionLocations.sessionId, id))
         .run();
-      this.db.delete(schema.sessions).where(eq(schema.sessions.id, id)).run();
+      tx.delete(schema.sessions).where(eq(schema.sessions.id, id)).run();
     });
   }
 }


### PR DESCRIPTION
https://orm.drizzle.team/docs/transactions
The documentation says to call methods on `tx` passed to the callback. I think methods on `db` work purely by accident,
but apparently they do work, so there should be no changes in behavior. Just a bit of stylistic consistency (there was one place which already used the correct pattern, `guests.ts`).