### PR TITLE
fix: verify referential integrity after migrations

### DIFF
--- a/db/container.ts
+++ b/db/container.ts
@@ -52,14 +52,20 @@ function buildRepositories(sqlite: Database.Database): Repositories {
 
 export function getRepositories(): Repositories {
   if (!_repositories) {
-    _sqlite = new Database(resolveDbPath());
-    // Enforce foreign keys on every connection. better-sqlite3 happens to
-    // compile SQLite with SQLITE_DEFAULT_FOREIGN_KEYS=1, but set it explicitly
-    // so our ON DELETE CASCADE / SET NULL behaviour never depends on that
-    // build default. runMigrations toggles it off and back on internally.
-    _sqlite.pragma("foreign_keys = ON");
-    runMigrations(_sqlite, path.join(process.cwd(), "drizzle"));
-    _repositories = buildRepositories(_sqlite);
+    const conn = new Database(resolveDbPath());
+    try {
+      // Enforce foreign keys on every connection. better-sqlite3 happens to
+      // compile SQLite with SQLITE_DEFAULT_FOREIGN_KEYS=1, but set it explicitly
+      // so our ON DELETE CASCADE / SET NULL behaviour never depends on that
+      // build default. runMigrations toggles it off and back on internally.
+      conn.pragma("foreign_keys = ON");
+      runMigrations(conn, path.join(process.cwd(), "drizzle"));
+      _sqlite = conn;
+      _repositories = buildRepositories(conn);
+    } catch (e) {
+      conn.close();
+      throw e;
+    }
   }
   return _repositories;
 }

--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -21,6 +21,11 @@ export function resolveDbPath(
  * therefore fail against a populated database. Disabling enforcement here,
  * outside any transaction, is SQLite's recommended workaround.
  * See https://github.com/drizzle-team/drizzle-orm/issues/4089
+ *
+ * Because enforcement is off, a faulty migration could introduce a dangling
+ * reference unnoticed, so afterwards we run `PRAGMA foreign_key_check` and
+ * throw if any violation slipped through (it cannot be rolled back at that
+ * point, but failing loudly surfaces the bad migration in dev/CI).
  */
 export function runMigrations(
   sqlite: Database.Database,
@@ -29,6 +34,13 @@ export function runMigrations(
   try {
     sqlite.pragma("foreign_keys = OFF");
     migrate(drizzle(sqlite), { migrationsFolder });
+    const violations = sqlite.pragma("foreign_key_check") as unknown[];
+    if (violations.length > 0) {
+      throw new Error(
+        `Migration produced ${violations.length} foreign key violation(s): ` +
+          JSON.stringify(violations)
+      );
+    }
   } finally {
     sqlite.pragma("foreign_keys = ON");
   }

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { runMigrations } from "@/db/migrate";
+
+// Writes a minimal Drizzle migrations folder containing a single migration.
+// Statements are separated by the Drizzle statement-breakpoint marker.
+function writeMigration(dir: string, statements: string[]): void {
+  fs.mkdirSync(path.join(dir, "meta"), { recursive: true });
+  const journal = {
+    version: "7",
+    dialect: "sqlite",
+    entries: [
+      { idx: 0, version: "6", when: 1, tag: "0000_test", breakpoints: true },
+    ],
+  };
+  fs.writeFileSync(
+    path.join(dir, "meta", "_journal.json"),
+    JSON.stringify(journal)
+  );
+  fs.writeFileSync(
+    path.join(dir, "0000_test.sql"),
+    statements.join("--> statement-breakpoint\n")
+  );
+}
+
+describe("runMigrations", () => {
+  let tmpDir: string;
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "migrate-test-"));
+    sqlite = new Database(":memory:");
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rebuilds a table referenced by a foreign key", () => {
+    // Seed a parent/child pair, then a second migration drops & recreates the
+    // parent. With FK enforcement on this fails; the helper disables it.
+    writeMigration(tmpDir, [
+      "CREATE TABLE parent (id text PRIMARY KEY);",
+      "CREATE TABLE child (id text PRIMARY KEY, parent_id text REFERENCES parent(id));",
+      "INSERT INTO parent (id) VALUES ('p1');",
+      "INSERT INTO child (id, parent_id) VALUES ('c1', 'p1');",
+      "CREATE TABLE __new_parent (id text PRIMARY KEY, label text);",
+      "INSERT INTO __new_parent (id) SELECT id FROM parent;",
+      "DROP TABLE parent;",
+      "ALTER TABLE __new_parent RENAME TO parent;",
+    ]);
+
+    expect(() => runMigrations(sqlite, tmpDir)).not.toThrow();
+    expect(sqlite.prepare("SELECT count(*) AS n FROM child").get()).toEqual({
+      n: 1,
+    });
+  });
+
+  it("throws when a migration leaves a foreign key violation", () => {
+    // A dangling reference only slips in because enforcement is off during
+    // migration; the post-migration integrity check must catch it.
+    writeMigration(tmpDir, [
+      "CREATE TABLE parent (id text PRIMARY KEY);",
+      "CREATE TABLE child (id text PRIMARY KEY, parent_id text REFERENCES parent(id));",
+      "INSERT INTO child (id, parent_id) VALUES ('c1', 'missing');",
+    ]);
+
+    expect(() => runMigrations(sqlite, tmpDir)).toThrow(/foreign key/i);
+  });
+
+  it("leaves foreign key enforcement enabled afterwards", () => {
+    writeMigration(tmpDir, ["CREATE TABLE t (id text PRIMARY KEY);"]);
+
+    runMigrations(sqlite, tmpDir);
+
+    expect(sqlite.pragma("foreign_keys", { simple: true })).toBe(1);
+  });
+});


### PR DESCRIPTION
Disabling foreign keys to allow table rebuilds means a faulty migration
could leave a dangling reference unnoticed. Run PRAGMA foreign_key_check
after migrating and throw on any violation, so a bad migration fails
loudly in dev/CI instead of silently corrupting data.

<!-- jip:pushed-commit=e740016acc805b4c9e981013739b201035e3fc82 -->