### PR TITLE
refactor: move DB seed script from tests/e2e to scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ dev-migrate-create: install
 	bun set-env.ts dev bun x drizzle-kit generate
 
 dev-db-seed: install
-	bun set-env.ts dev bun x tsx tests/e2e/reset-database.ts
+	bun set-env.ts dev bun x tsx scripts/seed-database.ts
 
 dev-admin: install
 	bun set-env.ts dev bun x tsx scripts/admin.ts

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -48,7 +48,7 @@ function openDb() {
   sqlite.pragma("foreign_keys = ON");
   const migrationsFolder = path.join(
     path.dirname(fileURLToPath(import.meta.url)),
-    "../../drizzle"
+    "../drizzle"
   );
   runMigrations(sqlite, migrationsFolder);
   return drizzle(sqlite, { schema });

--- a/tests/e2e/init.ts
+++ b/tests/e2e/init.ts
@@ -1,4 +1,4 @@
-import { resetDatabase } from "./reset-database";
+import { resetDatabase } from "@/scripts/seed-database";
 
 function globalSetup() {
   console.log("🚀 Setting up test environment...");


### PR DESCRIPTION
The seed script doubles as a dev tool (make dev-db-seed), so scripts/
alongside admin.ts and run-migrations.ts is a more fitting home than
tests/e2e. E2E tests still consume it via the @/ alias.