### PR TITLE
fix: run DB migrations with foreign keys disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ clean-all: clean
 	rm -rf node_modules
 
 dev-migrate-up: install
-	bun set-env.ts dev bun x drizzle-kit migrate
+	bun set-env.ts dev bun x tsx scripts/migrate.ts
 
 dev-migrate-status: install
 	bun set-env.ts dev bun x drizzle-kit check

--- a/db/container.ts
+++ b/db/container.ts
@@ -58,7 +58,12 @@ export function getRepositories(): Repositories {
     _sqlite = new Database(url.replace(/^file:/, ""));
     const db = drizzle(_sqlite, { schema });
     const migrationsFolder = path.join(process.cwd(), "drizzle");
-    migrate(db, { migrationsFolder });
+    try {
+      _sqlite.pragma("foreign_keys = OFF");
+      migrate(db, { migrationsFolder });
+    } finally {
+      _sqlite.pragma("foreign_keys = ON");
+    }
     _repositories = buildRepositories(_sqlite);
   }
   return _repositories;

--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -20,9 +20,14 @@ function openDb() {
   const url = process.env.DATABASE_URL ?? "file:./data.db";
   const sqlite = new Database(url.replace(/^file:/, ""));
   const db = drizzle(sqlite, { schema });
-  migrate(db, {
-    migrationsFolder: path.join(__dirname, "../drizzle"),
-  });
+  try {
+    sqlite.pragma("foreign_keys = OFF");
+    migrate(db, {
+      migrationsFolder: path.join(__dirname, "../drizzle"),
+    });
+  } finally {
+    sqlite.pragma("foreign_keys = ON");
+  }
   return db;
 }
 

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,33 @@
+// Adds workaround for https://github.com/drizzle-team/drizzle-orm/issues/4089
+// It turns off foreign keys only for the duration of the migration - this is officially recommended
+
+import path from "path";
+import { fileURLToPath } from "url";
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+const dbUrl = process.env.DATABASE_URL ?? "file:./data.db";
+const sqlite = new Database(dbUrl.replace(/^file:/, ""));
+const db = drizzle(sqlite);
+
+const migrationsFolder = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../drizzle"
+);
+try {
+  console.log(`[migrate] running...`);
+  const start = Date.now();
+
+  sqlite.pragma("foreign_keys = OFF");
+  migrate(db, { migrationsFolder });
+
+  console.log(`[migrate] done in ${Date.now() - start}ms`);
+} catch (err) {
+  console.error(`[migrate] failed:`, err);
+  process.exitCode = 1;
+} finally {
+  sqlite.pragma("foreign_keys = ON");
+}
+sqlite.close();

--- a/tests/e2e/reset-database.ts
+++ b/tests/e2e/reset-database.ts
@@ -50,7 +50,13 @@ function openDb() {
     path.dirname(fileURLToPath(import.meta.url)),
     "../../drizzle"
   );
-  migrate(db, { migrationsFolder });
+  try {
+    // https://github.com/drizzle-team/drizzle-orm/issues/4089
+    sqlite.pragma("foreign_keys = OFF");
+    migrate(db, { migrationsFolder });
+  } finally {
+    sqlite.pragma("foreign_keys = ON");
+  }
   return db;
 }
 


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [cf8ee26](https://github.com/LWCW-Europe/schellingboard/pull/469/commits/cf8ee26718862a049a83e6855663b02cc57027be).

PRs:
* #471
* #470
* ➡️ #469 (this PR, base of the stack — can be merged first)

---

## Description

Drizzle's auto-generated SQLite migrations rebuild an entire table to
change a single column: create `__new_<table>`, copy rows, DROP the old
table, then rename. When the rebuilt table is referenced by foreign keys
from other tables (e.g. session_proposals <- proposal_hosts/sessions/
votes), the DROP TABLE performs an implicit row delete that violates
those FKs and the whole migration aborts with SQLITE_CONSTRAINT_FOREIGNKEY.

Drizzle wraps the migration -- including its own `PRAGMA foreign_keys=OFF`
-- in a single transaction. But that PRAGMA is a silent no-op inside a
transaction, so FK enforcement is never actually turned off. SQLite
requires toggling foreign_keys *outside* the transaction
(https://www.sqlite.org/lang_altertable.html#otheralter).

Fix: disable foreign_keys on the connection before calling migrate() and
re-enable it in a finally, everywhere we migrate:
- scripts/migrate.ts (new) -- `make dev-migrate-up` now runs this instead
  of `drizzle-kit migrate`, which offered no hook to set the pragma first
- tests/e2e/reset-database.ts (`make dev-db-reset`)
- db/container.ts (app runtime)
- scripts/admin.ts

See also:
- https://github.com/drizzle-team/drizzle-orm/issues/1813
- https://github.com/drizzle-team/drizzle-orm/issues/4089
- https://github.com/drizzle-team/drizzle-orm/issues/5782

issue #468

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).
