### PR TITLE
fix: avoid timezone datalist hydration mismatch

### DIFF
--- a/app/admin/events/[id]/event-detail-form.tsx
+++ b/app/admin/events/[id]/event-detail-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/app/input";
 import type { Event } from "@/db/repositories/interfaces";
@@ -18,6 +18,21 @@ import {
 function toDateInputValue(date: Date): string {
   return date.toISOString().split("T")[0];
 }
+
+// useSyncExternalStore compares snapshots with Object.is, so each getter must
+// return a stable reference — otherwise it re-renders forever (React #185).
+const EMPTY_TIMEZONES: string[] = [];
+let cachedTimezones: string[] | null = null;
+function getClientTimezones(): string[] {
+  if (cachedTimezones === null) {
+    cachedTimezones = Intl.supportedValuesOf("timeZone");
+  }
+  return cachedTimezones;
+}
+function getServerTimezones(): string[] {
+  return EMPTY_TIMEZONES;
+}
+const subscribeTimezones = () => () => {};
 
 export function EventDetailForm({ event }: { event: Event }) {
   const router = useRouter();
@@ -39,6 +54,11 @@ export function EventDetailForm({ event }: { event: Event }) {
   const [deleteMode, setDeleteMode] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
   const [isDeleting, startDelete] = useTransition();
+  const timezones = useSyncExternalStore(
+    subscribeTimezones,
+    getClientTimezones,
+    getServerTimezones
+  );
 
   const set = (key: keyof EventInput, value: string) => {
     setSaveSuccess(false);
@@ -150,10 +170,9 @@ export function EventDetailForm({ event }: { event: Event }) {
               className="w-full h-10"
             />
             <datalist id="timezones">
-              {typeof Intl !== "undefined" &&
-                Intl.supportedValuesOf("timeZone").map((tz) => (
-                  <option key={tz} value={tz} />
-                ))}
+              {timezones.map((tz) => (
+                <option key={tz} value={tz} />
+              ))}
             </datalist>
           </div>
           <div className="flex flex-col gap-1">


### PR DESCRIPTION
The event detail form is server-rendered, but Node's ICU timezone
list can differ from the browser's, so populating the <datalist>
from Intl.supportedValuesOf during SSR risked a React hydration
mismatch. Use useSyncExternalStore to serve an empty list on the
server and the real list only on the client.

useSyncExternalStore compares snapshots with Object.is, so the
getters must return stable references; otherwise the snapshot looks
new every render and React re-renders forever (#185). Return cached
client/server arrays instead.

<!-- jip:pushed-commit=a52dca0158c55399ea4cb118273886c25bb04a1c -->