### PR TITLE
dev: gate standalone output behind env var to silence next start warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY . .
 # Pass via --build-arg APP_VERSION=$(git describe --tags --always --dirty)
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
+ENV BUILD_STANDALONE=1
 RUN bun x next build && \
     bun build --target=node --external better-sqlite3 --external bindings \
         scripts/admin.ts --outfile=.next/standalone/scripts/admin.js && \

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,10 @@ function getAppVersion() {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
+  // Standalone output is only used by the Docker production image
+  // (`node server.js`). `next start` can't serve it and warns, so we gate it
+  // behind an env var the Dockerfile sets and leave it off for local/e2e builds.
+  ...(process.env.BUILD_STANDALONE === "1" ? { output: "standalone" } : {}),
   experimental: {
     serverActions: {
       bodySizeLimit: "5mb",


### PR DESCRIPTION
This commit gets rid of the following warning which appeared when running 'make
test-e2e':

    [WebServer] ⚠ "next start" does not work with "output: standalone"
    configuration. Use "node .next/standalone/server.js" instead.

"output: standalone" was set unconditionally, but next start (used by the
Playwright e2e webServer) can't serve the standalone bundle and warns. Standalone
output is only needed by the Docker image (node server.js), so gate it behind
BUILD_STANDALONE, which the Dockerfile sets, and leave it off for local/e2e builds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- jip:pushed-commit=7b1f24a08669be4c15c22a67bfab78a2fa735cd9 -->