### PR TITLE
fix: avoid sending private guest information to the client.

### DIFF
--- a/app/actions/admin-guests.ts
+++ b/app/actions/admin-guests.ts
@@ -35,7 +35,7 @@ export async function createGuestAction(input: {
     return { ok: false, error: "A user with this email already exists" };
   }
 
-  await guests.create({ name, email });
+  await guests.create({ name, info: { email } });
   revalidatePath("/admin/users");
   return { ok: true };
 }
@@ -58,7 +58,7 @@ export async function updateGuestAction(input: {
     return { ok: false, error: "A user with this email already exists" };
   }
 
-  const updated = await guests.update(input.id, { name, email });
+  const updated = await guests.update(input.id, { name, info: { email } });
   if (!updated) return { ok: false, error: "User not found" };
 
   revalidatePath("/admin/users");

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -24,14 +24,14 @@ export default async function AdminEventDetailPage({
   const event = await repos.events.findById(id);
   if (!event) notFound();
 
-  const allGuests = await repos.guests.list();
+  const allGuests = await repos.guests.listFull();
   const assignedGuestIds = new Set(
     (await repos.guests.listByEvent(id)).map((g) => g.id)
   );
   const guestRows: GuestRow[] = allGuests.map((g) => ({
     id: g.id,
     name: g.name,
-    email: g.email,
+    email: g.info.email,
     assigned: assignedGuestIds.has(g.id),
   }));
 

--- a/app/admin/guests-manager.tsx
+++ b/app/admin/guests-manager.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import clsx from "clsx";
 import { Input } from "@/app/input";
-import type { Guest } from "@/db/repositories/interfaces";
+import type { CompleteGuest } from "@/db/repositories/interfaces";
 import {
   createGuestAction,
   updateGuestAction,
@@ -75,17 +75,17 @@ function GuestRow({
   guest,
   onError,
 }: {
-  guest: Guest;
+  guest: CompleteGuest;
   onError: (error: string | null) => void;
 }) {
   const [mode, setMode] = useState<"view" | "edit" | "delete">("view");
   const [name, setName] = useState(guest.name);
-  const [email, setEmail] = useState(guest.email);
+  const [email, setEmail] = useState(guest.info.email);
   const [isPending, startTransition] = useTransition();
 
   const startEdit = () => {
     setName(guest.name);
-    setEmail(guest.email);
+    setEmail(guest.info.email);
     onError(null);
     setMode("edit");
   };
@@ -161,7 +161,7 @@ function GuestRow({
     <li className="py-3 flex flex-col sm:flex-row gap-2 sm:items-center">
       <div className="flex-1 min-w-0">
         <p className="font-medium text-gray-900 truncate">{guest.name}</p>
-        <p className="text-sm text-gray-500 truncate">{guest.email}</p>
+        <p className="text-sm text-gray-500 truncate">{guest.info.email}</p>
       </div>
       {mode === "delete" ? (
         <div className="flex gap-2 items-center">
@@ -204,7 +204,7 @@ function GuestRow({
   );
 }
 
-export function GuestsManager({ guests }: { guests: Guest[] }) {
+export function GuestsManager({ guests }: { guests: CompleteGuest[] }) {
   const [error, setError] = useState<string | null>(null);
 
   return (

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -6,7 +6,7 @@ export default async function AdminUsersPage() {
   await requireAdminPage();
 
   const repositories = getRepositories();
-  const guests = await repositories.guests.list();
+  const guests = await repositories.guests.listFull();
 
   return (
     <div className="w-full max-w-3xl mx-auto space-y-6">

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -66,19 +66,29 @@ export interface EventsRepository {
 
 // ── Guests ────────────────────────────────────────────────────────────────────
 
-export type Guest = {
-  id: string;
-  name: string;
+type GuestPrivateInfo = {
   email: string;
 };
 
+export type Guest<PI extends GuestPrivateInfo | void = void> = {
+  id: string;
+  name: string;
+  info: PI;
+};
+
+export type CompleteGuest = Guest<GuestPrivateInfo>;
+
 export interface GuestsRepository {
   list(): Promise<Guest[]>;
+  listFull(): Promise<CompleteGuest[]>;
   listByEvent(eventId: string): Promise<Guest[]>;
-  findById(id: string): Promise<Guest | undefined>;
-  findByEmail(email: string): Promise<Guest | undefined>;
-  create(data: Omit<Guest, "id">): Promise<Guest>;
-  update(id: string, data: Omit<Guest, "id">): Promise<Guest | undefined>;
+  findById(id: string): Promise<CompleteGuest | undefined>;
+  findByEmail(email: string): Promise<CompleteGuest | undefined>;
+  create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest>;
+  update(
+    id: string,
+    data: Omit<CompleteGuest, "id">
+  ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;
   assignToEvent(eventId: string, guestIds: string[]): Promise<void>;
@@ -134,7 +144,7 @@ export interface LocationsRepository {
 
 // ── Sessions ──────────────────────────────────────────────────────────────────
 
-export type SessionHost = Pick<Guest, "id" | "name" | "email">;
+export type SessionHost = Pick<Guest, "id" | "name">;
 export type SessionLocation = Pick<Location, "id" | "name" | "color">;
 
 export type Session = {
@@ -208,7 +218,7 @@ export interface RsvpsRepository {
 
 // ── Session Proposals ─────────────────────────────────────────────────────────
 
-export type ProposalHost = Pick<Guest, "id" | "name" | "email">;
+export type ProposalHost = Pick<Guest, "id" | "name">;
 
 export type SessionProposal = {
   id: string;

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -2,18 +2,23 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
-import type { Guest, GuestsRepository } from "../interfaces";
+import type { Guest, GuestsRepository, CompleteGuest } from "../interfaces";
+import { sanitizeGuest } from "@/utils/guests";
 
 type DB = BetterSQLite3Database<typeof schema>;
 
-function rowToGuest(row: typeof schema.guests.$inferSelect): Guest {
-  return { id: row.id, name: row.name, email: row.email };
+function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
+  return { id: row.id, name: row.name, info: { email: row.email } };
 }
 
 export class SqliteGuestsRepository implements GuestsRepository {
   constructor(private readonly db: DB) {}
 
   async list(): Promise<Guest[]> {
+    return (await this.listFull()).map(sanitizeGuest);
+  }
+
+  async listFull(): Promise<CompleteGuest[]> {
     return this.db.select().from(schema.guests).all().map(rowToGuest);
   }
 
@@ -22,7 +27,6 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .select({
         id: schema.guests.id,
         name: schema.guests.name,
-        email: schema.guests.email,
       })
       .from(schema.guests)
       .innerJoin(
@@ -30,11 +34,12 @@ export class SqliteGuestsRepository implements GuestsRepository {
         eq(schema.guests.id, schema.eventGuests.guestId)
       )
       .where(eq(schema.eventGuests.eventId, eventId))
-      .all();
+      .all()
+      .map((row) => row as Guest);
     return rows;
   }
 
-  async findById(id: string): Promise<Guest | undefined> {
+  async findById(id: string): Promise<CompleteGuest | undefined> {
     const row = this.db
       .select()
       .from(schema.guests)
@@ -43,7 +48,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return row ? rowToGuest(row) : undefined;
   }
 
-  async findByEmail(email: string): Promise<Guest | undefined> {
+  async findByEmail(email: string): Promise<CompleteGuest | undefined> {
     const row = this.db
       .select()
       .from(schema.guests)
@@ -52,22 +57,29 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return row ? rowToGuest(row) : undefined;
   }
 
-  async create(data: Omit<Guest, "id">): Promise<Guest> {
+  async create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest> {
     const id = nanoid();
-    this.db
-      .insert(schema.guests)
-      .values({ id, ...data })
-      .run();
+    const {
+      name,
+      info: { email },
+    } = data;
+
+    this.db.insert(schema.guests).values({ id, name, email }).run();
     return { id, ...data };
   }
 
   async update(
     id: string,
-    data: Omit<Guest, "id">
-  ): Promise<Guest | undefined> {
+    data: Omit<CompleteGuest, "id">
+  ): Promise<CompleteGuest | undefined> {
+    const {
+      name,
+      info: { email },
+    } = data;
+
     const result = this.db
       .update(schema.guests)
-      .set(data)
+      .set({ name, email })
       .where(eq(schema.guests.id, id))
       .run();
     if (result.changes === 0) return undefined;

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -26,7 +26,6 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
         proposalId: schema.proposalHosts.proposalId,
         id: schema.guests.id,
         name: schema.guests.name,
-        email: schema.guests.email,
       })
       .from(schema.proposalHosts)
       .innerJoin(
@@ -58,7 +57,7 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
     const hostsByProposal = new Map<string, ProposalHost[]>();
     for (const r of hostRows) {
       const list = hostsByProposal.get(r.proposalId) ?? [];
-      list.push({ id: r.id, name: r.name, email: r.email });
+      list.push({ id: r.id, name: r.name });
       hostsByProposal.set(r.proposalId, list);
     }
 

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -51,7 +51,6 @@ export class SqliteSessionsRepository implements SessionsRepository {
         sessionId: schema.sessionHosts.sessionId,
         id: schema.guests.id,
         name: schema.guests.name,
-        email: schema.guests.email,
       })
       .from(schema.sessionHosts)
       .innerJoin(
@@ -86,7 +85,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
     const hostsBySession = new Map<string, SessionHost[]>();
     for (const r of hostRows) {
       const list = hostsBySession.get(r.sessionId) ?? [];
-      list.push({ id: r.id, name: r.name, email: r.email });
+      list.push({ id: r.id, name: r.name });
       hostsBySession.set(r.sessionId, list);
     }
 

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -7,6 +7,7 @@ import type {
   Session,
   SessionProposal,
 } from "@/db/repositories/interfaces";
+import { sanitizeGuest } from "@/utils/guests";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -81,10 +82,12 @@ export async function createGuest(opts?: {
 }): Promise<Guest> {
   const { guests } = getRepositories();
   const unique = Date.now();
-  return guests.create({
-    name: opts?.name ?? `Test Guest ${unique}`,
-    email: opts?.email ?? `guest-${unique}@test.example`,
-  });
+  return guests
+    .create({
+      name: opts?.name ?? `Test Guest ${unique}`,
+      info: { email: opts?.email ?? `guest-${unique}@test.example` },
+    })
+    .then((guest) => guest && sanitizeGuest(guest));
 }
 
 export async function createLocation(opts?: {

--- a/tests/integration/admin-guests.test.ts
+++ b/tests/integration/admin-guests.test.ts
@@ -159,7 +159,7 @@ describe("admin guest actions", () => {
       const updated = await getRepositories().guests.findById(guest.id);
       expect(updated).toMatchObject({
         name: "New Name",
-        email: "new@test.example",
+        info: { email: "new@test.example" },
       });
     });
 

--- a/utils/guests.ts
+++ b/utils/guests.ts
@@ -1,0 +1,7 @@
+import type { Guest, CompleteGuest } from "@/db/repositories/interfaces";
+
+export function sanitizeGuest(guest: CompleteGuest): Guest {
+  const out = { ...guest, info: undefined };
+  delete out.info;
+  return out;
+}


### PR DESCRIPTION
The emails of the guests were leaked to the client on session proposals.

This implementation splits the Guest interface from the private guest information. The split is implemented in such a way that mixing an object with the full information of a guest and an object with the limited information (name and ID only) is impossible.

TODO:
1. ~run e2e tests~ ✅
2. further workflow testing

issue #52