### PR TITLE
feat: Make eventId fields non-nullable to match our data

### DIFF
--- a/app/(site)/[eventSlug]/location-col.tsx
+++ b/app/(site)/[eventSlug]/location-col.tsx
@@ -12,7 +12,7 @@ export function LocationCol(props: {
   guests: Guest[];
 }) {
   const { eventName, sessions, location, day, guests } = props;
-  const sessionsWithBlanks = insertBlankSessions(sessions, day.start, day.end);
+  const sessionsWithBlanks = insertBlankSessions(sessions, day);
   const numHalfHours = getNumHalfHours(day.start, day.end);
   return (
     <div className={"px-0.5"}>
@@ -41,13 +41,12 @@ export function LocationCol(props: {
 
 function insertBlankSessions(
   sessions: Session[],
-  dayStart: Date,
-  dayEnd: Date
+  day: DayWithSessions
 ): Session[] {
   const sessionsWithBlanks: Session[] = [];
   for (
-    let currentTime = dayStart.getTime();
-    currentTime < dayEnd.getTime();
+    let currentTime = day.start.getTime();
+    currentTime < day.end.getTime();
     currentTime += 1800000
   ) {
     const sessionNow = sessions.find((session) => {
@@ -75,6 +74,7 @@ function insertBlankSessions(
         attendeeScheduled: false,
         blocker: false,
         closed: false,
+        eventId: day.eventId,
       });
     }
   }

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -37,7 +37,7 @@ export async function renderSessionForm(props: {
     <Suspense fallback={<div>Loading...</div>}>
       <div className="max-w-2xl mx-auto pb-24">
         <SessionForm
-          eventName={eventName}
+          event={event}
           days={days}
           locations={filteredLocations}
           sessions={sessions}

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -23,6 +23,7 @@ import { MyListbox, type Option } from "./select";
 import { viewProposalLinkFromElsewhere } from "./modal-nav";
 import type {
   Day,
+  Event,
   Guest,
   Location,
   Session,
@@ -30,7 +31,7 @@ import type {
   SessionProposal,
 } from "@/db/repositories/interfaces";
 import { ConfirmDeletionModal } from "../modals";
-import { UserContext, EventContext } from "../context";
+import { UserContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { buildSessionInterval } from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
@@ -40,7 +41,7 @@ interface ErrorResponse {
 }
 
 export function SessionForm(props: {
-  eventName: string;
+  event: Event;
   days: Day[];
   sessions: Session[];
   locations: Location[];
@@ -49,7 +50,7 @@ export function SessionForm(props: {
   maxSessionDuration: number;
 }) {
   const {
-    eventName,
+    event,
     days,
     sessions,
     locations,
@@ -58,8 +59,8 @@ export function SessionForm(props: {
     maxSessionDuration,
   } = props;
   const { user: currentUser } = useContext(UserContext);
-  const { event } = useContext(EventContext);
-  const timezone = event?.timezone ?? "UTC";
+  const eventName = event.name;
+  const timezone = event.timezone ?? "UTC";
 
   const searchParams = useSearchParams();
   const dayParam = searchParams?.get("day");
@@ -69,7 +70,7 @@ export function SessionForm(props: {
   const proposalID = searchParams?.get("proposalID");
   const initialProposal = proposals.find((p) => p.id === proposalID) ?? null;
   const session =
-    sessions.find((ses) => ses.id === sessionID) || newEmptySession();
+    sessions.find((ses) => ses.id === sessionID) || newEmptySession(event.id);
   const initDateTime =
     dayParam && timeParam
       ? convertParamDateTime(dayParam, timeParam, timezone)
@@ -169,7 +170,7 @@ export function SessionForm(props: {
     }
   }
 
-  let dummySession = newEmptySession();
+  let dummySession = newEmptySession(event.id);
   if (effectiveStartTime !== undefined && day) {
     const { start, end } = buildSessionInterval(
       day,
@@ -178,7 +179,7 @@ export function SessionForm(props: {
       timezone
     );
     dummySession = {
-      ...newEmptySession(),
+      ...newEmptySession(event.id),
       startTime: start,
       endTime: end,
       id: sessionID || "",

--- a/app/(site)/session_utils.ts
+++ b/app/(site)/session_utils.ts
@@ -1,6 +1,6 @@
 import type { Session } from "@/db/repositories/interfaces";
 
-export function newEmptySession(): Session {
+export function newEmptySession(eventId: string): Session {
   return {
     id: "",
     title: "",
@@ -15,7 +15,7 @@ export function newEmptySession(): Session {
     blocker: false,
     closed: false,
     proposalId: undefined,
-    eventId: undefined,
+    eventId,
   };
 }
 

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -9,7 +9,7 @@ export async function POST(req: Request) {
   const repos = getRepositories();
   const input = prepareToInsert(params);
   const existingSessions = (await repos.sessions.listScheduled()).filter(
-    (s) => !input.eventId || s.eventId === input.eventId
+    (s) => s.eventId === input.eventId
   );
   const sessionValid = validateSession(input, existingSessions);
   if (sessionValid) {

--- a/app/api/session-form-utils.ts
+++ b/app/api/session-form-utils.ts
@@ -66,7 +66,7 @@ export function prepareToInsert(params: SessionParams): SessionCreateInput {
     duration,
     params.timezone
   );
-  const input: SessionCreateInput = {
+  return {
     title,
     description,
     closed,
@@ -78,11 +78,8 @@ export function prepareToInsert(params: SessionParams): SessionCreateInput {
     attendeeScheduled: true,
     blocker: false,
     proposalId: params.proposal ?? undefined,
+    eventId: day.eventId,
   };
-  if (day.eventId) {
-    input.eventId = day.eventId;
-  }
-  return input;
 }
 
 export const validateSession = (

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
   const repos = getRepositories();
   const input = prepareToInsert(params);
   const allSessions = (await repos.sessions.listScheduled()).filter(
-    (s) => !input.eventId || s.eventId === input.eventId
+    (s) => s.eventId === input.eventId
   );
   const prevSession = allSessions.find((ses) => ses.id === params.id);
   if (prevSession === undefined) {

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -14,7 +14,7 @@ export type Day = {
   end: Date;
   startBookings: Date;
   endBookings: Date;
-  eventId?: string;
+  eventId: string;
 };
 
 export interface DaysRepository {
@@ -125,7 +125,7 @@ export type Session = {
   blocker: boolean;
   closed: boolean;
   proposalId?: string;
-  eventId?: string;
+  eventId: string;
   hosts: SessionHost[];
   locations: SessionLocation[];
   numRsvps: number;
@@ -141,7 +141,7 @@ export type SessionCreateInput = {
   blocker: boolean;
   closed: boolean;
   proposalId?: string;
-  eventId?: string;
+  eventId: string;
   hostIds: string[];
   locationIds: string[];
 };

--- a/db/repositories/sqlite/days.ts
+++ b/db/repositories/sqlite/days.ts
@@ -13,7 +13,7 @@ function rowToDay(row: typeof schema.days.$inferSelect): Day {
     end: new Date(row.end),
     startBookings: new Date(row.startBookings),
     endBookings: new Date(row.endBookings),
-    eventId: row.eventId ?? undefined,
+    eventId: row.eventId,
   };
 }
 
@@ -57,7 +57,7 @@ export class SqliteDaysRepository implements DaysRepository {
         end: data.end.toISOString(),
         startBookings: data.startBookings.toISOString(),
         endBookings: data.endBookings.toISOString(),
-        eventId: data.eventId ?? null,
+        eventId: data.eventId,
       })
       .run();
     return { id, ...data };

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -31,7 +31,7 @@ function buildSessions(
     blocker: row.blocker,
     closed: row.closed,
     proposalId: row.proposalId ?? undefined,
-    eventId: row.eventId ?? undefined,
+    eventId: row.eventId,
     hosts: hostsBySession.get(row.id) ?? [],
     locations: locationsBySession.get(row.id) ?? [],
     numRsvps: rsvpCountBySession.get(row.id) ?? 0,
@@ -178,7 +178,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
           blocker: data.blocker,
           closed: data.closed,
           proposalId: data.proposalId ?? null,
-          eventId: data.eventId ?? null,
+          eventId: data.eventId,
         })
         .run();
 
@@ -210,7 +210,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
       if (patch.blocker !== undefined) values.blocker = patch.blocker;
       if (patch.closed !== undefined) values.closed = patch.closed;
       if ("proposalId" in patch) values.proposalId = patch.proposalId ?? null;
-      if ("eventId" in patch) values.eventId = patch.eventId ?? null;
+      if (patch.eventId !== undefined) values.eventId = patch.eventId;
 
       if (Object.keys(values).length > 0) {
         tx.update(schema.sessions)

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -74,7 +74,9 @@ export const days = sqliteTable("days", {
   end: text("end").notNull(),
   startBookings: text("start_bookings").notNull(),
   endBookings: text("end_bookings").notNull(),
-  eventId: text("event_id").references(() => events.id),
+  eventId: text("event_id")
+    .notNull()
+    .references(() => events.id),
 });
 
 export const sessionProposals = sqliteTable("session_proposals", {
@@ -116,7 +118,9 @@ export const sessions = sqliteTable("sessions", {
   blocker: integer("blocker", { mode: "boolean" }).notNull().default(false),
   closed: integer("closed", { mode: "boolean" }).notNull().default(false),
   proposalId: text("proposal_id").references(() => sessionProposals.id),
-  eventId: text("event_id").references(() => events.id),
+  eventId: text("event_id")
+    .notNull()
+    .references(() => events.id),
 });
 
 export const sessionHosts = sqliteTable(

--- a/drizzle/0004_curious_richard_fisk.sql
+++ b/drizzle/0004_curious_richard_fisk.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_days` (
+	`id` text PRIMARY KEY NOT NULL,
+	`start` text NOT NULL,
+	`end` text NOT NULL,
+	`start_bookings` text NOT NULL,
+	`end_bookings` text NOT NULL,
+	`event_id` text NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_days`("id", "start", "end", "start_bookings", "end_bookings", "event_id") SELECT "id", "start", "end", "start_bookings", "end_bookings", "event_id" FROM `days`;--> statement-breakpoint
+DROP TABLE `days`;--> statement-breakpoint
+ALTER TABLE `__new_days` RENAME TO `days`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`start_time` text,
+	`end_time` text,
+	`capacity` integer DEFAULT 0 NOT NULL,
+	`attendee_scheduled` integer DEFAULT false NOT NULL,
+	`blocker` integer DEFAULT false NOT NULL,
+	`closed` integer DEFAULT false NOT NULL,
+	`proposal_id` text,
+	`event_id` text NOT NULL,
+	FOREIGN KEY (`proposal_id`) REFERENCES `session_proposals`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_sessions`("id", "title", "description", "start_time", "end_time", "capacity", "attendee_scheduled", "blocker", "closed", "proposal_id", "event_id") SELECT "id", "title", "description", "start_time", "end_time", "capacity", "attendee_scheduled", "blocker", "closed", "proposal_id", "event_id" FROM `sessions`;--> statement-breakpoint
+DROP TABLE `sessions`;--> statement-breakpoint
+ALTER TABLE `__new_sessions` RENAME TO `sessions`;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,837 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1b51c98c-d0b2-448b-87d7-c89c52514d9f",
+  "prevId": "80ef0503-adad-4e64-88c4-be038cd5fe0b",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attendee_scheduled": {
+          "name": "attendee_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777369604281,
       "tag": "0003_curious_nemesis",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1782260306200,
+      "tag": "0004_curious_richard_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/session-overlap.test.ts
+++ b/tests/unit/session-overlap.test.ts
@@ -16,6 +16,7 @@ function makeSession(id: string, start?: Date, end?: Date): Session {
     numRsvps: 0,
     startTime: start,
     endTime: end,
+    eventId: "111",
   };
 }
 

--- a/tests/unit/session-validation.test.ts
+++ b/tests/unit/session-validation.test.ts
@@ -22,6 +22,7 @@ function makeInput(
     locationIds: [LOC_A],
     startTime: fromNow(60),
     endTime: fromNow(120),
+    eventId: "111",
     ...overrides,
   };
 }
@@ -44,6 +45,7 @@ function makeExisting(
     numRsvps: 0,
     startTime: start,
     endTime: end,
+    eventId: "111",
   };
 }
 

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -75,6 +75,7 @@ const DAY: Day = {
   end: new Date("2025-06-15T18:00:00Z"),
   startBookings: new Date("2025-06-15T09:00:00Z"),
   endBookings: new Date("2025-06-15T17:00:00Z"),
+  eventId: "111",
 };
 
 describe("dateOnDay", () => {
@@ -149,6 +150,7 @@ function makeSession(startTime: Date, endTime: Date): Session {
     numRsvps: 0,
     startTime,
     endTime,
+    eventId: "111",
   };
 }
 


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [0a8cbab](https://github.com/LWCW-Europe/schellingboard/pull/470/commits/0a8cbab7ae56a58f65f400e7a6edbaa69480a609).

PRs:
* #471
* ➡️ #470 (this PR, base of the stack — can be merged first)

---

## Description

Make Session and Day .eventId fields non-nullable in the schema and in the
types, because they are never null in our data, and we have a bunch of null
handling which only gets in the way.

closes #459

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).
