### PR TITLE
feat: add locations section to event detail

### DIFF
--- a/app/(site)/utils/events.ts
+++ b/app/(site)/utils/events.ts
@@ -11,7 +11,13 @@ export enum EventPhase {
 }
 
 /**
- * Checks if the current time falls within a date period
+ * Checks if the current time falls within a date period.
+ *
+ * The interval is half-open `[start, end)`: the end is exclusive so that
+ * touching phases (where one phase's implicit end equals the next phase's
+ * start) hand over cleanly at the boundary instead of overlapping for one
+ * instant.
+ *
  * @param start - The start date of the period
  * @param end - The end date of the period (optional, defaults to no end limit)
  * @returns true if current time is within the period
@@ -19,30 +25,47 @@ export enum EventPhase {
 function inDatePeriod(start: Date, end?: Date): boolean {
   const now = Date.now();
   const afterStart = now >= start.getTime();
-  const beforeEnd = !end || now <= end.getTime();
+  const beforeEnd = !end || now < end.getTime();
   return afterStart && beforeEnd;
 }
 
 /**
- * Checks if an event is currently in the proposal phase
+ * Checks if an event is currently in the proposal phase.
+ *
+ * A phase without an explicit end is treated as ending when the next
+ * configured phase starts, so an open-ended proposal phase does not mask
+ * voting/scheduling. An explicit end set before the next phase start creates
+ * an intentional inactive gap.
+ *
  * @param event - The event to check
  * @returns true if the event is in the proposal phase
  */
 export function inProposalPhase(event: Event): boolean {
-  const { proposalPhaseStart, proposalPhaseEnd } = event;
+  const {
+    proposalPhaseStart,
+    proposalPhaseEnd,
+    votingPhaseStart,
+    schedulingPhaseStart,
+  } = event;
+  const effectiveEnd =
+    proposalPhaseEnd ?? votingPhaseStart ?? schedulingPhaseStart;
   return !!(
-    proposalPhaseStart && inDatePeriod(proposalPhaseStart, proposalPhaseEnd)
+    proposalPhaseStart && inDatePeriod(proposalPhaseStart, effectiveEnd)
   );
 }
 
 /**
- * Checks if an event is currently in the voting phase
+ * Checks if an event is currently in the voting phase.
+ *
+ * An open-ended voting phase is treated as ending when scheduling starts.
+ *
  * @param event - The event to check
  * @returns true if the event is in the voting phase
  */
 export function inVotingPhase(event: Event): boolean {
-  const { votingPhaseStart, votingPhaseEnd } = event;
-  return !!(votingPhaseStart && inDatePeriod(votingPhaseStart, votingPhaseEnd));
+  const { votingPhaseStart, votingPhaseEnd, schedulingPhaseStart } = event;
+  const effectiveEnd = votingPhaseEnd ?? schedulingPhaseStart;
+  return !!(votingPhaseStart && inDatePeriod(votingPhaseStart, effectiveEnd));
 }
 
 /**

--- a/app/actions/admin-days.ts
+++ b/app/actions/admin-days.ts
@@ -1,0 +1,220 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { sessionContainedInWindow } from "@/utils/day-window";
+import type { AdminActionResult } from "./admin-guests";
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+export type DayInput = {
+  eventId: string;
+  start: string;
+  end: string;
+  startBookings: string;
+  endBookings: string;
+};
+
+function parseDateTime(value: string): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value + "Z");
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+type ParsedDay = {
+  eventId: string;
+  start: Date;
+  end: Date;
+  startBookings: Date;
+  endBookings: Date;
+};
+
+function parseDayInput(
+  input: DayInput
+): { data: ParsedDay } | { error: string } {
+  const start = parseDateTime(input.start);
+  if (!start) {
+    return { error: "Invalid start date/time" };
+  }
+
+  const end = parseDateTime(input.end);
+  if (!end) {
+    return { error: "Invalid end date/time" };
+  }
+
+  if (end <= start) {
+    return { error: "Day end must be after start" };
+  }
+
+  const startBookings = parseDateTime(input.startBookings);
+  if (!startBookings) {
+    return { error: "Invalid bookings start date/time" };
+  }
+
+  const endBookings = parseDateTime(input.endBookings);
+  if (!endBookings) {
+    return { error: "Invalid bookings end date/time" };
+  }
+
+  if (endBookings <= startBookings) {
+    return { error: "Bookings end must be after bookings start" };
+  }
+
+  if (startBookings < start || endBookings > end) {
+    return { error: "Bookings window must be within the day window" };
+  }
+
+  return {
+    data: { eventId: input.eventId, start, end, startBookings, endBookings },
+  };
+}
+
+function daysOverlap(
+  aStart: Date,
+  aEnd: Date,
+  bStart: Date,
+  bEnd: Date
+): boolean {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+function revalidateDayPaths(eventId: string) {
+  revalidatePath("/admin");
+  revalidatePath("/admin/events");
+  revalidatePath(`/admin/events/${eventId}`);
+}
+
+export async function createDayAction(
+  input: DayInput
+): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) {
+    return { ok: false, error: "Unauthorized" };
+  }
+
+  const parsed = parseDayInput(input);
+  if ("error" in parsed) {
+    return { ok: false, error: parsed.error };
+  }
+
+  const repos = getRepositories();
+  const event = await repos.events.findById(input.eventId);
+  if (!event) {
+    return { ok: false, error: "Event not found" };
+  }
+
+  const existingDays = await repos.days.listByEvent(input.eventId);
+  if (
+    existingDays.some((d) =>
+      daysOverlap(parsed.data.start, parsed.data.end, d.start, d.end)
+    )
+  ) {
+    return { ok: false, error: "Day overlaps an existing day" };
+  }
+
+  try {
+    await repos.days.create(parsed.data);
+  } catch {
+    return { ok: false, error: "Failed to create day" };
+  }
+  revalidateDayPaths(input.eventId);
+  return { ok: true };
+}
+
+export async function updateDayAction(
+  input: DayInput & { id: string }
+): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) {
+    return { ok: false, error: "Unauthorized" };
+  }
+
+  const existing = await getRepositories().days.findById(input.id);
+  if (!existing) {
+    return { ok: false, error: "Day not found" };
+  }
+
+  const parsed = parseDayInput(input);
+  if ("error" in parsed) {
+    return { ok: false, error: parsed.error };
+  }
+
+  const { start, end, startBookings, endBookings } = parsed.data;
+
+  const existingDays = await getRepositories().days.listByEvent(
+    existing.eventId
+  );
+  if (
+    existingDays.some(
+      (d) => d.id !== input.id && daysOverlap(start, end, d.start, d.end)
+    )
+  ) {
+    return { ok: false, error: "Day overlaps an existing day" };
+  }
+
+  // Block edits that would push a session currently scheduled inside this day
+  // outside the new window (where it would become invalid/uneditable). The
+  // admin must reschedule or delete those sessions first.
+  const sessions = await getRepositories().sessions.listScheduledByEvent(
+    existing.eventId
+  );
+  const orphaned = sessions.filter(
+    (s) =>
+      sessionContainedInWindow(s, existing.start, existing.end) &&
+      !sessionContainedInWindow(s, start, end)
+  );
+  if (orphaned.length > 0) {
+    const titles = orphaned.map((s) => `"${s.title}"`).join(", ");
+    return {
+      ok: false,
+      error: `Cannot resize this day: ${titles} would fall outside the new window. Reschedule or delete ${
+        orphaned.length === 1 ? "it" : "them"
+      } first.`,
+    };
+  }
+
+  let updated;
+  try {
+    updated = await getRepositories().days.update(input.id, {
+      start,
+      end,
+      startBookings,
+      endBookings,
+    });
+  } catch {
+    return { ok: false, error: "Failed to update day" };
+  }
+
+  if (!updated) {
+    return { ok: false, error: "Day not found" };
+  }
+
+  revalidateDayPaths(existing.eventId);
+  return { ok: true };
+}
+
+export async function deleteDayAction(input: {
+  id: string;
+  eventId: string;
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) {
+    return { ok: false, error: "Unauthorized" };
+  }
+
+  const day = await getRepositories().days.findById(input.id);
+  if (!day) {
+    return { ok: false, error: "Day not found" };
+  }
+
+  try {
+    await getRepositories().days.delete(input.id);
+  } catch {
+    return { ok: false, error: "Failed to delete day" };
+  }
+
+  revalidateDayPaths(day.eventId);
+  return { ok: true };
+}

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -132,19 +132,94 @@ function parseDateTime(value: string | undefined): Date | undefined {
   return isNaN(d.getTime()) ? undefined : d;
 }
 
+type ParsedPhaseDates = {
+  proposalPhaseStart: Date | undefined;
+  proposalPhaseEnd: Date | undefined;
+  votingPhaseStart: Date | undefined;
+  votingPhaseEnd: Date | undefined;
+  schedulingPhaseStart: Date | undefined;
+  schedulingPhaseEnd: Date | undefined;
+};
+
+function validatePhasesInput(
+  input: EventPhasesInput
+): string | ParsedPhaseDates {
+  const fieldDefs: [keyof Omit<EventPhasesInput, "id">, string][] = [
+    ["proposalPhaseStart", "proposal phase start"],
+    ["proposalPhaseEnd", "proposal phase end"],
+    ["votingPhaseStart", "voting phase start"],
+    ["votingPhaseEnd", "voting phase end"],
+    ["schedulingPhaseStart", "scheduling phase start"],
+    ["schedulingPhaseEnd", "scheduling phase end"],
+  ];
+
+  const parsed: Partial<ParsedPhaseDates> = {};
+  for (const [field, label] of fieldDefs) {
+    const raw = input[field]?.trim();
+    if (raw) {
+      const d = parseDateTime(raw);
+      if (d === undefined) return `Invalid ${label}`;
+      parsed[field] = d;
+    } else {
+      parsed[field] = undefined;
+    }
+  }
+
+  const {
+    proposalPhaseStart: pStart,
+    proposalPhaseEnd: pEnd,
+    votingPhaseStart: vStart,
+    votingPhaseEnd: vEnd,
+    schedulingPhaseStart: sStart,
+    schedulingPhaseEnd: sEnd,
+  } = parsed as ParsedPhaseDates;
+
+  if (pStart && pEnd && pEnd <= pStart) {
+    return "Proposal phase end must be after its start";
+  }
+  if (vStart && vEnd && vEnd <= vStart) {
+    return "Voting phase end must be after its start";
+  }
+  if (sStart && sEnd && sEnd <= sStart) {
+    return "Scheduling phase end must be after its start";
+  }
+  if (pEnd && vStart && vStart < pEnd) {
+    return "Voting phase must not start before proposal phase ends";
+  }
+  if (vEnd && sStart && sStart < vEnd) {
+    return "Scheduling phase must not start before voting phase ends";
+  }
+  // A phase without an explicit end implicitly ends when the next phase starts,
+  // so the starts themselves must stay in order.
+  if (pStart && vStart && vStart < pStart) {
+    return "Voting phase must not start before proposal phase starts";
+  }
+  if (vStart && sStart && sStart < vStart) {
+    return "Scheduling phase must not start before voting phase starts";
+  }
+  // When voting is unset, the checks above leave scheduling unconstrained
+  // relative to the proposal phase. Constrain it directly so scheduling can
+  // never start before the proposal phase starts or ends.
+  if (pStart && sStart && sStart < pStart) {
+    return "Scheduling phase must not start before proposal phase starts";
+  }
+  if (pEnd && sStart && sStart < pEnd) {
+    return "Scheduling phase must not start before proposal phase ends";
+  }
+  return parsed as ParsedPhaseDates;
+}
+
 export async function updateEventPhasesAction(
   input: EventPhasesInput
 ): Promise<AdminActionResult> {
   if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
 
-  const updated = await getRepositories().events.update(input.id, {
-    proposalPhaseStart: parseDateTime(input.proposalPhaseStart),
-    proposalPhaseEnd: parseDateTime(input.proposalPhaseEnd),
-    votingPhaseStart: parseDateTime(input.votingPhaseStart),
-    votingPhaseEnd: parseDateTime(input.votingPhaseEnd),
-    schedulingPhaseStart: parseDateTime(input.schedulingPhaseStart),
-    schedulingPhaseEnd: parseDateTime(input.schedulingPhaseEnd),
-  });
+  const result = validatePhasesInput(input);
+  if (typeof result === "string") {
+    return { ok: false, error: result };
+  }
+
+  const updated = await getRepositories().events.update(input.id, result);
   if (!updated) return { ok: false, error: "Event not found" };
 
   revalidatePath("/admin");

--- a/app/actions/admin-guest-events.ts
+++ b/app/actions/admin-guest-events.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import type { AdminActionResult } from "./admin-guests";
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+function revalidateEventPaths(eventId: string) {
+  revalidatePath("/admin");
+  revalidatePath("/admin/events");
+  revalidatePath(`/admin/events/${eventId}`);
+}
+
+export async function assignGuestsToEventAction(input: {
+  eventId: string;
+  guestIds: string[];
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const event = await getRepositories().events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+
+  for (const guestId of input.guestIds) {
+    const guest = await getRepositories().guests.findById(guestId);
+    if (!guest) return { ok: false, error: "Guest not found" };
+  }
+
+  await getRepositories().guests.assignToEvent(input.eventId, input.guestIds);
+  revalidateEventPaths(input.eventId);
+  return { ok: true };
+}
+
+export async function removeGuestsFromEventAction(input: {
+  eventId: string;
+  guestIds: string[];
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const event = await getRepositories().events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+
+  await getRepositories().guests.removeFromEvent(input.eventId, input.guestIds);
+  revalidateEventPaths(input.eventId);
+  return { ok: true };
+}

--- a/app/actions/admin-location-events.ts
+++ b/app/actions/admin-location-events.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import type { AdminActionResult } from "./admin-guests";
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+function revalidateEventPaths(eventId: string) {
+  revalidatePath("/admin");
+  revalidatePath("/admin/events");
+  revalidatePath(`/admin/events/${eventId}`);
+  revalidatePath("/admin/locations");
+}
+
+export async function assignLocationsToEventAction(input: {
+  eventId: string;
+  locationIds: string[];
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const { events, locations } = getRepositories();
+  const event = await events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+
+  if (input.locationIds.length > 0) {
+    const existing = await locations.findExistingIds(input.locationIds);
+    if (existing.length !== input.locationIds.length) {
+      return { ok: false, error: "Location not found" };
+    }
+  }
+
+  await locations.assignToEvent(input.eventId, input.locationIds);
+
+  revalidateEventPaths(input.eventId);
+  return { ok: true };
+}
+
+export async function removeLocationsFromEventAction(input: {
+  eventId: string;
+  locationIds: string[];
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const { events, locations } = getRepositories();
+  const event = await events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+
+  await locations.removeFromEvent(input.eventId, input.locationIds);
+
+  revalidateEventPaths(input.eventId);
+  return { ok: true };
+}

--- a/app/admin/events/[id]/event-days-manager.tsx
+++ b/app/admin/events/[id]/event-days-manager.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/app/input";
+import {
+  createDayAction,
+  updateDayAction,
+  deleteDayAction,
+  type DayInput,
+} from "@/app/actions/admin-days";
+import {
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+  DANGER_BUTTON,
+} from "@/app/admin/buttons";
+
+// Dates are pre-serialized to ISO strings in the server component to avoid
+// any RSC Date serialization ambiguity (Day.start is Date on server, but
+// string after the RSC wire-format round-trip in some Next.js versions).
+export type SerializedDay = {
+  id: string;
+  eventId?: string | null;
+  start: string;
+  end: string;
+  startBookings: string;
+  endBookings: string;
+  // Titles of scheduled sessions overlapping this day's window — i.e. the
+  // sessions that deleting the day will also delete.
+  affectedSessionTitles: string[];
+};
+
+const EMPTY_FORM: Omit<DayInput, "eventId"> = {
+  start: "",
+  end: "",
+  startBookings: "",
+  endBookings: "",
+};
+
+function AddDayForm({
+  eventId,
+  onError,
+}: {
+  eventId: string;
+  onError: (e: string | null) => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [form, setFormState] = useState<Omit<DayInput, "eventId">>(EMPTY_FORM);
+  const [isPending, startTransition] = useTransition();
+
+  const set = (key: keyof typeof EMPTY_FORM, value: string) =>
+    setFormState((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    startTransition(async () => {
+      try {
+        const result = await createDayAction({ eventId, ...form });
+        if (!result.ok) {
+          onError(result.error);
+        } else {
+          onError(null);
+          setFormState(EMPTY_FORM);
+          setOpen(false);
+          router.refresh();
+        }
+      } catch {
+        onError("Request failed");
+      }
+    });
+  };
+
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)} className={PRIMARY_BUTTON}>
+        Add day
+      </button>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3 border border-gray-200 rounded-md p-4"
+    >
+      <h3 className="font-medium text-gray-900">New day</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="day-start" className="text-sm text-gray-600">
+            Start *
+          </label>
+          <Input
+            id="day-start"
+            type="datetime-local"
+            value={form.start}
+            onChange={(e) => set("start", e.target.value)}
+            required
+            className="w-full h-10"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="day-end" className="text-sm text-gray-600">
+            End *
+          </label>
+          <Input
+            id="day-end"
+            type="datetime-local"
+            value={form.end}
+            onChange={(e) => set("end", e.target.value)}
+            required
+            className="w-full h-10"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="day-sb" className="text-sm text-gray-600">
+            Bookings open *
+          </label>
+          <Input
+            id="day-sb"
+            type="datetime-local"
+            value={form.startBookings}
+            onChange={(e) => set("startBookings", e.target.value)}
+            required
+            className="w-full h-10"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor="day-eb" className="text-sm text-gray-600">
+            Bookings close *
+          </label>
+          <Input
+            id="day-eb"
+            type="datetime-local"
+            value={form.endBookings}
+            onChange={(e) => set("endBookings", e.target.value)}
+            required
+            className="w-full h-10"
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button type="submit" disabled={isPending} className={PRIMARY_BUTTON}>
+          {isPending ? "Adding..." : "Add day"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            onError(null);
+          }}
+          disabled={isPending}
+          className={SECONDARY_BUTTON}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function DayRow({
+  day,
+  eventId,
+  onError,
+}: {
+  day: SerializedDay;
+  eventId: string;
+  onError: (e: string | null) => void;
+}) {
+  const router = useRouter();
+  const [editMode, setEditMode] = useState(false);
+  const [deleteMode, setDeleteMode] = useState(false);
+  const [form, setFormState] = useState<Omit<DayInput, "eventId">>({
+    start: day.start.slice(0, 16),
+    end: day.end.slice(0, 16),
+    startBookings: day.startBookings.slice(0, 16),
+    endBookings: day.endBookings.slice(0, 16),
+  });
+  const [isSaving, startSave] = useTransition();
+  const [isDeleting, startDelete] = useTransition();
+
+  const set = (key: keyof Omit<DayInput, "eventId">, value: string) =>
+    setFormState((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    startSave(async () => {
+      try {
+        const result = await updateDayAction({ id: day.id, eventId, ...form });
+        if (!result.ok) {
+          onError(result.error);
+        } else {
+          onError(null);
+          setEditMode(false);
+          router.refresh();
+        }
+      } catch {
+        onError("Request failed");
+      }
+    });
+  };
+
+  const handleDelete = () => {
+    startDelete(async () => {
+      try {
+        const result = await deleteDayAction({ id: day.id, eventId });
+        if (!result.ok) {
+          onError(result.error);
+        } else {
+          onError(null);
+          router.refresh();
+        }
+      } catch {
+        onError("Request failed");
+      }
+    });
+  };
+
+  const label = `${day.start.slice(0, 16)} – ${day.end.slice(0, 16)} UTC`;
+
+  if (deleteMode) {
+    const affected = day.affectedSessionTitles;
+    return (
+      <li className="py-3 space-y-2">
+        <p className="text-sm text-gray-700">{label}</p>
+        <p className="text-sm text-red-700">
+          {affected.length === 0
+            ? "Delete this day? No scheduled sessions fall within its time window."
+            : `Delete this day? The following ${
+                affected.length === 1
+                  ? "session"
+                  : `${affected.length} sessions`
+              } scheduled within its time window will also be deleted:`}
+        </p>
+        {affected.length > 0 && (
+          <ul className="list-disc list-inside text-sm text-red-700">
+            {affected.map((title, i) => (
+              <li key={`${title}-${i}`}>{title}</li>
+            ))}
+          </ul>
+        )}
+        <div className="flex gap-2">
+          <button
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className={DANGER_BUTTON}
+          >
+            {isDeleting ? "Deleting..." : "Confirm delete"}
+          </button>
+          <button
+            onClick={() => setDeleteMode(false)}
+            disabled={isDeleting}
+            className={SECONDARY_BUTTON}
+          >
+            Cancel
+          </button>
+        </div>
+      </li>
+    );
+  }
+
+  if (editMode) {
+    return (
+      <li className="py-3">
+        <form onSubmit={handleSave} className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor={`day-start-${day.id}`}
+                className="text-sm text-gray-600"
+              >
+                Start *
+              </label>
+              <Input
+                id={`day-start-${day.id}`}
+                type="datetime-local"
+                value={form.start}
+                onChange={(e) => set("start", e.target.value)}
+                required
+                className="w-full h-10"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor={`day-end-${day.id}`}
+                className="text-sm text-gray-600"
+              >
+                End *
+              </label>
+              <Input
+                id={`day-end-${day.id}`}
+                type="datetime-local"
+                value={form.end}
+                onChange={(e) => set("end", e.target.value)}
+                required
+                className="w-full h-10"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor={`day-sb-${day.id}`}
+                className="text-sm text-gray-600"
+              >
+                Bookings open *
+              </label>
+              <Input
+                id={`day-sb-${day.id}`}
+                type="datetime-local"
+                value={form.startBookings}
+                onChange={(e) => set("startBookings", e.target.value)}
+                required
+                className="w-full h-10"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor={`day-eb-${day.id}`}
+                className="text-sm text-gray-600"
+              >
+                Bookings close *
+              </label>
+              <Input
+                id={`day-eb-${day.id}`}
+                type="datetime-local"
+                value={form.endBookings}
+                onChange={(e) => set("endBookings", e.target.value)}
+                required
+                className="w-full h-10"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className={PRIMARY_BUTTON}
+            >
+              {isSaving ? "Saving..." : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditMode(false)}
+              disabled={isSaving}
+              className={SECONDARY_BUTTON}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </li>
+    );
+  }
+
+  return (
+    <li className="py-3 flex items-center justify-between gap-3">
+      <p className="text-sm text-gray-700">{label}</p>
+      <div className="flex gap-2 shrink-0">
+        <button
+          onClick={() => setEditMode(true)}
+          className={SECONDARY_BUTTON}
+          aria-label={`Edit day ${label}`}
+        >
+          Edit
+        </button>
+        <button
+          onClick={() => setDeleteMode(true)}
+          className={DANGER_BUTTON}
+          aria-label={`Delete day ${label}`}
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export function EventDaysManager({
+  days,
+  eventId,
+}: {
+  days: SerializedDay[];
+  eventId: string;
+}) {
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <section aria-label="Days" className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Days</h2>
+      <p className="text-sm text-gray-500">All times are UTC.</p>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {days.length > 0 && (
+        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+          {days.map((day) => (
+            <DayRow
+              key={day.id}
+              day={day}
+              eventId={eventId}
+              onError={setError}
+            />
+          ))}
+        </ul>
+      )}
+
+      <AddDayForm eventId={eventId} onError={setError} />
+    </section>
+  );
+}

--- a/app/admin/events/[id]/event-guests-manager.tsx
+++ b/app/admin/events/[id]/event-guests-manager.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  assignGuestsToEventAction,
+  removeGuestsFromEventAction,
+} from "@/app/actions/admin-guest-events";
+
+export type GuestRow = {
+  id: string;
+  name: string;
+  email: string;
+  assigned: boolean;
+};
+
+type Filter = "all" | "assigned" | "not-assigned";
+
+const FILTER_LABEL: Record<Filter, string> = {
+  all: "All",
+  assigned: "Assigned",
+  "not-assigned": "Not assigned",
+};
+
+export function EventGuestsManager({
+  guests,
+  eventId,
+}: {
+  guests: GuestRow[];
+  eventId: string;
+}) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<Filter>("all");
+  // Tracks which guest IDs have a pending toggle so we can disable the checkbox.
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const handleToggle = (guestId: string, currentlyAssigned: boolean) => {
+    setPendingIds((prev) => new Set([...prev, guestId]));
+    setError(null);
+
+    startTransition(async () => {
+      const action = currentlyAssigned
+        ? removeGuestsFromEventAction
+        : assignGuestsToEventAction;
+      try {
+        const result = await action({ eventId, guestIds: [guestId] });
+        if (!result.ok) {
+          setError(result.error);
+        } else {
+          router.refresh();
+        }
+      } catch {
+        setError("Request failed");
+      } finally {
+        setPendingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(guestId);
+          return next;
+        });
+      }
+    });
+  };
+
+  const visible = guests.filter((g) => {
+    if (filter === "assigned") return g.assigned;
+    if (filter === "not-assigned") return !g.assigned;
+    return true;
+  });
+
+  return (
+    <section aria-label="Guests" className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Guests</h2>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex gap-2">
+        {(["all", "assigned", "not-assigned"] as Filter[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 text-sm rounded-md border ${
+              filter === f
+                ? "bg-gray-900 text-white border-gray-900"
+                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            {FILTER_LABEL[f]}
+          </button>
+        ))}
+      </div>
+
+      {guests.length === 0 ? (
+        <p className="text-sm text-gray-500">No users yet.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-gray-600">
+              <th className="py-2 pr-4 font-medium">Name</th>
+              <th className="py-2 pr-4 font-medium">Email</th>
+              <th className="py-2 font-medium">Assigned</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((g) => (
+              <tr key={g.id} className="border-b border-gray-100">
+                <td className="py-2 pr-4">{g.name}</td>
+                <td className="py-2 pr-4 text-gray-500">{g.email}</td>
+                <td className="py-2">
+                  <input
+                    type="checkbox"
+                    checked={g.assigned}
+                    disabled={pendingIds.has(g.id)}
+                    aria-label={`Assign ${g.name}`}
+                    onChange={() => handleToggle(g.id, g.assigned)}
+                    className="h-4 w-4 cursor-pointer"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/app/admin/events/[id]/event-locations-manager.tsx
+++ b/app/admin/events/[id]/event-locations-manager.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  assignLocationsToEventAction,
+  removeLocationsFromEventAction,
+} from "@/app/actions/admin-location-events";
+
+export type LocationRow = {
+  id: string;
+  name: string;
+  capacity: number;
+  assigned: boolean;
+};
+
+type Filter = "all" | "assigned" | "not-assigned";
+
+const FILTER_LABEL: Record<Filter, string> = {
+  all: "All",
+  assigned: "Assigned",
+  "not-assigned": "Not assigned",
+};
+
+export function EventLocationsManager({
+  locations,
+  eventId,
+}: {
+  locations: LocationRow[];
+  eventId: string;
+}) {
+  const router = useRouter();
+  const [filter, setFilter] = useState<Filter>("all");
+  // Tracks which location IDs have a pending toggle so we can disable the box.
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const handleToggle = (locationId: string, currentlyAssigned: boolean) => {
+    setPendingIds((prev) => new Set([...prev, locationId]));
+    setError(null);
+
+    startTransition(async () => {
+      const action = currentlyAssigned
+        ? removeLocationsFromEventAction
+        : assignLocationsToEventAction;
+      const result = await action({ eventId, locationIds: [locationId] });
+      setPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(locationId);
+        return next;
+      });
+      if (!result.ok) {
+        setError(result.error);
+      } else {
+        router.refresh();
+      }
+    });
+  };
+
+  const visible = locations.filter((l) => {
+    if (filter === "assigned") return l.assigned;
+    if (filter === "not-assigned") return !l.assigned;
+    return true;
+  });
+
+  return (
+    <section aria-label="Locations" className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Locations</h2>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex gap-2">
+        {(["all", "assigned", "not-assigned"] as Filter[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 text-sm rounded-md border ${
+              filter === f
+                ? "bg-gray-900 text-white border-gray-900"
+                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            {FILTER_LABEL[f]}
+          </button>
+        ))}
+      </div>
+
+      {locations.length === 0 ? (
+        <p className="text-sm text-gray-500">No locations yet.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-gray-600">
+              <th className="py-2 pr-4 font-medium">Name</th>
+              <th className="py-2 pr-4 font-medium">Capacity</th>
+              <th className="py-2 font-medium">Assigned</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((l) => (
+              <tr key={l.id} className="border-b border-gray-100">
+                <td className="py-2 pr-4">{l.name}</td>
+                <td className="py-2 pr-4 text-gray-500">{l.capacity}</td>
+                <td className="py-2">
+                  <input
+                    type="checkbox"
+                    checked={l.assigned}
+                    disabled={pendingIds.has(l.id)}
+                    aria-label={`Assign ${l.name}`}
+                    onChange={() => handleToggle(l.id, l.assigned)}
+                    className="h-4 w-4 cursor-pointer"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/app/admin/events/[id]/event-phases-form.tsx
+++ b/app/admin/events/[id]/event-phases-form.tsx
@@ -51,7 +51,9 @@ export function EventPhasesForm({ event }: { event: Event }) {
     <form onSubmit={handleSave} className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Phases</h2>
       <p className="text-sm text-gray-500">
-        All times are UTC. Leave fields empty to unset a phase.
+        All times are UTC. Leave fields empty to unset a phase. A phase with no
+        end runs until the next phase starts; set an end earlier than the next
+        start to leave an inactive gap.
       </p>
       {saveError && <p className="text-sm text-red-600">{saveError}</p>}
 

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -7,6 +7,10 @@ import { EventDetailForm } from "./event-detail-form";
 import { EventPhasesForm } from "./event-phases-form";
 import { EventDaysManager, type SerializedDay } from "./event-days-manager";
 import { EventGuestsManager, type GuestRow } from "./event-guests-manager";
+import {
+  EventLocationsManager,
+  type LocationRow,
+} from "./event-locations-manager";
 
 export default async function AdminEventDetailPage({
   params,
@@ -29,6 +33,17 @@ export default async function AdminEventDetailPage({
     name: g.name,
     email: g.email,
     assigned: assignedGuestIds.has(g.id),
+  }));
+
+  const allLocations = await repos.locations.list();
+  const assignedLocationIds = new Set(
+    await repos.locations.listLocationIdsByEvent(id)
+  );
+  const locationRows: LocationRow[] = allLocations.map((l) => ({
+    id: l.id,
+    name: l.name,
+    capacity: l.capacity,
+    assigned: assignedLocationIds.has(l.id),
   }));
 
   const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
@@ -62,6 +77,8 @@ export default async function AdminEventDetailPage({
       <EventDaysManager days={days} eventId={id} />
       <hr className="border-gray-200" />
       <EventGuestsManager guests={guestRows} eventId={id} />
+      <hr className="border-gray-200" />
+      <EventLocationsManager locations={locationRows} eventId={id} />
     </div>
   );
 }

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getRepositories } from "@/db/container";
+import { sessionOverlapsWindow } from "@/utils/day-window";
 import { requireAdminPage } from "../../require-admin";
 import { EventDetailForm } from "./event-detail-form";
 import { EventPhasesForm } from "./event-phases-form";
+import { EventDaysManager, type SerializedDay } from "./event-days-manager";
 
 export default async function AdminEventDetailPage({
   params,
@@ -13,8 +15,22 @@ export default async function AdminEventDetailPage({
   await requireAdminPage();
 
   const { id } = await params;
-  const event = await getRepositories().events.findById(id);
+  const repos = getRepositories();
+  const event = await repos.events.findById(id);
   if (!event) notFound();
+
+  const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
+  const days: SerializedDay[] = (await repos.days.listByEvent(id)).map((d) => ({
+    id: d.id,
+    eventId: d.eventId,
+    start: d.start.toISOString(),
+    end: d.end.toISOString(),
+    startBookings: d.startBookings.toISOString(),
+    endBookings: d.endBookings.toISOString(),
+    affectedSessionTitles: scheduledSessions
+      .filter((s) => sessionOverlapsWindow(s, d.start, d.end))
+      .map((s) => s.title),
+  }));
 
   return (
     <div className="w-full max-w-3xl mx-auto space-y-6">
@@ -30,6 +46,8 @@ export default async function AdminEventDetailPage({
       <EventDetailForm event={event} />
       <hr className="border-gray-200" />
       <EventPhasesForm event={event} />
+      <hr className="border-gray-200" />
+      <EventDaysManager days={days} eventId={id} />
     </div>
   );
 }

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -6,6 +6,7 @@ import { requireAdminPage } from "../../require-admin";
 import { EventDetailForm } from "./event-detail-form";
 import { EventPhasesForm } from "./event-phases-form";
 import { EventDaysManager, type SerializedDay } from "./event-days-manager";
+import { EventGuestsManager, type GuestRow } from "./event-guests-manager";
 
 export default async function AdminEventDetailPage({
   params,
@@ -18,6 +19,17 @@ export default async function AdminEventDetailPage({
   const repos = getRepositories();
   const event = await repos.events.findById(id);
   if (!event) notFound();
+
+  const allGuests = await repos.guests.list();
+  const assignedGuestIds = new Set(
+    (await repos.guests.listByEvent(id)).map((g) => g.id)
+  );
+  const guestRows: GuestRow[] = allGuests.map((g) => ({
+    id: g.id,
+    name: g.name,
+    email: g.email,
+    assigned: assignedGuestIds.has(g.id),
+  }));
 
   const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
   const days: SerializedDay[] = (await repos.days.listByEvent(id)).map((d) => ({
@@ -48,6 +60,8 @@ export default async function AdminEventDetailPage({
       <EventPhasesForm event={event} />
       <hr className="border-gray-200" />
       <EventDaysManager days={days} eventId={id} />
+      <hr className="border-gray-200" />
+      <EventGuestsManager guests={guestRows} eventId={id} />
     </div>
   );
 }

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -81,6 +81,8 @@ export interface GuestsRepository {
   update(id: string, data: Omit<Guest, "id">): Promise<Guest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;
+  assignToEvent(eventId: string, guestIds: string[]): Promise<void>;
+  removeFromEvent(eventId: string, guestIds: string[]): Promise<void>;
 }
 
 // ── Locations ─────────────────────────────────────────────────────────────────

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -22,6 +22,12 @@ export interface DaysRepository {
   listByEvent(eventId: string): Promise<Day[]>;
   findById(id: string): Promise<Day | undefined>;
   create(data: Omit<Day, "id">): Promise<Day>;
+  update(
+    id: string,
+    patch: Partial<Omit<Day, "id" | "eventId">>
+  ): Promise<Day | undefined>;
+  /** Deletes the day and every session that overlaps the day's window. */
+  delete(id: string): Promise<void>;
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -114,8 +114,16 @@ export interface LocationsRepository {
   countSessionLinks(id: string): Promise<number>;
   /** IDs of events this location is assigned to. */
   listEventIds(id: string): Promise<string[]>;
+  /** IDs of locations assigned to the given event. */
+  listLocationIdsByEvent(eventId: string): Promise<string[]>;
   /** Replaces the location's event assignments. */
   setEventIds(id: string, eventIds: string[]): Promise<void>;
+  /** Returns the subset of `ids` that exist in the locations table. */
+  findExistingIds(ids: string[]): Promise<string[]>;
+  /** Atomically adds the location to the given events (idempotent). */
+  assignToEvent(eventId: string, locationIds: string[]): Promise<void>;
+  /** Atomically removes the location from the given events. */
+  removeFromEvent(eventId: string, locationIds: string[]): Promise<void>;
   /**
    * Moves the location one position up or down in the sort order.
    * Normalizes sortIndex values to consecutive integers as a side effect.

--- a/db/repositories/sqlite/days.ts
+++ b/db/repositories/sqlite/days.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, gt, isNotNull, lt } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -61,5 +61,62 @@ export class SqliteDaysRepository implements DaysRepository {
       })
       .run();
     return { id, ...data };
+  }
+
+  async update(
+    id: string,
+    patch: Partial<Omit<Day, "id" | "eventId">>
+  ): Promise<Day | undefined> {
+    if (!(await this.findById(id))) {
+      return undefined;
+    }
+
+    const set: Partial<typeof schema.days.$inferInsert> = {};
+    if (patch.start !== undefined) {
+      set.start = patch.start.toISOString();
+    }
+    if (patch.end !== undefined) {
+      set.end = patch.end.toISOString();
+    }
+    if (patch.startBookings !== undefined) {
+      set.startBookings = patch.startBookings.toISOString();
+    }
+    if (patch.endBookings !== undefined) {
+      set.endBookings = patch.endBookings.toISOString();
+    }
+
+    if (Object.keys(set).length > 0) {
+      this.db.update(schema.days).set(set).where(eq(schema.days.id, id)).run();
+    }
+    return this.findById(id);
+  }
+
+  async delete(id: string): Promise<void> {
+    const day = await this.findById(id);
+    if (!day) {
+      return;
+    }
+
+    this.db.transaction((tx) => {
+      // Delete every session that overlaps the day window (start < day.end and
+      // end > day.start), including ones only partially inside it. Sessions
+      // without scheduled times are excluded (null check). Mirrors
+      // sessionOverlapsWindow in utils/day-window.
+      if (day.eventId) {
+        tx.delete(schema.sessions)
+          .where(
+            and(
+              eq(schema.sessions.eventId, day.eventId),
+              isNotNull(schema.sessions.startTime),
+              isNotNull(schema.sessions.endTime),
+              lt(schema.sessions.startTime, day.end.toISOString()),
+              gt(schema.sessions.endTime, day.start.toISOString())
+            )
+          )
+          .run();
+      }
+
+      tx.delete(schema.days).where(eq(schema.days.id, id)).run();
+    });
   }
 }

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -72,6 +72,28 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .run();
     if (result.changes === 0) return undefined;
     return { id, ...data };
+  }
+
+  async assignToEvent(eventId: string, guestIds: string[]): Promise<void> {
+    if (guestIds.length === 0) return;
+    this.db
+      .insert(schema.eventGuests)
+      .values(guestIds.map((guestId) => ({ eventId, guestId })))
+      .onConflictDoNothing()
+      .run();
+  }
+
+  async removeFromEvent(eventId: string, guestIds: string[]): Promise<void> {
+    if (guestIds.length === 0) return;
+    this.db
+      .delete(schema.eventGuests)
+      .where(
+        and(
+          eq(schema.eventGuests.eventId, eventId),
+          inArray(schema.eventGuests.guestId, guestIds)
+        )
+      )
+      .run();
   }
 
   async delete(id: string): Promise<void> {

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -123,6 +123,15 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .map((r) => r.eventId);
   }
 
+  async listLocationIdsByEvent(eventId: string): Promise<string[]> {
+    return this.db
+      .select({ locationId: schema.eventLocations.locationId })
+      .from(schema.eventLocations)
+      .where(eq(schema.eventLocations.eventId, eventId))
+      .all()
+      .map((r) => r.locationId);
+  }
+
   async setEventIds(id: string, eventIds: string[]): Promise<void> {
     this.db.transaction((tx) => {
       tx.delete(schema.eventLocations)
@@ -134,6 +143,38 @@ export class SqliteLocationsRepository implements LocationsRepository {
           .run();
       }
     });
+  }
+
+  async findExistingIds(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+    return this.db
+      .select({ id: schema.locations.id })
+      .from(schema.locations)
+      .where(inArray(schema.locations.id, ids))
+      .all()
+      .map((r) => r.id);
+  }
+
+  async assignToEvent(eventId: string, locationIds: string[]): Promise<void> {
+    if (locationIds.length === 0) return;
+    this.db
+      .insert(schema.eventLocations)
+      .values(locationIds.map((locationId) => ({ eventId, locationId })))
+      .onConflictDoNothing()
+      .run();
+  }
+
+  async removeFromEvent(eventId: string, locationIds: string[]): Promise<void> {
+    if (locationIds.length === 0) return;
+    this.db
+      .delete(schema.eventLocations)
+      .where(
+        and(
+          eq(schema.eventLocations.eventId, eventId),
+          inArray(schema.eventLocations.locationId, locationIds)
+        )
+      )
+      .run();
   }
 
   async move(id: string, direction: "up" | "down"): Promise<boolean> {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -299,6 +299,20 @@ test.describe("Admin UI events", () => {
       page.getByRole("group", { name: "Proposal phase" }).getByLabel("End")
     ).toHaveValue("2026-09-15T17:00");
 
+    // Validation: end before start shows an error
+    await page
+      .getByRole("group", { name: "Proposal phase" })
+      .getByLabel("Start")
+      .fill("2026-09-20T09:00");
+    await page
+      .getByRole("group", { name: "Proposal phase" })
+      .getByLabel("End")
+      .fill("2026-09-01T09:00");
+    await page.getByRole("button", { name: "Save phases" }).click();
+    await expect(
+      page.getByText(/proposal phase end must be after its start/i)
+    ).toBeVisible();
+
     // Clear the phase dates
     await page
       .getByRole("group", { name: "Proposal phase" })

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -333,6 +333,110 @@ test.describe("Admin UI events", () => {
   });
 });
 
+test.describe("Admin UI days", () => {
+  test("can add, edit, and delete days on an event detail page", async ({
+    page,
+  }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+
+    // Create a throwaway event so we never touch seeded events
+    const unique = Date.now();
+    const eventName = `E2E Days ${unique}`;
+    await page.getByRole("button", { name: "New event" }).click();
+    await page.getByLabel("Name *").fill(eventName);
+    await page.getByLabel("Start *").fill("2026-10-01");
+    await page.getByLabel("End *").fill("2026-10-03");
+    await page.getByRole("button", { name: "Create event" }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const daysSection = page.getByRole("region", { name: "Days" });
+
+    // Add a day
+    await daysSection.getByRole("button", { name: "Add day" }).click();
+    await daysSection.getByLabel("Start *").fill("2026-10-01T09:00");
+    await daysSection.getByLabel("End *").fill("2026-10-01T18:00");
+    await daysSection.getByLabel("Bookings open *").fill("2026-10-01T09:00");
+    await daysSection.getByLabel("Bookings close *").fill("2026-10-01T17:30");
+    await daysSection.getByRole("button", { name: "Add day" }).click();
+
+    // router.refresh() re-fetches the server component — wait for the day
+    // to appear in the refreshed list
+    await expect(
+      page.getByRole("region", { name: "Days" }).getByRole("listitem")
+    ).toHaveCount(1);
+
+    // Edit the day — router.refresh() also happens after save
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: /Edit day/ })
+      .click();
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByLabel("End *")
+      .fill("2026-10-01T20:00");
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: "Save" })
+      .click();
+    // Server component refreshes; wait for Days section to re-appear
+    await expect(
+      page.getByRole("region", { name: "Days" }).getByRole("listitem")
+    ).toHaveCount(1);
+
+    // Delete the day
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: /Delete day/ })
+      .click();
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: "Confirm delete" })
+      .click();
+    // Server component refreshes; list should be empty
+    await expect(
+      page.getByRole("region", { name: "Days" }).getByRole("listitem")
+    ).toHaveCount(0);
+
+    // Validation: end before start shows error (no reload — action returns error)
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: "Add day" })
+      .click();
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByLabel("Start *")
+      .fill("2026-10-01T18:00");
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByLabel("End *")
+      .fill("2026-10-01T09:00");
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByLabel("Bookings open *")
+      .fill("2026-10-01T09:00");
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByLabel("Bookings close *")
+      .fill("2026-10-01T17:30");
+    await page
+      .getByRole("region", { name: "Days" })
+      .getByRole("button", { name: "Add day" })
+      .click();
+    await expect(page.getByText(/day end must be after start/i)).toBeVisible();
+
+    // Clean up
+    await page.getByRole("button", { name: "Delete event" }).click();
+    await page.getByLabel("Type the event name to confirm").fill(eventName);
+    await page.getByRole("button", { name: "Confirm delete" }).click();
+    await expect(page).toHaveURL(/\/admin\/events$/);
+  });
+});
+
 async function makeImage(width: number, height: number): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -510,6 +510,80 @@ test.describe("Admin UI guest assignment", () => {
   });
 });
 
+test.describe("Admin UI location assignment", () => {
+  test("can assign and remove locations from an event", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+
+    // Create a throwaway event (seeded locations are linked to seeded events
+    // only, so a fresh event starts with none assigned)
+    const unique = Date.now();
+    const eventName = `E2E Locations ${unique}`;
+    await page.getByRole("button", { name: "New event" }).click();
+    await page.getByLabel("Name *").fill(eventName);
+    await page.getByLabel("Start *").fill("2026-10-01");
+    await page.getByLabel("End *").fill("2026-10-03");
+    await page.getByRole("button", { name: "Create event" }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const locations = page.getByRole("region", { name: "Locations" });
+    await expect(locations).toBeVisible();
+
+    // Seeded locations are shown; none assigned yet
+    const dataRows = locations
+      .getByRole("row")
+      .filter({ hasNot: page.locator("th") });
+    const count = await dataRows.count();
+    expect(count).toBeGreaterThan(0);
+    const firstRow = dataRows.first();
+    await expect(firstRow.getByRole("checkbox")).not.toBeChecked();
+
+    // Assign the first location
+    await firstRow.getByRole("checkbox").click();
+    await expect(firstRow.getByRole("checkbox")).toBeChecked();
+
+    // Navigate away and back — assignment must persist
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    await expect(
+      page
+        .getByRole("region", { name: "Locations" })
+        .getByRole("checkbox", { checked: true })
+    ).toHaveCount(1);
+
+    // Filter: "Assigned" shows exactly 1 row; "Not assigned" hides it
+    const l2 = page.getByRole("region", { name: "Locations" });
+    await l2.getByRole("button", { name: "Assigned", exact: true }).click();
+    await expect(
+      l2.getByRole("row").filter({ hasNot: page.locator("th") })
+    ).toHaveCount(1);
+
+    await l2.getByRole("button", { name: "Not assigned", exact: true }).click();
+    await expect(
+      l2.getByRole("row").filter({ hasNot: page.locator("th") })
+    ).toHaveCount(count - 1);
+
+    // Switch back to All and remove the assignment
+    await l2.getByRole("button", { name: "All", exact: true }).click();
+    await l2.getByRole("checkbox", { checked: true }).click();
+    await expect(l2.getByRole("checkbox", { checked: true })).toHaveCount(0);
+
+    // Clean up
+    await page.getByRole("button", { name: "Delete event" }).click();
+    await page.getByLabel("Type the event name to confirm").fill(eventName);
+    await page.getByRole("button", { name: "Confirm delete" }).click();
+    await expect(page).toHaveURL(/\/admin\/events$/);
+  });
+});
+
 async function makeImage(width: number, height: number): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -437,6 +437,79 @@ test.describe("Admin UI days", () => {
   });
 });
 
+test.describe("Admin UI guest assignment", () => {
+  test("can assign and remove guests from an event", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+
+    // Create a throwaway event
+    const unique = Date.now();
+    const eventName = `E2E Guests ${unique}`;
+    await page.getByRole("button", { name: "New event" }).click();
+    await page.getByLabel("Name *").fill(eventName);
+    await page.getByLabel("Start *").fill("2026-10-01");
+    await page.getByLabel("End *").fill("2026-10-03");
+    await page.getByRole("button", { name: "Create event" }).click();
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const guests = page.getByRole("region", { name: "Guests" });
+    await expect(guests).toBeVisible();
+
+    // Seeded guests are shown; none assigned yet
+    const dataRows = guests
+      .getByRole("row")
+      .filter({ hasNot: page.getByRole("columnheader") });
+    const count = await dataRows.count();
+    expect(count).toBeGreaterThan(0);
+    const firstRow = dataRows.first();
+    await expect(firstRow.getByRole("checkbox")).not.toBeChecked();
+
+    // Assign the first guest — click and wait for server-driven state update
+    await firstRow.getByRole("checkbox").click();
+    await expect(firstRow.getByRole("checkbox")).toBeChecked();
+
+    // Navigate away and back — assignment must persist
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: eventName })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    await expect(
+      page
+        .getByRole("region", { name: "Guests" })
+        .getByRole("checkbox", { checked: true })
+    ).toHaveCount(1);
+
+    // Filter: "Assigned" shows exactly 1 row; "Not assigned" hides it
+    const g2 = page.getByRole("region", { name: "Guests" });
+    await g2.getByRole("button", { name: "Assigned", exact: true }).click();
+    await expect(
+      g2.getByRole("row").filter({ hasNot: page.getByRole("columnheader") })
+    ).toHaveCount(1);
+
+    await g2.getByRole("button", { name: "Not assigned", exact: true }).click();
+    await expect(
+      g2.getByRole("row").filter({ hasNot: page.getByRole("columnheader") })
+    ).toHaveCount(count - 1);
+
+    // Switch back to All and remove the assignment
+    await g2.getByRole("button", { name: "All", exact: true }).click();
+    await g2.getByRole("checkbox", { checked: true }).click();
+    await expect(g2.getByRole("checkbox", { checked: true })).toHaveCount(0);
+
+    // Clean up
+    await page.getByRole("button", { name: "Delete event" }).click();
+    await page.getByLabel("Type the event name to confirm").fill(eventName);
+    await page.getByRole("button", { name: "Confirm delete" }).click();
+    await expect(page).toHaveURL(/\/admin\/events$/);
+  });
+});
+
 async function makeImage(width: number, height: number): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },

--- a/tests/integration/admin-days.test.ts
+++ b/tests/integration/admin-days.test.ts
@@ -1,0 +1,432 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createDay, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import {
+  createDayAction,
+  updateDayAction,
+  deleteDayAction,
+} from "@/app/actions/admin-days";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("days repo", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("update", () => {
+    it("updates day fields", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const newStart = new Date("2026-10-01T08:00:00Z");
+      const updated = await getRepositories().days.update(day.id, {
+        start: newStart,
+      });
+      expect(updated?.start.toISOString()).toBe(newStart.toISOString());
+      const fetched = await getRepositories().days.findById(day.id);
+      expect(fetched?.start.toISOString()).toBe(newStart.toISOString());
+    });
+
+    it("returns undefined for unknown id", async () => {
+      const result = await getRepositories().days.update("no-such-id", {
+        start: new Date(),
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("preserves unpatched fields", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const origEnd = day.end;
+      await getRepositories().days.update(day.id, {
+        start: new Date("2026-10-01T08:00:00Z"),
+      });
+      const fetched = await getRepositories().days.findById(day.id);
+      expect(fetched?.end.toISOString()).toBe(origEnd.toISOString());
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes the day", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      await getRepositories().days.delete(day.id);
+      expect(await getRepositories().days.findById(day.id)).toBeUndefined();
+    });
+
+    it("cascade-deletes sessions within the day window", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      // Session fully within the day window
+      const session = await createSession(event.id);
+      await getRepositories().sessions.update(session.id, {
+        startTime: new Date("2026-10-01T10:00:00Z"),
+        endTime: new Date("2026-10-01T11:00:00Z"),
+      });
+
+      await getRepositories().days.delete(day.id);
+
+      expect(
+        await getRepositories().sessions.findById(session.id)
+      ).toBeUndefined();
+    });
+
+    it("cascade-deletes sessions that only partially overlap the day window", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      // Session starts inside the window but runs past the day end.
+      const session = await createSession(event.id);
+      await getRepositories().sessions.update(session.id, {
+        startTime: new Date("2026-10-01T17:00:00Z"),
+        endTime: new Date("2026-10-01T19:00:00Z"),
+      });
+
+      await getRepositories().days.delete(day.id);
+
+      expect(
+        await getRepositories().sessions.findById(session.id)
+      ).toBeUndefined();
+    });
+
+    it("does not delete sessions outside the day window", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      // Session on a different day
+      const session = await createSession(event.id);
+      await getRepositories().sessions.update(session.id, {
+        startTime: new Date("2026-10-02T10:00:00Z"),
+        endTime: new Date("2026-10-02T11:00:00Z"),
+      });
+
+      await getRepositories().days.delete(day.id);
+
+      expect(
+        await getRepositories().sessions.findById(session.id)
+      ).toBeDefined();
+    });
+
+    it("does not delete sessions without scheduled times", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const session = await createSession(event.id); // no startTime/endTime
+
+      await getRepositories().days.delete(day.id);
+
+      expect(
+        await getRepositories().sessions.findById(session.id)
+      ).toBeDefined();
+    });
+  });
+});
+
+describe("day actions", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("createDayAction", () => {
+    it("creates a day for an event", async () => {
+      const event = await createEvent();
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(result.ok).toBe(true);
+      const days = await getRepositories().days.listByEvent(event.id);
+      expect(days).toHaveLength(1);
+      expect(days[0].start.toISOString()).toBe("2026-10-01T09:00:00.000Z");
+    });
+
+    it("rejects without admin cookie", async () => {
+      cookieJar.clear();
+      const event = await createEvent();
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(!result.ok && result.error).toBe("Unauthorized");
+    });
+
+    it("rejects when end is before start", async () => {
+      const event = await createEvent();
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-01T18:00",
+        end: "2026-10-01T09:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(!result.ok && result.error).toMatch(/end.*after.*start/i);
+    });
+
+    it("rejects when bookings window is outside day window", async () => {
+      const event = await createEvent();
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T08:00",
+        endBookings: "2026-10-01T19:00",
+      });
+      expect(!result.ok && result.error).toMatch(/bookings.*within.*day/i);
+    });
+
+    it("rejects when new day overlaps an existing day", async () => {
+      const event = await createEvent();
+      await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-01T12:00",
+        end: "2026-10-01T20:00",
+        startBookings: "2026-10-01T12:00",
+        endBookings: "2026-10-01T19:00",
+      });
+      expect(!result.ok && result.error).toMatch(/overlap/i);
+    });
+
+    it("allows non-overlapping days for the same event", async () => {
+      const event = await createEvent();
+      await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const result = await createDayAction({
+        eventId: event.id,
+        start: "2026-10-02T09:00",
+        end: "2026-10-02T18:00",
+        startBookings: "2026-10-02T09:00",
+        endBookings: "2026-10-02T17:30",
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("updateDayAction", () => {
+    it("updates a day", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(result.ok).toBe(true);
+      const updated = await getRepositories().days.findById(day.id);
+      expect(updated?.start.toISOString()).toBe("2026-10-01T09:00:00.000Z");
+    });
+
+    it("errors for unknown id", async () => {
+      const event = await createEvent();
+      const result = await updateDayAction({
+        id: "no-such-id",
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(!result.ok && result.error).toBe("Day not found");
+    });
+
+    it("cannot move a day to a different event", async () => {
+      const event1 = await createEvent();
+      const event2 = await createEvent();
+      const day = await createDay(event1.id);
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event2.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T18:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T17:30",
+      });
+      expect(result.ok).toBe(true);
+      const fetched = await getRepositories().days.findById(day.id);
+      expect(fetched?.eventId).toBe(event1.id);
+    });
+
+    it("rejects when updated day overlaps another existing day", async () => {
+      const event = await createEvent();
+      await createDay(event.id, {
+        start: new Date("2026-10-02T09:00:00Z"),
+        end: new Date("2026-10-02T18:00:00Z"),
+      });
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event.id,
+        start: "2026-10-02T12:00",
+        end: "2026-10-02T20:00",
+        startBookings: "2026-10-02T12:00",
+        endBookings: "2026-10-02T19:00",
+      });
+      expect(!result.ok && result.error).toMatch(/overlap/i);
+    });
+
+    it("rejects shrinking a day that would push a scheduled session outside it", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const session = await createSession(event.id, {
+        title: "Outside Session",
+      });
+      await getRepositories().sessions.update(session.id, {
+        startTime: new Date("2026-10-01T16:00:00Z"),
+        endTime: new Date("2026-10-01T17:00:00Z"),
+      });
+
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T12:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T11:30",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(!result.ok && result.error).toMatch(/Outside Session/);
+      // The day must be left untouched.
+      const fetched = await getRepositories().days.findById(day.id);
+      expect(fetched?.end.toISOString()).toBe("2026-10-01T18:00:00.000Z");
+    });
+
+    it("allows resizing a day when its scheduled sessions stay inside it", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const session = await createSession(event.id);
+      await getRepositories().sessions.update(session.id, {
+        startTime: new Date("2026-10-01T10:00:00Z"),
+        endTime: new Date("2026-10-01T11:00:00Z"),
+      });
+
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event.id,
+        start: "2026-10-01T09:00",
+        end: "2026-10-01T12:00",
+        startBookings: "2026-10-01T09:00",
+        endBookings: "2026-10-01T11:30",
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows updating a day without it overlapping itself", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id, {
+        start: new Date("2026-10-01T09:00:00Z"),
+        end: new Date("2026-10-01T18:00:00Z"),
+      });
+      const result = await updateDayAction({
+        id: day.id,
+        eventId: event.id,
+        start: "2026-10-01T08:00",
+        end: "2026-10-01T19:00",
+        startBookings: "2026-10-01T08:00",
+        endBookings: "2026-10-01T18:30",
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("deleteDayAction", () => {
+    it("deletes a day", async () => {
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const result = await deleteDayAction({ id: day.id, eventId: event.id });
+      expect(result.ok).toBe(true);
+      expect(await getRepositories().days.findById(day.id)).toBeUndefined();
+    });
+
+    it("rejects without admin cookie", async () => {
+      cookieJar.clear();
+      const event = await createEvent();
+      const day = await createDay(event.id);
+      const result = await deleteDayAction({ id: day.id, eventId: event.id });
+      expect(!result.ok && result.error).toBe("Unauthorized");
+    });
+
+    it("errors for unknown id", async () => {
+      const event = await createEvent();
+      const result = await deleteDayAction({
+        id: "no-such-id",
+        eventId: event.id,
+      });
+      expect(!result.ok && result.error).toBe("Day not found");
+    });
+  });
+});

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -323,6 +323,137 @@ describe("event actions", () => {
     });
   });
 
+  describe("updateEventPhasesAction validation", () => {
+    it("rejects when phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-15T18:00",
+        proposalPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /proposal.*end.*after.*start/i
+      );
+    });
+
+    it("rejects when voting phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-15T18:00",
+        votingPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(/voting.*end.*after.*start/i);
+    });
+
+    it("rejects when scheduling phase end is before its start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        schedulingPhaseStart: "2026-09-15T18:00",
+        schedulingPhaseEnd: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*end.*after.*start/i
+      );
+    });
+
+    it("rejects when voting start is before proposal end", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        proposalPhaseEnd: "2026-09-20T18:00",
+        votingPhaseStart: "2026-09-10T08:00",
+        votingPhaseEnd: "2026-09-25T18:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /voting.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling start is before voting end", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-01T08:00",
+        votingPhaseEnd: "2026-09-20T18:00",
+        schedulingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*voting/i
+      );
+    });
+
+    it("allows phases without an end date", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows an open-ended proposal phase with a later voting start", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        votingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects when voting starts before proposal starts", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-10T08:00",
+        votingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /voting.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling starts before voting starts", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        votingPhaseStart: "2026-09-10T08:00",
+        schedulingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*voting/i
+      );
+    });
+
+    it("rejects when scheduling starts before proposal ends and voting is unset", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-01T08:00",
+        proposalPhaseEnd: "2026-09-20T18:00",
+        schedulingPhaseStart: "2026-09-10T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*proposal/i
+      );
+    });
+
+    it("rejects when scheduling starts before proposal starts and voting is unset", async () => {
+      const event = await createEvent();
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        proposalPhaseStart: "2026-09-10T08:00",
+        schedulingPhaseStart: "2026-09-01T08:00",
+      });
+      expect(!result.ok && result.error).toMatch(
+        /scheduling.*not.*start.*before.*proposal/i
+      );
+    });
+  });
+
   describe("updateEventPhasesAction", () => {
     it("sets phase dates", async () => {
       const event = await createEvent();

--- a/tests/integration/admin-guest-events.test.ts
+++ b/tests/integration/admin-guest-events.test.ts
@@ -1,0 +1,213 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import {
+  assignGuestsToEventAction,
+  removeGuestsFromEventAction,
+} from "@/app/actions/admin-guest-events";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("guests.assignToEvent / removeFromEvent", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("assigns guests to an event", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const g2 = await createGuest();
+    const repos = getRepositories();
+
+    await repos.guests.assignToEvent(event.id, [g1.id, g2.id]);
+
+    const assigned = await repos.guests.listByEvent(event.id);
+    expect(assigned.map((g) => g.id).sort()).toEqual([g1.id, g2.id].sort());
+  });
+
+  it("is idempotent — re-assigning already-assigned guests does not error", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const repos = getRepositories();
+
+    await repos.guests.assignToEvent(event.id, [g1.id]);
+    await repos.guests.assignToEvent(event.id, [g1.id]); // no error
+
+    const assigned = await repos.guests.listByEvent(event.id);
+    expect(assigned).toHaveLength(1);
+  });
+
+  it("removes guests from an event", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const g2 = await createGuest();
+    const repos = getRepositories();
+
+    await repos.guests.assignToEvent(event.id, [g1.id, g2.id]);
+    await repos.guests.removeFromEvent(event.id, [g1.id]);
+
+    const assigned = await repos.guests.listByEvent(event.id);
+    expect(assigned.map((g) => g.id)).toEqual([g2.id]);
+  });
+
+  it("removeFromEvent is a no-op for unassigned guests", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const repos = getRepositories();
+
+    await repos.guests.removeFromEvent(event.id, [g1.id]); // no error
+    const assigned = await repos.guests.listByEvent(event.id);
+    expect(assigned).toHaveLength(0);
+  });
+});
+
+describe("assignGuestsToEventAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("assigns guests to an event", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const g2 = await createGuest();
+
+    const result = await assignGuestsToEventAction({
+      eventId: event.id,
+      guestIds: [g1.id, g2.id],
+    });
+    expect(result.ok).toBe(true);
+
+    const assigned = await getRepositories().guests.listByEvent(event.id);
+    expect(assigned.map((g) => g.id).sort()).toEqual([g1.id, g2.id].sort());
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    cookieJar.clear();
+
+    const result = await assignGuestsToEventAction({
+      eventId: event.id,
+      guestIds: [g1.id],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+
+  it("errors for unknown event", async () => {
+    const g1 = await createGuest();
+    const result = await assignGuestsToEventAction({
+      eventId: "no-such-event",
+      guestIds: [g1.id],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+  });
+
+  it("errors for unknown guest", async () => {
+    const event = await createEvent();
+    const result = await assignGuestsToEventAction({
+      eventId: event.id,
+      guestIds: ["no-such-guest"],
+    });
+    expect(!result.ok && result.error).toBe("Guest not found");
+  });
+});
+
+describe("removeGuestsFromEventAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("removes guests from an event", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const g2 = await createGuest();
+    const repos = getRepositories();
+    await repos.guests.assignToEvent(event.id, [g1.id, g2.id]);
+
+    const result = await removeGuestsFromEventAction({
+      eventId: event.id,
+      guestIds: [g1.id],
+    });
+    expect(result.ok).toBe(true);
+
+    const assigned = await repos.guests.listByEvent(event.id);
+    expect(assigned.map((g) => g.id)).toEqual([g2.id]);
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    cookieJar.clear();
+
+    const result = await removeGuestsFromEventAction({
+      eventId: event.id,
+      guestIds: [g1.id],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+
+  it("errors for unknown event", async () => {
+    const g1 = await createGuest();
+    const result = await removeGuestsFromEventAction({
+      eventId: "no-such-event",
+      guestIds: [g1.id],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+  });
+});

--- a/tests/integration/admin-location-events.test.ts
+++ b/tests/integration/admin-location-events.test.ts
@@ -1,0 +1,188 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createLocation } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import {
+  assignLocationsToEventAction,
+  removeLocationsFromEventAction,
+} from "@/app/actions/admin-location-events";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("assignLocationsToEventAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("assigns locations to an event", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+    const l2 = await createLocation();
+
+    const result = await assignLocationsToEventAction({
+      eventId: event.id,
+      locationIds: [l1.id, l2.id],
+    });
+    expect(result.ok).toBe(true);
+
+    const repos = getRepositories();
+    expect(await repos.locations.listEventIds(l1.id)).toContain(event.id);
+    expect(await repos.locations.listEventIds(l2.id)).toContain(event.id);
+  });
+
+  it("is idempotent and preserves other event assignments", async () => {
+    const eventA = await createEvent();
+    const eventB = await createEvent();
+    const l1 = await createLocation();
+    const repos = getRepositories();
+    await repos.locations.setEventIds(l1.id, [eventB.id]);
+
+    await assignLocationsToEventAction({
+      eventId: eventA.id,
+      locationIds: [l1.id],
+    });
+    // re-assign — no error, no duplicate
+    await assignLocationsToEventAction({
+      eventId: eventA.id,
+      locationIds: [l1.id],
+    });
+
+    const eventIds = await repos.locations.listEventIds(l1.id);
+    expect(eventIds.sort()).toEqual([eventA.id, eventB.id].sort());
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+    cookieJar.clear();
+
+    const result = await assignLocationsToEventAction({
+      eventId: event.id,
+      locationIds: [l1.id],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+
+  it("errors for unknown event", async () => {
+    const l1 = await createLocation();
+    const result = await assignLocationsToEventAction({
+      eventId: "no-such-event",
+      locationIds: [l1.id],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+  });
+
+  it("errors if any location id does not exist", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+    const result = await assignLocationsToEventAction({
+      eventId: event.id,
+      locationIds: [l1.id, "no-such-location"],
+    });
+    expect(!result.ok && result.error).toBe("Location not found");
+    // ensure nothing was written
+    expect(await getRepositories().locations.listEventIds(l1.id)).toEqual([]);
+  });
+});
+
+describe("removeLocationsFromEventAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("removes locations from an event, leaving other assignments intact", async () => {
+    const eventA = await createEvent();
+    const eventB = await createEvent();
+    const l1 = await createLocation();
+    const repos = getRepositories();
+    await repos.locations.setEventIds(l1.id, [eventA.id, eventB.id]);
+
+    const result = await removeLocationsFromEventAction({
+      eventId: eventA.id,
+      locationIds: [l1.id],
+    });
+    expect(result.ok).toBe(true);
+
+    expect(await repos.locations.listEventIds(l1.id)).toEqual([eventB.id]);
+  });
+
+  it("is a no-op for unassigned locations", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+
+    const result = await removeLocationsFromEventAction({
+      eventId: event.id,
+      locationIds: [l1.id],
+    });
+    expect(result.ok).toBe(true);
+    expect(await getRepositories().locations.listEventIds(l1.id)).toEqual([]);
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+    cookieJar.clear();
+
+    const result = await removeLocationsFromEventAction({
+      eventId: event.id,
+      locationIds: [l1.id],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+
+  it("errors for unknown event", async () => {
+    const l1 = await createLocation();
+    const result = await removeLocationsFromEventAction({
+      eventId: "no-such-event",
+      locationIds: [l1.id],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+  });
+});

--- a/tests/unit/day-window.test.ts
+++ b/tests/unit/day-window.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  sessionOverlapsWindow,
+  sessionContainedInWindow,
+} from "@/utils/day-window";
+
+const winStart = new Date("2026-10-01T09:00:00Z");
+const winEnd = new Date("2026-10-01T18:00:00Z");
+
+describe("sessionOverlapsWindow", () => {
+  it("is true for a fully contained session", () => {
+    const s = {
+      startTime: new Date("2026-10-01T10:00:00Z"),
+      endTime: new Date("2026-10-01T11:00:00Z"),
+    };
+    expect(sessionOverlapsWindow(s, winStart, winEnd)).toBe(true);
+  });
+
+  it("is true for a session that starts inside but ends after the window", () => {
+    const s = {
+      startTime: new Date("2026-10-01T17:00:00Z"),
+      endTime: new Date("2026-10-01T19:00:00Z"),
+    };
+    expect(sessionOverlapsWindow(s, winStart, winEnd)).toBe(true);
+  });
+
+  it("is true for a session that starts before but ends inside the window", () => {
+    const s = {
+      startTime: new Date("2026-10-01T08:00:00Z"),
+      endTime: new Date("2026-10-01T10:00:00Z"),
+    };
+    expect(sessionOverlapsWindow(s, winStart, winEnd)).toBe(true);
+  });
+
+  it("is false for a session entirely outside the window", () => {
+    const s = {
+      startTime: new Date("2026-10-02T10:00:00Z"),
+      endTime: new Date("2026-10-02T11:00:00Z"),
+    };
+    expect(sessionOverlapsWindow(s, winStart, winEnd)).toBe(false);
+  });
+
+  it("is false for an unscheduled session", () => {
+    expect(sessionOverlapsWindow({}, winStart, winEnd)).toBe(false);
+  });
+});
+
+describe("sessionContainedInWindow", () => {
+  it("is true only when start and end both fall within the window", () => {
+    const s = {
+      startTime: new Date("2026-10-01T10:00:00Z"),
+      endTime: new Date("2026-10-01T11:00:00Z"),
+    };
+    expect(sessionContainedInWindow(s, winStart, winEnd)).toBe(true);
+  });
+
+  it("is false for a session that ends after the window", () => {
+    const s = {
+      startTime: new Date("2026-10-01T17:00:00Z"),
+      endTime: new Date("2026-10-01T19:00:00Z"),
+    };
+    expect(sessionContainedInWindow(s, winStart, winEnd)).toBe(false);
+  });
+
+  it("is false for an unscheduled session", () => {
+    expect(sessionContainedInWindow({}, winStart, winEnd)).toBe(false);
+  });
+});

--- a/tests/unit/event-phases.test.ts
+++ b/tests/unit/event-phases.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EventPhase, getCurrentPhase } from "@/app/(site)/utils/events";
+import type { Event } from "@/db/repositories/interfaces";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ago = (days: number) => new Date(Date.now() - days * DAY_MS);
+const ahead = (days: number) => new Date(Date.now() + days * DAY_MS);
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: "e1",
+    name: "Test",
+    description: "",
+    website: "",
+    start: ahead(30),
+    end: ahead(31),
+    maxSessionDuration: 120,
+    breakMinutes: 10,
+    timezone: "UTC",
+    ...overrides,
+  };
+}
+
+describe("getCurrentPhase with implicit phase ends", () => {
+  it("ends an open-ended proposal phase when voting starts", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(3),
+      // no proposalPhaseEnd -> implicitly ends when voting starts
+      votingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.VOTING);
+  });
+
+  it("ends an open-ended voting phase when scheduling starts", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(3),
+      // no votingPhaseEnd -> implicitly ends when scheduling starts
+      schedulingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("falls through to scheduling when voting is unset", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(3),
+      // no proposalPhaseEnd, no voting -> implicit end is scheduling start
+      schedulingPhaseStart: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("keeps an open-ended scheduling phase active (no successor)", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(3),
+      schedulingPhaseStart: ago(1),
+      // no schedulingPhaseEnd -> stays active
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.SCHEDULING);
+  });
+
+  it("respects an explicit gap between phases as INACTIVE", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      proposalPhaseEnd: ago(3),
+      votingPhaseStart: ahead(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.INACTIVE);
+  });
+
+  it("respects an explicit scheduling end as INACTIVE afterwards", () => {
+    const event = makeEvent({
+      proposalPhaseStart: ago(5),
+      votingPhaseStart: ago(4),
+      schedulingPhaseStart: ago(3),
+      schedulingPhaseEnd: ago(1),
+    });
+    expect(getCurrentPhase(event)).toBe(EventPhase.INACTIVE);
+  });
+
+  describe("at the exact boundary instant between touching phases", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("selects the next phase, not the ending one", () => {
+      const now = new Date("2026-06-26T12:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const event = makeEvent({
+        proposalPhaseStart: ago(1),
+        // open-ended -> implicit end equals votingPhaseStart, which is "now"
+        votingPhaseStart: now,
+      });
+
+      expect(getCurrentPhase(event)).toBe(EventPhase.VOTING);
+    });
+  });
+});

--- a/utils/day-window.ts
+++ b/utils/day-window.ts
@@ -1,0 +1,28 @@
+// Predicates relating a scheduled session to a day's time window. Shared so the
+// delete-cascade, the edit guard, and the admin UI warning all agree on which
+// sessions a day window affects.
+
+type ScheduledTimes = {
+  startTime?: Date | null;
+  endTime?: Date | null;
+};
+
+/** True when the session shares any time with [windowStart, windowEnd). */
+export function sessionOverlapsWindow(
+  session: ScheduledTimes,
+  windowStart: Date,
+  windowEnd: Date
+): boolean {
+  if (!session.startTime || !session.endTime) return false;
+  return session.startTime < windowEnd && session.endTime > windowStart;
+}
+
+/** True when the session falls entirely inside [windowStart, windowEnd]. */
+export function sessionContainedInWindow(
+  session: ScheduledTimes,
+  windowStart: Date,
+  windowEnd: Date
+): boolean {
+  if (!session.startTime || !session.endTime) return false;
+  return session.startTime >= windowStart && session.endTime <= windowEnd;
+}


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [3bdada5](https://github.com/LWCW-Europe/schellingboard/pull/483/commits/3bdada5d1cdd7ddf63c1db440ad416b080f038c9).

PRs:
* ➡️ #483 (this PR, depends on the ones below ⬇️)
* #479
* #478
* #477

---

## Description

Event-side locations manager mirroring the guests manager: filterable
table of all global locations with an assigned toggle.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

issue #368

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=3bdada5d1cdd7ddf63c1db440ad416b080f038c9 -->