### PR TITLE
feat: add phase ordering validation and implicit phase ends

### DIFF
--- a/app/(site)/utils/events.ts
+++ b/app/(site)/utils/events.ts
@@ -11,7 +11,13 @@ export enum EventPhase {
 }
 
 /**
- * Checks if the current time falls within a date period
+ * Checks if the current time falls within a date period.
+ *
+ * The interval is half-open `[start, end)`: the end is exclusive so that
+ * touching phases (where one phase's implicit end equals the next phase's
+ * start) hand over cleanly at the boundary instead of overlapping for one
+ * instant.
+ *
  * @param start - The start date of the period
  * @param end - The end date of the period (optional, defaults to no end limit)
  * @returns true if current time is within the period
@@ -19,30 +25,47 @@ export enum EventPhase {
 function inDatePeriod(start: Date, end?: Date): boolean {
   const now = Date.now();
   const afterStart = now >= start.getTime();
-  const beforeEnd = !end || now <= end.getTime();
+  const beforeEnd = !end || now < end.getTime();
   return afterStart && beforeEnd;
 }
 
 /**
- * Checks if an event is currently in the proposal phase
+ * Checks if an event is currently in the proposal phase.
+ *
+ * A phase without an explicit end is treated as ending when the next
+ * configured phase starts, so an open-ended proposal phase does not mask
+ * voting/scheduling. An explicit end set before the next phase start creates
+ * an intentional inactive gap.
+ *
  * @param event - The event to check
  * @returns true if the event is in the proposal phase
  */
 export function inProposalPhase(event: Event): boolean {
-  const { proposalPhaseStart, proposalPhaseEnd } = event;
+  const {
+    proposalPhaseStart,
+    proposalPhaseEnd,
+    votingPhaseStart,
+    schedulingPhaseStart,
+  } = event;
+  const effectiveEnd =
+    proposalPhaseEnd ?? votingPhaseStart ?? schedulingPhaseStart;
   return !!(
-    proposalPhaseStart && inDatePeriod(proposalPhaseStart, proposalPhaseEnd)
+    proposalPhaseStart && inDatePeriod(proposalPhaseStart, effectiveEnd)
   );
 }
 
 /**
- * Checks if an event is currently in the voting phase
+ * Checks if an event is currently in the voting phase.
+ *
+ * An open-ended voting phase is treated as ending when scheduling starts.
+ *
  * @param event - The event to check
  * @returns true if the event is in the voting phase
  */
 export function inVotingPhase(event: Event): boolean {
-  const { votingPhaseStart, votingPhaseEnd } = event;
-  return !!(votingPhaseStart && inDatePeriod(votingPhaseStart, votingPhaseEnd));
+  const { votingPhaseStart, votingPhaseEnd, schedulingPhaseStart } = event;
+  const effectiveEnd = votingPhaseEnd ?? schedulingPhaseStart;
+  return !!(votingPhaseStart && inDatePeriod(votingPhaseStart, effectiveEnd));
 }
 
 /**

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -132,19 +132,94 @@ function parseDateTime(value: string | undefined): Date | undefined {
   return isNaN(d.getTime()) ? undefined : d;
 }
 
+type ParsedPhaseDates = {
+  proposalPhaseStart: Date | undefined;
+  proposalPhaseEnd: Date | undefined;
+  votingPhaseStart: Date | undefined;
+  votingPhaseEnd: Date | undefined;
+  schedulingPhaseStart: Date | undefined;
+  schedulingPhaseEnd: Date | undefined;
+};
+
+function validatePhasesInput(
+  input: EventPhasesInput
+): string | ParsedPhaseDates {
+  const fieldDefs: [keyof Omit<EventPhasesInput, "id">, string][] = [
+    ["proposalPhaseStart", "proposal phase start"],
+    ["proposalPhaseEnd", "proposal phase end"],
+    ["votingPhaseStart", "voting phase start"],
+    ["votingPhaseEnd", "voting phase end"],
+    ["schedulingPhaseStart", "scheduling phase start"],
+    ["schedulingPhaseEnd", "scheduling phase end"],
+  ];
+
+  const parsed: Partial<ParsedPhaseDates> = {};
+  for (const [field, label] of fieldDefs) {
+    const raw = input[field]?.trim();
+    if (raw) {
+      const d = parseDateTime(raw);
+      if (d === undefined) return `Invalid ${label}`;
+      parsed[field] = d;
+    } else {
+      parsed[field] = undefined;
+    }
+  }
+
+  const {
+    proposalPhaseStart: pStart,
+    proposalPhaseEnd: pEnd,
+    votingPhaseStart: vStart,
+    votingPhaseEnd: vEnd,
+    schedulingPhaseStart: sStart,
+    schedulingPhaseEnd: sEnd,
+  } = parsed as ParsedPhaseDates;
+
+  if (pStart && pEnd && pEnd <= pStart) {
+    return "Proposal phase end must be after its start";
+  }
+  if (vStart && vEnd && vEnd <= vStart) {
+    return "Voting phase end must be after its start";
+  }
+  if (sStart && sEnd && sEnd <= sStart) {
+    return "Scheduling phase end must be after its start";
+  }
+  if (pEnd && vStart && vStart < pEnd) {
+    return "Voting phase must not start before proposal phase ends";
+  }
+  if (vEnd && sStart && sStart < vEnd) {
+    return "Scheduling phase must not start before voting phase ends";
+  }
+  // A phase without an explicit end implicitly ends when the next phase starts,
+  // so the starts themselves must stay in order.
+  if (pStart && vStart && vStart < pStart) {
+    return "Voting phase must not start before proposal phase starts";
+  }
+  if (vStart && sStart && sStart < vStart) {
+    return "Scheduling phase must not start before voting phase starts";
+  }
+  // When voting is unset, the checks above leave scheduling unconstrained
+  // relative to the proposal phase. Constrain it directly so scheduling can
+  // never start before the proposal phase starts or ends.
+  if (pStart && sStart && sStart < pStart) {
+    return "Scheduling phase must not start before proposal phase starts";
+  }
+  if (pEnd && sStart && sStart < pEnd) {
+    return "Scheduling phase must not start before proposal phase ends";
+  }
+  return parsed as ParsedPhaseDates;
+}
+
 export async function updateEventPhasesAction(
   input: EventPhasesInput
 ): Promise<AdminActionResult> {
   if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
 
-  const updated = await getRepositories().events.update(input.id, {
-    proposalPhaseStart: parseDateTime(input.proposalPhaseStart),
-    proposalPhaseEnd: parseDateTime(input.proposalPhaseEnd),
-    votingPhaseStart: parseDateTime(input.votingPhaseStart),
-    votingPhaseEnd: parseDateTime(input.votingPhaseEnd),
-    schedulingPhaseStart: parseDateTime(input.schedulingPhaseStart),
-    schedulingPhaseEnd: parseDateTime(input.schedulingPhaseEnd),
-  });
+  const result = validatePhasesInput(input);
+  if (typeof result === "string") {
+    return { ok: false, error: result };
+  }
+
+  const updated = await getRepositories().events.update(input.id, result);
   if (!updated) return { ok: false, error: "Event not found" };
 
   revalidatePath("/admin");

--- a/app/admin/events/[id]/event-phases-form.tsx
+++ b/app/admin/events/[id]/event-phases-form.tsx
@@ -51,7 +51,9 @@ export function EventPhasesForm({ event }: { event: Event }) {
     <form onSubmit={handleSave} className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Phases</h2>
       <p className="text-sm text-gray-500">
-        All times are UTC. Leave fields empty to unset a phase.
+        All times are UTC. Leave fields empty to unset a phase. A phase with no
+        end runs until the next phase starts; set an end earlier than the next
+        start to leave an inactive gap.
       </p>
       {saveError && <p className="text-sm text-red-600">{saveError}</p>}
 

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -299,6 +299,20 @@ test.describe("Admin UI events", () => {
       page.getByRole("group", { name: "Proposal phase" }).getByLabel("End")
     ).toHaveValue("2026-09-15T17:00");
 
+    // Validation: end before start shows an error
+    await page
+      .getByRole("group", { name: "Proposal phase" })
+      .getByLabel("Start")
+      .fill("2026-09-20T09:00");
+    await page
+      .getByRole("group", { name: "Proposal phase" })
+      .getByLabel("End")
+      .fill("2026-09-01T09:00");
+    await page.getByRole("button", { name: "Save phases" }).click();
+    await expect(
+      page.getByText(/proposal phase end must be after its start/i)
+    ).toBeVisible();
+
     // Clear the phase dates
     await page
       .getByRole("group", { name: "Proposal phase" })

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -323,6 +323,137 @@ describe("event actions", () => {
     });
   });
 
+  describe("updateEventPhasesAction validation", () => {
+    it("rejects when phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-15T18:00",
+        proposalPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /proposal.*end.*after.*start/i
+      );
+    });
+
+    it("rejects when voting phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-15T18:00",
+        votingPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(/voting.*end.*after.*start/i);
+    });
+
+    it("rejects when scheduling phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        schedulingPhaseStart: "2026-09-15T18:00",
+        schedulingPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*end.*after.*start/i
+      );
+    });
+
+    it("rejects when voting start is before proposal end", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        proposalPhaseEnd: "2026-09-20T18:00",
+        votingPhaseStart: "2026-09-10T08:00",
+        votingPhaseEnd: "2026-09-25T18:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /voting.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling start is before voting end", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-01T08:00",
+        votingPhaseEnd: "2026-09-20T18:00",
+        schedulingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*voting/i
+      );
+    });
+
+    it("allows phases without an end date", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows an open-ended proposal phase with a later voting start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        votingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects when voting starts before proposal starts", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-10T08:00",
+        votingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /voting.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling starts before voting starts", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-10T08:00",
+        schedulingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*voting/i
+      );
+    });
+
+    it("rejects when scheduling starts before proposal ends and voting is unset", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        proposalPhaseEnd: "2026-09-20T18:00",
+        schedulingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling starts before proposal starts and voting is unset", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-10T08:00",
+        schedulingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*proposal/i
+      );
+    });
+  });
+
   describe("updateEventPhasesAction", () => {
     it("sets phase dates", async () => {
       const event = await createEvent();

--- a/tests/unit/event-phases.test.ts
+++ b/tests/unit/event-phases.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EventPhase, getCurrentPhase } from "@/app/(site)/utils/events";
+import type { Event } from "@/db/repositories/interfaces";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ago = (days: number) => new Date(Date.now() - days * DAY_MS);
+const ahead = (days: number) => new Date(Date.now() + days * DAY_MS);
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: "e1",
+    name: "Test",
+    description: "",
+    website: "",
+    start: ahead(30),
+    end: ahead(31),
+    maxSessionDuration: 120,
+    breakMinutes: 10,
+    timezone: "UTC",
+    ...overrides,
+  };
+}
+
+describe("getCurrentPhase with implicit phase ends", () => {
+  it("ends an open-ended proposal phase when voting starts", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(3),
+      // no proposalPhaseEnd -> implicitly ends when voting starts
+      votingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.VOTING);
+  });
+
+  it("ends an open-ended voting phase when scheduling starts", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(3),
+      // no votingPhaseEnd -> implicitly ends when scheduling starts
+      schedulingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("falls through to scheduling when voting is unset", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(3),
+      // no proposalPhaseEnd, no voting -> implicit end is scheduling start
+      schedulingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("keeps an open-ended scheduling phase active (no successor)", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(3),
+      schedulingPhaseStart: ago(1),
+      // no schedulingPhaseEnd -> stays active
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("respects an explicit gap between phases as INACTIVE", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      proposalPhaseEnd: ago(3),
+      votingPhaseStart: ahead(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.INACTIVE);
+  });
+
+  it("respects an explicit scheduling end as INACTIVE afterwards", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(4),
+      schedulingPhaseStart: ago(3),
+      schedulingPhaseEnd: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.INACTIVE);
+  });
+
+  describe("at the exact boundary instant between touching phases", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("selects the next phase, not the ending one", () => {
+      const now = new Date("2026-06-26T12:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const event = makeEvent({
+        proposalPhaseStart: ago(1),
+        // open-ended -> implicit end equals votingPhaseStart, which is "now"
+        votingPhaseStart: now,
+      });
+
+      expect(getCurrentPhase(event)).toBe(EventPhase.VOTING);
+    });
+  });
+});


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [5200b66](https://github.com/LWCW-Europe/schellingboard/pull/477/commits/5200b663848aeee88361bbf2ada4d06ccdf3cac0).

PRs:
* #483
* #479
* #478
* ➡️ #477 (this PR, base of the stack — can be merged first)

---

## Description

Phases are gated by independent start/end pairs, and getCurrentPhase
returns the first active phase (proposal -> voting -> scheduling). An
open-ended earlier phase (no explicit end) therefore stayed active
forever and masked later phases.

Treat a phase's effective end as its explicit end or, when absent, the
next configured phase's start. Explicit ends still allow intentional
inactive gaps and closing the final phase. Validate start ordering so
the implicit-end model stays coherent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=5200b663848aeee88361bbf2ada4d06ccdf3cac0 -->