### PR TITLE
fix: session staleness for real this time, hopefully

### DIFF
--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -123,13 +123,47 @@ export function EventProvider({
   >;
 }) {
   const { user } = useContext(UserContext);
-  const valueSessions = value.days.flatMap((d) => d.sessions);
+  const serverSessions = value.days.flatMap((d) => d.sessions);
   // value.rsvps seeds the initial state once. The user-change effect below
   // is the only authoritative source of subsequent updates (plus optimistic
   // mutations in updateRsvp). Server-side revalidation is not used for RSVPs.
   const [rsvps, setRsvps] = useState<Rsvp[]>(value.rsvps);
-  // contains all optimistic updates
-  const [localSessions, setLocalSessions] = useState<Session[]>(valueSessions);
+  const [rsvpCountDeltas, setRsvpCountDeltas] = useState(
+    () => new Map<string, number>()
+  );
+
+  const localSessions = serverSessions.map((session) => {
+    const delta = rsvpCountDeltas.get(session.id) ?? 0;
+    if (delta === 0) return session;
+
+    return {
+      ...session,
+      numRsvps: session.numRsvps + delta,
+    };
+  });
+
+  useEffect(() => {
+    // Deltas are relative to serverSessions' numRsvps values. When value.days
+    // changes after an RSC refresh, the old deltas must be discarded so we don't
+    // double-count optimistic changes that are now included by the server.
+    //
+    // Do not reset rsvps here: value.rsvps is only the initial/RSC value, and
+    // may be older than the client-side user fetch or optimistic RSVP state.
+    //
+    // Tradeoffs of doing this in an effect:
+    // - React first renders fresh serverSessions with the previous deltas, then
+    //   this effect clears them, so there can be a transient wrong count.
+    // - Depending on value.days may reset more often than strictly necessary.
+    // - A failed RSVP request already in flight can still restore its old delta
+    //   snapshot after this reset. That race already exists in the optimistic
+    //   update flow; fixing it would require tracking a generation per request.
+    // The alternative is storing generation metadata with the deltas, which is
+    // more complex.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRsvpCountDeltas((current) =>
+      current.size === 0 ? current : new Map<string, number>()
+    );
+  }, [value.days]);
 
   // Fetch RSVPs when user changes
   useEffect(() => {
@@ -156,7 +190,7 @@ export function EventProvider({
   function userBusySessions() {
     if (user) {
       const sessionsWithRSVP = rsvps.map((r) => r.sessionId);
-      return valueSessions.filter(
+      return localSessions.filter(
         (ses) =>
           sessionsWithRSVP.includes(ses.id) ||
           ses.hosts.some((h) => h.id === user)
@@ -176,19 +210,21 @@ export function EventProvider({
     sessionId: string,
     remove: boolean
   ) => {
+    const rsvpsBeforeUpdate = rsvps;
+    const rsvpCountDeltasBeforeUpdate = rsvpCountDeltas;
     try {
       const countChange = remove ? -1 : 1;
-      const newSessions = localSessions.map((session) => {
-        if (session.id === sessionId) {
-          return {
-            ...session,
-            numRsvps: session.numRsvps + countChange,
-          };
+      setRsvpCountDeltas((old) => {
+        const res = new Map(old);
+        const delta = (res.get(sessionId) ?? 0) + countChange;
+        if (delta === 0) {
+          res.delete(sessionId);
         } else {
-          return session;
+          res.set(sessionId, delta);
         }
+        return res;
       });
-      setLocalSessions(newSessions);
+
       if (remove) {
         // Remove RSVP
         setRsvps((prevRsvps) =>
@@ -215,15 +251,15 @@ export function EventProvider({
 
       if (!response.ok) {
         // Revert optimistic update on failure
-        setRsvps(value.rsvps);
-        setLocalSessions(valueSessions);
+        setRsvps(rsvpsBeforeUpdate);
+        setRsvpCountDeltas(rsvpCountDeltasBeforeUpdate);
       }
       return response.ok;
     } catch (error: unknown) {
       // Revert optimistic update on error
       console.error("Error updating RSVP:", error);
-      setRsvps(value.rsvps);
-      setLocalSessions(valueSessions);
+      setRsvps(rsvpsBeforeUpdate);
+      setRsvpCountDeltas(rsvpCountDeltasBeforeUpdate);
       return false;
     }
   };

--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 
-test("a newly added session appears on the overview", async ({ page }) => {
+test("a newly added session appears on the overview and can be opened", async ({
+  page,
+}) => {
   await login(page);
 
   await page.goto("/Conference-Gamma");
@@ -46,5 +48,13 @@ test("a newly added session appears on the overview", async ({ page }) => {
   ).toBeVisible();
 
   // The new session must be visible WITHOUT reloading (see #253).
-  await expect(page.getByText(sessionTitle)).toBeVisible();
+  const newSessionLink = page.getByRole("link", { name: sessionTitle });
+  await expect(newSessionLink).toBeVisible();
+
+  // Opening the new session exercises the event-layout session data used by
+  // the details modal, not just the schedule card rendered from fresh props.
+  await newSessionLink.click();
+  const dialog = page.getByRole("dialog", { name: "Session details" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(sessionTitle, { exact: true })).toBeVisible();
 });


### PR DESCRIPTION
Change e14364409d invalidates local router cache on every session edit, so viewing the schedule after an edit will cause an RSC roundtrip and show up-to-date info.

However, `localSessions` in `EventContext` is still stale, since it's a regular `useState`. It's used when showing session data in the modal.
So reopening session modal after an edit will show old data, and clicking on a freshly added session will show "not found" instead of session details modal.

Trying to naively invalidate `localSessions` results in yet another yak shave.

`context.localSessions` duplicates RSVP-derived count state from `context.rsvps`. So any update to `rsvp` should be accompanied by an update to `localSessions`, which results in code duplication. Current implementation has bugs by the way: when "update RSVP" API call fails, it reverts `rsvps` and `localSessions` to the original RSC states. Changes to `rsvps` caused by switching the user, as well as by successful past "update RSVP" calls, are incorrectly discarded. And disregarding this issue, trying to touch (invalidate) `localSessions` without correspondingly changing `rsvps` will invite nasal demons.

Instead, this converts `localSessions` from state to a computed value (deliberately not memoized because the amount of computation is trivial). Computation logic lives in one place.
What do we need to derive it?
`valueSessions` (more appropriately named `serverSessions`), and what changed in `rsvps` since `serverSessions` arrived by RSC. But we don't keep track of what changed in `rsvps`! We only have the final state.

So this adds `rsvpCountDeltas` (map session -> Δ), which is updated on local RSVP changes and applied on top of `serverSessions`.

Important subtlety: `rsvpCountDeltas` should be reset when the server session baseline changes, i.e. when fresh `serverSessions` arrive from RSC. It should not be reset when `rsvps` are updated by the async fetch on user change, because that fetch only refreshes the current user's RSVP list, not the session RSVP count baseline. Resetting deltas there would discard optimistic/session-count changes made since the last RSC payload.

(By the way, this is still not entirely correct, because it assumes that `serverSessions` coming from RSC and `rsvps` coming from an async fetch are consistent; they are not necessarily consistent, but the old implementation already had this problem.)

Also, nobody knows what happens when a session is deleted while we have an optimistic RSVP to it, or any similar scenario. These problems are endemic to the current approach and fixing them is out of scope.

Now, since `localSessions` is derived from fresh `serverSessions`, it updates automatically after the RSC refresh, which should finish fixing #253. RSVP count deltas are reset when `value.days` changes, which is a simple proxy for receiving a new server session baseline. This can briefly render fresh server sessions with old deltas until the reset effect runs, but that seems acceptable for this fix.

Failed "update RSVP" calls now make snapshots of `rsvps` and `deltas` just before the call, and revert to those snapshots. Though this will be slightly incorrect in case of multiple in-flight requests.

As you can see, the system of optimistic RSVP updates is too complicated to contain obvious deficiencies.

On a serious note, I hate making a change this unprincipled. This is a case of technical debt begetting technical debt.

It would be nice to come up with a straightforwardly correct approach to optimistic RSVPs, but nothing comes to mind at the moment.
Until then, this keeps the existing approach limping along with maybe fewer stale-state bugs.
