### PR TITLE
feat: Add editable user profiles with avatars

### DIFF
--- a/app/(site)/[eventSlug]/proposal.tsx
+++ b/app/(site)/[eventSlug]/proposal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import type { SessionProposal } from "@/db/repositories/interfaces";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 import { useBreakMinutes } from "@/app/(site)/context";
@@ -11,7 +12,17 @@ export function Proposal(props: { proposal: SessionProposal }) {
     <>
       <h1 className="text-xl font-semibold mb-2 mt-5">{proposal.title}</h1>
       <p className="text-lg font-medium text-gray-700 mb-4">
-        {proposal.hosts.map((h) => h.name).join(", ")}
+        {proposal.hosts.map((h, i) => (
+          <span key={h.id}>
+            {i > 0 && ", "}
+            <Link
+              href={`/guests/${h.id}`}
+              className="text-rose-500 hover:text-rose-600 hover:underline"
+            >
+              {h.name}
+            </Link>
+          </span>
+        ))}
       </p>
       <p className="mb-3 whitespace-pre-line">{proposal.description}</p>
       {proposal.durationMinutes && (

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -498,7 +498,19 @@ export function ProposalTable({
                 </td>
                 <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                   <div className="truncate">
-                    {proposal.hosts.map((h) => h.name).join(", ") || "-"}
+                    {proposal.hosts.length === 0
+                      ? "-"
+                      : proposal.hosts.map((h, i) => (
+                          <span key={h.id}>
+                            {i > 0 && ", "}
+                            <Link
+                              href={`/guests/${h.id}`}
+                              className="hover:text-blue-600 transition-colors"
+                            >
+                              {h.name}
+                            </Link>
+                          </span>
+                        ))}
                   </div>
                 </td>
                 <td className="px-4 lg:px-6 py-4" title={proposal.description}>

--- a/app/(site)/[eventSlug]/session-text.tsx
+++ b/app/(site)/[eventSlug]/session-text.tsx
@@ -22,8 +22,6 @@ export function SessionText(props: {
   const timezone = event?.timezone ?? "UTC";
   const breakMinutes = useBreakMinutes();
   const [showFullDescription, setShowFullDescription] = useState(false);
-  const formattedHostNames =
-    session.hosts.map((h) => h.name).join(", ") || "No hosts";
 
   const rsvpd = currentUser ? rsvpdForSession(session.id) : false;
   const isHost = currentUser && session.hosts.some((h) => h.id === currentUser);
@@ -91,7 +89,24 @@ export function SessionText(props: {
                 .toFormat(TIME_FORMAT)}
             </span>
           </div>
-          •<span>{formattedHostNames}</span>
+          •
+          {session.hosts.length === 0 ? (
+            <span>No hosts</span>
+          ) : (
+            <span>
+              {session.hosts.map((h, i) => (
+                <span key={h.id}>
+                  {i > 0 && ", "}
+                  <Link
+                    href={`/guests/${h.id}`}
+                    className="hover:text-blue-600 transition-colors"
+                  >
+                    {h.name}
+                  </Link>
+                </span>
+              ))}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-1">
           {locations.map((loc) => (

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -70,14 +70,13 @@ export function ViewSession(props: {
   const isHost = currentUser && session.hosts.some((h) => h.id === currentUser);
   const isEditable = !!isHost && session.attendeeScheduled;
 
-  const guestMap = new Map(guests.map((guest) => [guest.id, guest.name]));
-  const attendeeNames =
+  const guestMap = new Map(guests.map((guest) => [guest.id, guest]));
+  const attendees =
     optimisticRsvps === null
       ? null
       : optimisticRsvps
-          .map((rsvp) => guestMap.get(rsvp.guestId))
-          .filter((name): name is string => name !== undefined)
-          .sort();
+          .flatMap((rsvp) => guestMap.get(rsvp.guestId) ?? [])
+          .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   const location = locations.find((loc) => loc.id === session.locations[0]?.id);
 
@@ -239,7 +238,19 @@ export function ViewSession(props: {
       <div className="space-y-2 mb-6 text-sm text-gray-700">
         <div className="flex gap-2">
           <span className="font-medium">Hosts(s):</span>
-          <span>{hostNames}</span>
+          <span>
+            {session.hosts.map((h, i) => (
+              <span key={h.id}>
+                {i > 0 && ", "}
+                <Link
+                  href={`/guests/${h.id}`}
+                  className="text-rose-500 hover:text-rose-600 hover:underline"
+                >
+                  {h.name}
+                </Link>
+              </span>
+            ))}
+          </span>
         </div>
         <div className="flex gap-2">
           <span className="font-medium">Location:</span>
@@ -260,7 +271,7 @@ export function ViewSession(props: {
         <div className="flex gap-2">
           <span className="font-medium">
             Attendees (
-            {attendeeNames === null ? session.numRsvps : attendeeNames.length}):
+            {attendees === null ? session.numRsvps : attendees.length}):
           </span>
           {/* TODO: If the list of attendees spans multiple lines, the layout will jump on load.
           Ideas:
@@ -268,11 +279,21 @@ export function ViewSession(props: {
           - include ALL RSVPs in the preloaded EventContext, so that we don't need to fetch them later at all
           */}
           <span>
-            {attendeeNames === null
+            {attendees === null
               ? "Loading…"
-              : attendeeNames.length === 0
+              : attendees.length === 0
                 ? "No attendees yet"
-                : attendeeNames.join(", ")}
+                : attendees.map((a, i) => (
+                    <span key={a.id}>
+                      {i > 0 && ", "}
+                      <Link
+                        href={`/guests/${a.id}`}
+                        className="text-rose-500 hover:text-rose-600 hover:underline"
+                      >
+                        {a.name}
+                      </Link>
+                    </span>
+                  ))}
           </span>
         </div>
       </div>

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { eventNameToSlug } from "@/utils/utils";
+import { sanitizeGuest } from "@/utils/guests";
+import { Avatar } from "../avatar";
+import { JSX, PropsWithChildren } from "react";
+import {
+  ProfileItem,
+  ProposalLink,
+  SessionLink,
+} from "@/app/(site)/guests/[guestId]/profile-link";
+
+export default async function GuestProfilePage(props: {
+  params: Promise<{ guestId: string }>;
+}) {
+  const { guestId } = await props.params;
+  const repos = getRepositories();
+
+  const [completeGuest, hostedSessions, proposals, rsvpdSessions, events] =
+    await Promise.all([
+      repos.guests.findById(guestId),
+      repos.sessions.listHostedByGuest(guestId),
+      repos.sessionProposals.listByHost(guestId),
+      repos.sessions.listRsvpdByGuest(guestId),
+      repos.events.list(),
+    ]);
+
+  if (!completeGuest) {
+    return <p className="text-gray-600">Profile not found.</p>;
+  }
+
+  // This is a public profile; never expose private info (email) here.
+  const guest = sanitizeGuest(completeGuest);
+
+  const eventIdToSlug = (eventId: string) =>
+    eventNameToSlug(events.find((e) => e.id === eventId)!.name);
+
+  const cookieStore = await cookies();
+  const isOwnProfile = cookieStore.get("user")?.value === guestId;
+  const isSessionHost = hostedSessions.length > 0;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-8">
+      <div className="flex items-center justify-between gap-4">
+        <Link
+          href="/guests"
+          className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+        >
+          Back to attendees
+        </Link>
+        {isOwnProfile && (
+          <Link
+            href="/guests/edit"
+            className="text-sm font-semibold text-rose-500 hover:text-rose-600"
+          >
+            Edit profile
+          </Link>
+        )}
+      </div>
+
+      <header className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <Avatar name={guest.name} image={guest.avatarUrl ?? undefined} />
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">{guest.name}</h1>
+          {isSessionHost && (
+            <span className="w-fit rounded-full bg-rose-100 text-rose-700 text-xs font-semibold px-3 py-1">
+              Session host
+            </span>
+          )}
+        </div>
+      </header>
+
+      {guest.aboutMe && (
+        <section>
+          <h2 className="text-lg font-semibold mb-2">About me</h2>
+          <p className="whitespace-pre-line text-gray-800">{guest.aboutMe}</p>
+        </section>
+      )}
+
+      <ProfileList
+        title="Hosting"
+        items={hostedSessions.map((s) => ({
+          key: s.id,
+          label: s.title,
+          item: { eventSlug: eventIdToSlug(s.eventId), id: s.id },
+        }))}
+        LinkType={SessionLink}
+      />
+
+      <ProfileList
+        title="Proposals"
+        items={proposals.map((p) => ({
+          key: p.id,
+          label: p.title,
+          item: { eventSlug: eventIdToSlug(p.eventId), id: p.id },
+        }))}
+        LinkType={ProposalLink}
+      />
+
+      <ProfileList
+        title="Going to"
+        items={rsvpdSessions.map((s) => ({
+          key: s.id,
+          label: s.title,
+          item: { eventSlug: eventIdToSlug(s.eventId), id: s.id },
+        }))}
+        LinkType={ProposalLink}
+      />
+    </div>
+  );
+}
+
+function ProfileList({
+  title,
+  items,
+  LinkType,
+}: {
+  title: string;
+  items: { key: string; label: string; item?: ProfileItem }[];
+  LinkType: (props: PropsWithChildren<ProfileItem>) => JSX.Element;
+}) {
+  if (items.length === 0) return null;
+  else
+    return (
+      <section>
+        <h2 className="text-lg font-semibold mb-2">{title}</h2>
+        <ul className="flex flex-col gap-1">
+          {items.map((item) => (
+            <li key={item.key}>
+              {item.item ? (
+                <LinkType {...item.item}>{item.label}</LinkType>
+              ) : (
+                <span className="text-gray-800">{item.label}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    );
+}

--- a/app/(site)/guests/[guestId]/profile-link.tsx
+++ b/app/(site)/guests/[guestId]/profile-link.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { PropsWithChildren } from "react";
+import Link, { LinkProps } from "next/link";
+import {
+  viewProposalLinkFromElsewhere,
+  viewSessionLinkFromElsewhere,
+} from "@/app/(site)/[eventSlug]/modal-nav";
+
+export type ProfileItem = {
+  eventSlug: string;
+  id: string;
+};
+
+function ProfileItemLink({
+  props,
+  children,
+}: PropsWithChildren<{ props: LinkProps }>) {
+  return (
+    <Link
+      {...props}
+      className="text-rose-500 hover:text-rose-600 hover:underline"
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function SessionLink({
+  eventSlug,
+  id,
+  children,
+}: PropsWithChildren<ProfileItem>) {
+  return (
+    <ProfileItemLink props={viewSessionLinkFromElsewhere(eventSlug, id)}>
+      {children}
+    </ProfileItemLink>
+  );
+}
+
+export function ProposalLink({
+  eventSlug,
+  id,
+  children,
+}: PropsWithChildren<ProfileItem>) {
+  return (
+    <ProfileItemLink props={viewProposalLinkFromElsewhere(eventSlug, id)}>
+      {children}
+    </ProfileItemLink>
+  );
+}

--- a/app/(site)/guests/avatar.tsx
+++ b/app/(site)/guests/avatar.tsx
@@ -1,0 +1,59 @@
+import clsx from "clsx";
+import { DragEventHandler, MouseEventHandler } from "react";
+import Image from "next/image";
+
+function initials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/**
+ * Renders the user-uploaded avatar image or a placeholder avatar showing
+ * the guest's initials as a fallback.
+ */
+export function Avatar({
+  className,
+  name,
+  size = "lg",
+  image,
+  onDrop,
+  onClick,
+}: {
+  className?: string;
+  name: string;
+  size?: "lg" | "sm";
+  image?: string;
+  onDrop?: DragEventHandler<HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+}) {
+  const dimensions = size === "lg" ? "h-28 w-28 text-3xl" : "h-12 w-12 text-sm";
+
+  return (
+    <div
+      aria-hidden="true"
+      className={clsx(
+        className,
+        dimensions,
+        "shrink-0 rounded-full bg-rose-100 text-rose-600 font-semibold flex items-center justify-center overflow-hidden"
+      )}
+      onClick={onClick}
+      onDrop={onDrop}
+    >
+      {image ? (
+        <Image
+          className="w-full h-full object-cover"
+          src={image}
+          alt={`Profile avatar of ${name}`}
+          width="256"
+          height="256"
+        />
+      ) : (
+        initials(name) || "?"
+      )}
+    </div>
+  );
+}

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { sanitizeGuest } from "@/utils/guests";
+import { ProfileForm } from "./profile-form";
+
+export default async function EditProfilePage() {
+  const cookieStore = await cookies();
+  const currentUser = cookieStore.get("user")?.value;
+
+  if (!currentUser) {
+    return (
+      <div className="max-w-2xl mx-auto flex flex-col gap-4">
+        <p className="text-gray-700">
+          You need to select who you are before editing your profile. Pick your
+          name from the &ldquo;My name is&rdquo; selector on the proposals or
+          schedule page.
+        </p>
+        <Link
+          href="/guests"
+          className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+        >
+          Back to attendees
+        </Link>
+      </div>
+    );
+  }
+
+  const guest = await getRepositories().guests.findById(currentUser);
+
+  if (!guest) {
+    return (
+      <p className="text-gray-600">Profile not found, please log in again.</p>
+    );
+  }
+
+  // Strip private info (email) before handing the guest to a client component.
+  return <ProfileForm guest={sanitizeGuest(guest)} />;
+}

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import {
+  useState,
+  type SyntheticEvent,
+  useRef,
+  useEffect,
+  useMemo,
+  ButtonHTMLAttributes,
+} from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { Input } from "@/app/input";
+import { updateProfileAction } from "@/app/actions/profile";
+import { Avatar } from "../avatar";
+import type { Guest } from "@/db/repositories/interfaces";
+import { resizeImage } from "@/utils/images-client";
+import clsx from "clsx";
+
+export function ProfileForm({ guest }: { guest: Guest }) {
+  const router = useRouter();
+  const [name, setName] = useState(guest.name);
+  const [aboutMe, setAboutMe] = useState(guest.aboutMe ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [avatar, setAvatar] = useState<File | null | undefined>();
+  const [isDragging, setIsDragging] = useState(false);
+  const canvas = useRef<HTMLCanvasElement | null>(null);
+
+  const avatarUrl = useMemo(
+    () => avatar && URL.createObjectURL(avatar),
+    [avatar]
+  );
+
+  useEffect(
+    () => () => {
+      if (avatarUrl) URL.revokeObjectURL(avatarUrl);
+    },
+    [avatarUrl]
+  );
+
+  const resize = async (file: File, maxSize: number) => {
+    return canvas.current
+      ? await resizeImage(canvas.current, file, maxSize)
+      : { blob: file };
+  };
+
+  const handleSubmit = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    const formData = new FormData();
+    formData.append("name", name);
+    formData.append("aboutMe", aboutMe);
+
+    try {
+      if (avatar === null) {
+        formData.append("avatar", "");
+      } else if (avatar) {
+        const resized = await resize(avatar, 256);
+        if ("error" in resized) {
+          setError(resized.error);
+          return;
+        }
+
+        formData.append("avatar", resized.blob);
+      }
+
+      const result = await updateProfileAction(formData);
+      if (!result.ok) {
+        setError(result.error);
+      } else {
+        router.push(`/guests/${guest.id}`);
+        router.refresh();
+      }
+    } catch (err) {
+      setError("An unexpected error occurred");
+      console.error(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const avatarAreaController: ButtonHTMLAttributes<HTMLButtonElement> = useMemo(
+    () => ({
+      onDrop(e) {
+        e.preventDefault();
+        setAvatar(e.dataTransfer.files?.item(0) ?? null);
+        setIsDragging(false);
+      },
+      onDragOver: function (e) {
+        e.preventDefault();
+        setIsDragging(true);
+      },
+      onDragLeave(e) {
+        e.preventDefault();
+        setIsDragging(false);
+      },
+      onClick() {
+        fileInput.current?.click();
+      },
+    }),
+    [fileInput]
+  );
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-4">
+      <Link
+        href="/guests"
+        className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+      >
+        Back to attendees
+      </Link>
+      <h1 className="text-2xl font-bold">Edit profile</h1>
+
+      <canvas ref={canvas} hidden />
+
+      <form
+        onSubmit={(e) => void handleSubmit(e)}
+        className="flex flex-col gap-4"
+      >
+        <div className="flex items-center gap-4 cursor-pointer">
+          <button
+            className={clsx(
+              "flex items-center gap-4 cursor-pointer pe-4 border-solid border-e",
+              "hover:text-rose-500 active:text-rose-600 drop:boder-rose-400",
+              "transition-outline duration-200 ease-in-out outline-gray-500 outline-dashed outline-0",
+              isDragging
+                ? "cursor-grabbing outline-4 rounded-full border-transparent"
+                : "border-gray-500"
+            )}
+            type="button"
+            {...avatarAreaController}
+          >
+            <Avatar
+              name={name}
+              size="sm"
+              image={
+                avatarUrl === null
+                  ? undefined
+                  : avatarUrl
+                    ? avatarUrl
+                    : guest.avatarUrl
+                      ? guest.avatarUrl
+                      : undefined
+              }
+            />
+            <label htmlFor={`${guest.id}-image`}>Change profile picture</label>
+          </button>
+          <button
+            type="button"
+            className="text-rose-400 hover:text-rose-500 active:text-rose-600 cursor-pointer"
+            onClick={() => setAvatar(null)}
+          >
+            Reset
+          </button>
+          <input
+            id={`${guest.id}-image`}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            ref={fileInput}
+            hidden
+            onChange={(e) => setAvatar(e.target.files?.item(0) ?? null)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="font-medium" htmlFor="profile-name">
+            Name
+            <span className="text-rose-500 mx-1">*</span>
+          </label>
+          <Input
+            id="profile-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="Your name"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="font-medium" htmlFor="profile-about-me">
+            About me
+          </label>
+          <textarea
+            id="profile-about-me"
+            value={aboutMe}
+            onChange={(e) => setAboutMe(e.target.value)}
+            placeholder="Tell others about yourself"
+            className="rounded-md text-sm resize-y h-40 border bg-white px-4 py-2 shadow-sm transition-colors focus:outline-none border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none"
+          />
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+            <p className="text-sm font-medium">Error: {error}</p>
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className="bg-rose-400 text-white font-semibold py-2 rounded shadow disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500 mx-auto px-12"
+          disabled={!name || isSubmitting}
+        >
+          {isSubmitting ? "Saving..." : "Save"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/(site)/guests/page.tsx
+++ b/app/(site)/guests/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getRepositories } from "@/db/container";
+import { Avatar } from "./avatar";
+import { cookies } from "next/headers";
+
+export default async function GuestsPage() {
+  const guests = await getRepositories().guests.list();
+  guests.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  const cookieStore = await cookies();
+  const currentUser = cookieStore.get("user")?.value;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-3xl font-bold">Attendees</h1>
+        {currentUser && (
+          <Link
+            href="/guests/edit"
+            className="text-sm font-semibold text-rose-500 hover:text-rose-600"
+          >
+            Edit profile
+          </Link>
+        )}
+      </div>
+
+      {guests.length === 0 ? (
+        <p className="text-gray-500">No attendees yet.</p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-gray-200">
+          {guests.map((guest) => (
+            <li key={guest.id}>
+              <Link
+                href={`/guests/${guest.id}`}
+                className="flex items-center gap-4 py-3 hover:bg-gray-50 rounded-md px-2"
+              >
+                <Avatar
+                  name={guest.name}
+                  size="sm"
+                  image={guest.avatarUrl ?? undefined}
+                />
+                <span className="font-medium text-gray-900">{guest.name}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -36,6 +36,7 @@ export default async function SiteLayout({
       <NavBar
         navItems={multipleEvents ? navItems : []}
         showLogout={passwordProtected && isAuthenticated}
+        showGuestsLink={isAuthenticated}
       />
       <main
         className={clsx(

--- a/app/(site)/nav-bar.tsx
+++ b/app/(site)/nav-bar.tsx
@@ -88,9 +88,11 @@ export type NavItem = {
 export default function NavBar({
   navItems,
   showLogout,
+  showGuestsLink,
 }: {
   navItems: NavItem[];
   showLogout: boolean;
+  showGuestsLink: boolean;
 }) {
   return (
     <Disclosure
@@ -124,6 +126,15 @@ export default function NavBar({
                   </div>
                 </div>
                 <div className="flex items-center gap-3">
+                  {showGuestsLink && (
+                    <Link
+                      href="/guests"
+                      className="group flex gap-1 cursor-pointer items-center rounded-md px-3 py-2 text-sm font-medium text-gray-400 hover:bg-gray-100"
+                    >
+                      <UserGroupIcon className="block h-5 w-auto" />
+                      Participants
+                    </Link>
+                  )}
                   <MapModal />
                   <ExportScheduleModal />
                   {showLogout && <LogoutButton />}

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { getImageRepositories } from "@/utils/images";
+
+export type ProfileActionResult = { ok: true } | { ok: false; error: string };
+
+export async function updateProfileAction(
+  formData: FormData
+): Promise<ProfileActionResult> {
+  const name = ((formData.get("name") as string | null) ?? "").trim();
+  const aboutMe = (formData.get("aboutMe") as string | null)?.trim() ?? null;
+  const avatarEntry = formData.get("avatar");
+  const avatarFile =
+    avatarEntry === ""
+      ? null
+      : avatarEntry instanceof File && avatarEntry.size > 0
+        ? avatarEntry
+        : undefined;
+
+  const cookieStore = await cookies();
+  const currentUser = cookieStore.get("user")?.value;
+  if (!currentUser) {
+    return { ok: false, error: "No user is logged in" };
+  }
+
+  if (!name) {
+    return { ok: false, error: "Name is required" };
+  }
+
+  const { guests } = getRepositories();
+  const currentProfile = await guests.findById(currentUser);
+  if (!currentProfile) {
+    return { ok: false, error: "Profile not found" };
+  }
+
+  const { avatars } = getImageRepositories();
+
+  let avatarUrl: string | undefined | null =
+    avatarFile === null ? null : (currentProfile.avatarUrl ?? null);
+
+  if (avatarFile) {
+    const avatarBuffer = await avatars.validate(
+      Buffer.from(await avatarFile.arrayBuffer())
+    );
+    if ("error" in avatarBuffer) {
+      return { ok: false, error: avatarBuffer.error };
+    }
+
+    avatarUrl = await avatars.save(
+      currentUser,
+      avatarBuffer.buffer,
+      avatarBuffer.ext
+    );
+  }
+
+  await guests.updateProfile(currentUser, { name, aboutMe, avatarUrl });
+
+  revalidatePath(`/guests/${currentUser}`);
+  revalidatePath("/guests");
+  return { ok: true };
+}

--- a/app/media/avatars/[filename]/route.ts
+++ b/app/media/avatars/[filename]/route.ts
@@ -1,0 +1,22 @@
+// Serves user-uploaded location images from UPLOADS_DIR. URLs carry a
+// ?v= cache-buster set on upload, so responses can be cached aggressively.
+import { NextRequest, NextResponse } from "next/server";
+import { getImageRepositories } from "@/utils/images";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> }
+) {
+  const { filename } = await params;
+
+  const image = await getImageRepositories().avatars.read(filename);
+  if (!image) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  return new NextResponse(new Uint8Array(image.data), {
+    headers: {
+      "Content-Type": image.contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -73,6 +73,9 @@ type GuestPrivateInfo = {
 export type Guest<PI extends GuestPrivateInfo | void = void> = {
   id: string;
   name: string;
+  // Public: shown on the guest's profile to anyone who can view it.
+  aboutMe?: string | null;
+  avatarUrl?: string | null;
   info: PI;
 };
 
@@ -85,9 +88,15 @@ export interface GuestsRepository {
   findById(id: string): Promise<CompleteGuest | undefined>;
   findByEmail(email: string): Promise<CompleteGuest | undefined>;
   create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest>;
+  // Usage: an admin updates a user (name and private info such as email).
   update(
     id: string,
-    data: Omit<CompleteGuest, "id">
+    data: Pick<CompleteGuest, "name" | "info">
+  ): Promise<CompleteGuest | undefined>;
+  // Usage: a user updates their own profile (name and public aboutMe).
+  updateProfile(
+    id: string,
+    data: { name: string; aboutMe: string | null; avatarUrl: string | null }
   ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;
@@ -191,6 +200,8 @@ export interface SessionsRepository {
   listScheduled(): Promise<Session[]>;
   listByEvent(eventId: string): Promise<Session[]>;
   listScheduledByEvent(eventId: string): Promise<Session[]>;
+  listHostedByGuest(guestId: string): Promise<Session[]>;
+  listRsvpdByGuest(guestId: string): Promise<Session[]>;
   findById(id: string): Promise<Session | undefined>;
   create(data: SessionCreateInput): Promise<Session>;
   update(id: string, patch: SessionUpdateInput): Promise<Session>;
@@ -251,6 +262,7 @@ export type SessionProposalUpdateInput = {
 
 export interface SessionProposalsRepository {
   listByEvent(eventId: string): Promise<SessionProposal[]>;
+  listByHost(guestId: string): Promise<SessionProposal[]>;
   findById(id: string): Promise<SessionProposal | undefined>;
   create(data: SessionProposalCreateInput): Promise<SessionProposal>;
   update(
@@ -287,4 +299,14 @@ export interface VotesRepository {
     proposalId: string,
     guestIds: string[]
   ): Promise<void>;
+}
+
+// ── Images ─────────────────────────────────────────────────────────────────────
+
+export interface ImageResourceRepository<Id> {
+  validate(
+    buffer: Buffer
+  ): Promise<{ buffer: Buffer; ext: string } | { error: string }>;
+  save(id: Id, buffer: Buffer, ext: string): Promise<string>;
+  delete(id: Id): Promise<void>;
 }

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -8,7 +8,13 @@ import { sanitizeGuest } from "@/utils/guests";
 type DB = BetterSQLite3Database<typeof schema>;
 
 function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
-  return { id: row.id, name: row.name, info: { email: row.email } };
+  return {
+    id: row.id,
+    name: row.name,
+    aboutMe: row.aboutMe,
+    avatarUrl: row.avatarUrl,
+    info: { email: row.email },
+  };
 }
 
 export class SqliteGuestsRepository implements GuestsRepository {
@@ -27,6 +33,8 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .select({
         id: schema.guests.id,
         name: schema.guests.name,
+        avatarUrl: schema.guests.avatarUrl,
+        aboutMe: schema.guests.aboutMe,
       })
       .from(schema.guests)
       .innerJoin(
@@ -70,7 +78,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
 
   async update(
     id: string,
-    data: Omit<CompleteGuest, "id">
+    data: Pick<CompleteGuest, "name" | "info">
   ): Promise<CompleteGuest | undefined> {
     const {
       name,
@@ -83,7 +91,24 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .where(eq(schema.guests.id, id))
       .run();
     if (result.changes === 0) return undefined;
-    return { id, ...data };
+    return this.findById(id);
+  }
+
+  async updateProfile(
+    id: string,
+    data: { name: string; aboutMe: string | null; avatarUrl: string | null }
+  ): Promise<CompleteGuest | undefined> {
+    const result = this.db
+      .update(schema.guests)
+      .set({
+        name: data.name,
+        aboutMe: data.aboutMe,
+        avatarUrl: data.avatarUrl,
+      })
+      .where(eq(schema.guests.id, id))
+      .run();
+    if (result.changes === 0) return undefined;
+    return this.findById(id);
   }
 
   async assignToEvent(eventId: string, guestIds: string[]): Promise<void> {

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -118,6 +118,20 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
     return this.enrichProposals(rows);
   }
 
+  async listByHost(guestId: string): Promise<SessionProposal[]> {
+    const rows = this.db
+      .select({ proposal: schema.sessionProposals })
+      .from(schema.sessionProposals)
+      .innerJoin(
+        schema.proposalHosts,
+        eq(schema.proposalHosts.proposalId, schema.sessionProposals.id)
+      )
+      .where(eq(schema.proposalHosts.guestId, guestId))
+      .all()
+      .map((r) => r.proposal);
+    return this.enrichProposals(rows);
+  }
+
   async findById(id: string): Promise<SessionProposal | undefined> {
     const row = this.db
       .select()

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -152,6 +152,31 @@ export class SqliteSessionsRepository implements SessionsRepository {
     return this.enrichSessions(rows);
   }
 
+  async listHostedByGuest(guestId: string): Promise<Session[]> {
+    const rows = this.db
+      .select({ session: schema.sessions })
+      .from(schema.sessions)
+      .innerJoin(
+        schema.sessionHosts,
+        eq(schema.sessionHosts.sessionId, schema.sessions.id)
+      )
+      .where(eq(schema.sessionHosts.guestId, guestId))
+      .all()
+      .map((r) => r.session);
+    return this.enrichSessions(rows);
+  }
+
+  async listRsvpdByGuest(guestId: string): Promise<Session[]> {
+    const rows = this.db
+      .select({ session: schema.sessions })
+      .from(schema.sessions)
+      .innerJoin(schema.rsvps, eq(schema.rsvps.sessionId, schema.sessions.id))
+      .where(eq(schema.rsvps.guestId, guestId))
+      .all()
+      .map((r) => r.session);
+    return this.enrichSessions(rows);
+  }
+
   async findById(id: string): Promise<Session | undefined> {
     const row = this.db
       .select()

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -10,6 +10,8 @@ export const guests = sqliteTable("guests", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull(),
+  aboutMe: text("about_me"),
+  avatarUrl: text("avatar_url"),
 });
 
 export const events = sqliteTable("events", {

--- a/drizzle/0008_unknown_chamber.sql
+++ b/drizzle/0008_unknown_chamber.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `guests` ADD `about_me` text;--> statement-breakpoint
+ALTER TABLE `guests` ADD `avatar_url` text;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,865 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d8e89b10-e0e2-4c9e-acf9-bb36e185fae0",
+  "prevId": "c24cb003-4a0e-409a-8577-5186bea422aa",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attendee_scheduled": {
+          "name": "attendee_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783004074395,
       "tag": "0007_faulty_pete_wisdom",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1782451329873,
+      "tag": "0008_unknown_chamber",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import sharp from "sharp";
+
+async function selectCurrentUser(page: import("@playwright/test").Page) {
+  // The proposals page has a "My name is:" selector backed by a combobox.
+  await page.getByRole("combobox", { name: /My name is/i }).click();
+  await page.getByRole("combobox", { name: /My name is/i }).fill("Alice Test");
+  await page.getByRole("option", { name: /Alice Test/i }).click();
+  await page.keyboard.press("Escape");
+}
+
+async function makeImage(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+test.describe("Edit profile", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test("lists guests and edits the current user's profile", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+    await expect(page).toHaveURL(/\/guests$/);
+
+    // All guests are listed.
+    await expect(page.getByRole("link", { name: "Alice Test" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Charlie Test" })
+    ).toBeVisible();
+
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+    await expect(page).toHaveURL(/\/guests\/edit$/);
+    await expect(
+      page.getByRole("heading", { name: /Edit profile/i })
+    ).toBeVisible();
+
+    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    await page.getByLabel("About me").fill(aboutMe);
+    // hidden inputs aren't interactable through `getByLabel` in playwright
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "square.png",
+      mimeType: "image/png",
+      buffer: await makeImage(800, 800),
+    });
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    // Lands on Alice's profile with the new About me text.
+    await expect(page).toHaveURL(/\/guests\/[^/]+$/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Alice Test" })
+    ).toBeVisible();
+    await expect(page.getByText(aboutMe)).toBeVisible();
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeVisible();
+  });
+
+  test("avatar doesn't change on profile about me edit", async ({ page }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+
+    // Reset the avatar
+    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    await page.getByLabel("About me").fill(aboutMe);
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeVisible();
+  });
+
+  test("shows no image when the user avatar is reset", async ({ page }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+
+    // Reset the avatar
+    await page.getByRole("button", { name: /^Reset$/ }).click();
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeHidden();
+    await expect(page.getByText(/^AT$/)).toBeVisible();
+  });
+});
+
+test("shows an error on the edit page when no user is selected", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests/edit");
+
+  await expect(page.getByText(/select who you are/i)).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /Edit profile/i })
+  ).toHaveCount(0);
+});

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -1,0 +1,14 @@
+import sharp from "sharp";
+
+export async function createImageFile(
+  width: number,
+  height: number,
+  name: string
+): Promise<File> {
+  const buffer = await sharp({
+    create: { width, height, channels: 3, background: { r: 1, g: 2, b: 3 } },
+  })
+    .png()
+    .toBuffer();
+  return new File([new Uint8Array(buffer)], name, { type: "image/png" });
+}

--- a/tests/integration/admin-locations.test.ts
+++ b/tests/integration/admin-locations.test.ts
@@ -10,7 +10,6 @@ import {
 import fs from "fs";
 import os from "os";
 import path from "path";
-import sharp from "sharp";
 
 const cookieJar = new Map<string, string>();
 
@@ -42,6 +41,7 @@ import {
   deleteLocationAction,
   moveLocationAction,
 } from "@/app/actions/admin-locations";
+import { createImageFile } from "@/tests/helpers/utils";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
 
@@ -69,12 +69,7 @@ async function makeImageFile(
   height: number,
   name = "room.png"
 ): Promise<File> {
-  const buffer = await sharp({
-    create: { width, height, channels: 3, background: { r: 1, g: 2, b: 3 } },
-  })
-    .png()
-    .toBuffer();
-  return new File([new Uint8Array(buffer)], name, { type: "image/png" });
+  return createImageFile(width, height, name);
 }
 
 let uploadsDir: string;

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createProposal,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("guest profile repositories", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  describe("guests.updateProfile", () => {
+    it("updates name and aboutMe, leaving email intact", async () => {
+      const { guests } = getRepositories();
+      const guest = await createGuest({ name: "Old", email: "g@test.example" });
+
+      const updated = await guests.updateProfile(guest.id, {
+        name: "New Name",
+        aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
+      });
+
+      expect(updated).toMatchObject({
+        id: guest.id,
+        name: "New Name",
+        aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
+        info: { email: "g@test.example" },
+      });
+      const fetched = await guests.findById(guest.id);
+      expect(fetched).toMatchObject({
+        name: "New Name",
+        aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
+      });
+    });
+  });
+
+  describe("sessions.listHostedByGuest", () => {
+    it("returns only sessions the guest hosts", async () => {
+      const { sessions } = getRepositories();
+      const event = await createEvent();
+      const guest = await createGuest();
+      const other = await createGuest();
+
+      const hosted = await createSession(event.id, {
+        title: "Mine",
+        hostIds: [guest.id],
+      });
+      await createSession(event.id, { title: "Theirs", hostIds: [other.id] });
+
+      const result = await sessions.listHostedByGuest(guest.id);
+      expect(result.map((s) => s.id)).toEqual([hosted.id]);
+      expect(result[0].hosts.map((h) => h.id)).toContain(guest.id);
+    });
+  });
+
+  describe("sessions.listRsvpdByGuest", () => {
+    it("returns only sessions the guest RSVP'd to", async () => {
+      const { sessions, rsvps } = getRepositories();
+      const event = await createEvent();
+      const guest = await createGuest();
+
+      const attended = await createSession(event.id, { title: "Going" });
+      await createSession(event.id, { title: "Not going" });
+      await rsvps.create({ sessionId: attended.id, guestId: guest.id });
+
+      const result = await sessions.listRsvpdByGuest(guest.id);
+      expect(result.map((s) => s.id)).toEqual([attended.id]);
+    });
+  });
+
+  describe("sessionProposals.listByHost", () => {
+    it("returns only proposals the guest hosts", async () => {
+      const { sessionProposals } = getRepositories();
+      const event = await createEvent();
+      const guest = await createGuest();
+      const other = await createGuest();
+
+      const mine = await createProposal(event.id, [guest.id], {
+        title: "My proposal",
+      });
+      await createProposal(event.id, [other.id], { title: "Their proposal" });
+
+      const result = await sessionProposals.listByHost(guest.id);
+      expect(result.map((p) => p.id)).toEqual([mine.id]);
+    });
+  });
+});

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -1,0 +1,128 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  vi,
+  afterEach,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { updateProfileAction } from "@/app/actions/profile";
+import { createImageFile } from "@/tests/helpers/utils";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import sharp from "sharp";
+
+function form(fields: Record<string, string | Blob>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  return fd;
+}
+
+let uploadsDir: string;
+
+describe("updateProfileAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-test-"));
+    vi.stubEnv("UPLOADS_DIR", uploadsDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(uploadsDir, { recursive: true, force: true });
+  });
+
+  it("updates name and aboutMe for the current user", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({ name: "New Name", aboutMe: "Hello there" })
+    );
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated).toMatchObject({ name: "New Name", aboutMe: "Hello there" });
+  });
+
+  it("updates name, aboutMe and avatar for the current user", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(256, 256, "avatar.png"),
+      })
+    );
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated).toMatchObject({
+      name: "New Name",
+      aboutMe: "Hello there",
+    });
+    expect(updated?.avatarUrl).toMatch(
+      new RegExp(`^/media/avatars/${updated?.id}\\.png\\?v=\\d+$`)
+    );
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    expect(fs.existsSync(imagePath)).toBe(true);
+  });
+
+  it("resizes avatar to 256 and keeps extension", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(512, 512, "avatar.png"),
+      })
+    );
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    expect(fs.existsSync(imagePath)).toBe(true);
+    const imageMetadata = await sharp(fs.readFileSync(imagePath)).metadata();
+    expect(imageMetadata).toMatchObject({
+      width: 256,
+      height: 256,
+      format: "png",
+    });
+  });
+
+  it("rejects images smaller than 256x256", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(128, 128, "avatar.png"),
+      })
+    );
+    expect(result).toMatchObject({ ok: false });
+  });
+});

--- a/utils/images-client.ts
+++ b/utils/images-client.ts
@@ -1,0 +1,78 @@
+function drawCover(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  destWidth: number,
+  destHeight: number
+) {
+  const sourceAspect = sourceWidth / sourceHeight;
+  const destAspect = destWidth / destHeight;
+
+  let sx = 0;
+  let sy = 0;
+  let sw = sourceWidth;
+  let sh = sourceHeight;
+
+  if (sourceAspect > destAspect) {
+    // Source is wider: crop left/right
+    sw = sourceHeight * destAspect;
+    sx = (sourceWidth - sw) / 2;
+  } else {
+    // Source is taller: crop top/bottom
+    sh = sourceWidth / destAspect;
+    sy = (sourceHeight - sh) / 2;
+  }
+
+  ctx.drawImage(image, sx, sy, sw, sh, 0, 0, destWidth, destHeight);
+}
+
+function toBlob(canvas: HTMLCanvasElement, file: File) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create blob"));
+        }
+      },
+      file.type.startsWith("image/") ? file.type : "image/jpeg",
+      0.9
+    );
+  })
+    .then((blob) => ({ blob }))
+    .catch((e) => {
+      console.error(e);
+      return { error: "Failed to resize image" };
+    });
+}
+
+export async function resizeImage(
+  canvas: HTMLCanvasElement,
+  file: File,
+  maxSize: number
+): Promise<{ blob: Blob } | { error: string }> {
+  const bitmap = await createImageBitmap(file);
+
+  canvas.width = maxSize;
+  canvas.height = maxSize;
+
+  const ctx = canvas.getContext("2d")!;
+
+  try {
+    drawCover(
+      ctx,
+      bitmap,
+      bitmap.width,
+      bitmap.height,
+      canvas.width,
+      canvas.height
+    );
+  } catch (e) {
+    console.error(e);
+    return { error: "Failed to draw image" };
+  }
+
+  return toBlob(canvas, file);
+}

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -1,0 +1,165 @@
+import { ImageResourceRepository } from "@/db/repositories/interfaces";
+import sharp, { FormatEnum, Metadata, Sharp } from "sharp";
+import fs from "fs/promises";
+import path from "path";
+
+// Images are stored on the filesystem under UPLOADS_DIR
+// (a persistent volume in production), not in public/,
+// because public/ is baked into the build and lost on redeploy.
+
+// Avatar images are uploaded through the /guests/edit UI
+// They are served by app/media/avatar/[filename]/route.ts.
+
+const FORMAT_EXTENSIONS: Partial<Record<keyof FormatEnum, string>> = {
+  jpeg: "jpg",
+  png: "png",
+  webp: "webp",
+};
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const MIN_IMAGE_WIDTH = 400;
+
+export abstract class BaseImageResourceRepository<
+  Id extends string,
+> implements ImageResourceRepository<Id> {
+  readonly maxImageBytes = MAX_IMAGE_BYTES;
+  readonly minImageWidth: number = MIN_IMAGE_WIDTH;
+  abstract readonly directory: string;
+
+  get dirPath() {
+    return path.join(process.env.UPLOADS_DIR ?? "./uploads", this.directory);
+  }
+
+  protected abstract getEndpoint(filename: string): string;
+
+  /**
+   * Validates format and size
+   * Returns the canonical file extension on success, or an error message.
+   */
+  async validate(
+    buffer: Buffer
+  ): Promise<{ ext: string; buffer: Buffer } | { error: string }> {
+    if (buffer.byteLength > this.maxImageBytes) {
+      const mb = new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 2,
+      }).format(this.maxImageBytes / 1_000_000);
+      return {
+        error: `Image is too large (max ${mb} MB)`,
+      };
+    }
+
+    let decodedImage: Sharp;
+    let metadata: Metadata;
+    try {
+      decodedImage = sharp(buffer);
+      metadata = await decodedImage.metadata();
+    } catch {
+      return { error: "File is not a valid image" };
+    }
+
+    const { width, format } = metadata;
+
+    const ext = FORMAT_EXTENSIONS[format];
+
+    if (!ext) {
+      return { error: "Unsupported image format (use JPEG, PNG, or WebP)" };
+    }
+    if (width < this.minImageWidth) {
+      return { error: `Image is too small (min ${this.minImageWidth}px wide)` };
+    }
+
+    try {
+      // strips EXIF, ICC profiles, XMP, IPTC, GPS data, and other metadata from images
+      const newBuffer = await this.decodeImage(
+        decodedImage,
+        metadata
+      ).toBuffer();
+
+      return { ext, buffer: newBuffer };
+    } catch {
+      return { error: "Unable to decode image" };
+    }
+  }
+
+  protected decodeImage(image: Sharp, metadata: Metadata): Sharp {
+    return image.rotate().toFormat(metadata.format);
+  }
+
+  /** Removes all stored image files for the ID, if any. */
+  async delete(id: Id): Promise<void> {
+    const dir = this.dirPath;
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch {
+      return;
+    }
+    await Promise.all(
+      entries
+        .filter((name) => name.startsWith(`${id}.`))
+        .map((name) => fs.unlink(path.join(dir, name)).catch(() => {}))
+    );
+  }
+
+  /**
+   * Stores the image as <ID>.<ext>, replacing any previous image for
+   * the ID. Returns the public URL (with a cache-busting version).
+   */
+  async save(id: Id, buffer: Buffer, ext: string): Promise<string> {
+    const dir = this.dirPath;
+    await fs.mkdir(dir, { recursive: true });
+    await this.delete(id);
+    const filename = `${id}.${ext}`;
+    await fs.writeFile(path.join(dir, filename), buffer);
+    return `${this.getEndpoint(filename)}?v=${Date.now()}`;
+  }
+
+  /**
+   * Resolves a requested filename to a stored image, guarding against path
+   * traversal. Returns undefined for invalid or missing files.
+   */
+  async read(
+    filename: string
+  ): Promise<{ data: Buffer; contentType: string } | undefined> {
+    if (!SAFE_FILENAME.test(filename)) return undefined;
+
+    filename = path.join(this.dirPath, filename);
+    try {
+      const data = await fs.readFile(filename);
+      const ext = filename.split(".").pop()!;
+      return { data, contentType: CONTENT_TYPES[ext] };
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+const SAFE_FILENAME = /^[A-Za-z0-9_-]+\.(jpg|png|webp)$/;
+
+const CONTENT_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+export class AvatarImageResourceRepository extends BaseImageResourceRepository<string> {
+  override directory = "avatars";
+
+  override minImageWidth = 256;
+
+  protected override getEndpoint(filename: string): string {
+    return `/media/avatars/${filename}`;
+  }
+
+  override decodeImage(image: Sharp, metadata: Metadata): Sharp {
+    return super
+      .decodeImage(image, metadata)
+      .resize(256, 256, { fit: "cover" });
+  }
+}
+
+export function getImageRepositories() {
+  return {
+    avatars: new AvatarImageResourceRepository(),
+  };
+}


### PR DESCRIPTION
Guests get a public profile page (/guests/[guestId]) showing their
name, "about me" text, and lists of sessions they host, propose, or
plan to attend. They can edit their own name, about-me text, and
avatar image from /guests/edit. Host and attendee names throughout
the app now link to these profiles.

Avatars are handled by a new ImageRepository abstraction (currently
filesystem-backed) so the same pattern can later be reused for
location images.

Renames the SQL column guests.aboutMe to guests.about_me for naming
consistency.

issue #369

<!-- jip:pushed-commit=0661fbb1db56366c5ea1c2a5c1e974c889234b80 -->