### PR TITLE
feat: add RSVP moderation to event detail sessions

### DIFF
--- a/app/actions/admin-rsvps.ts
+++ b/app/actions/admin-rsvps.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import type { AdminActionResult } from "./admin-guests";
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+export async function adminRemoveRsvpAction(input: {
+  sessionId: string;
+  guestId: string;
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const { sessions, rsvps } = getRepositories();
+  const session = await sessions.findById(input.sessionId);
+  if (!session) return { ok: false, error: "Session not found" };
+
+  await rsvps.deleteBySessionAndGuest(input.sessionId, input.guestId);
+
+  revalidatePath("/admin");
+  revalidatePath("/admin/events");
+  revalidatePath(`/admin/events/${session.eventId}`);
+  return { ok: true };
+}

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -7,6 +7,7 @@ import {
   adminUpdateSessionAction,
   adminDeleteSessionAction,
 } from "@/app/actions/admin-sessions";
+import { adminRemoveRsvpAction } from "@/app/actions/admin-rsvps";
 import {
   PRIMARY_BUTTON,
   SECONDARY_BUTTON,
@@ -26,6 +27,7 @@ export type SessionRow = {
   hosts: { id: string; name: string }[];
   locations: { id: string; name: string }[];
   numRsvps: number;
+  rsvps: { guestId: string; name: string }[];
 };
 
 export type EventGuest = { id: string; name: string };
@@ -52,6 +54,91 @@ function flagLabels(session: SessionRow): string[] {
 // so append "Z" before sending to the server; empty means "not scheduled".
 function toIsoOrNull(value: string): string | null {
   return value.trim() === "" ? null : `${value}Z`;
+}
+
+function SessionRsvps({
+  session,
+  onError,
+}: {
+  session: SessionRow;
+  onError: (e: string | null) => void;
+}) {
+  const router = useRouter();
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const remove = (guestId: string) => {
+    setPendingId(guestId);
+    startTransition(async () => {
+      try {
+        const result = await adminRemoveRsvpAction({
+          sessionId: session.id,
+          guestId,
+        });
+        if (!result.ok) {
+          onError(result.error);
+        } else {
+          onError(null);
+          router.refresh();
+        }
+      } catch {
+        onError("Request failed");
+      } finally {
+        setPendingId(null);
+        setConfirmingId(null);
+      }
+    });
+  };
+
+  return (
+    <details className="text-sm">
+      <summary className="cursor-pointer text-gray-600">
+        RSVPs ({session.rsvps.length})
+      </summary>
+      {session.rsvps.length === 0 ? (
+        <p className="mt-2 text-gray-500">No RSVPs.</p>
+      ) : (
+        <ul className="mt-2 space-y-1">
+          {session.rsvps.map((r) => (
+            <li
+              key={r.guestId}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-gray-700">{r.name}</span>
+              {confirmingId === r.guestId ? (
+                <span className="flex items-center gap-2">
+                  <span className="text-red-700">Remove?</span>
+                  <button
+                    onClick={() => remove(r.guestId)}
+                    disabled={pendingId === r.guestId}
+                    className="text-red-600 hover:underline"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setConfirmingId(null)}
+                    disabled={pendingId === r.guestId}
+                    className="text-gray-500 hover:underline"
+                  >
+                    Cancel
+                  </button>
+                </span>
+              ) : (
+                <button
+                  onClick={() => setConfirmingId(r.guestId)}
+                  className="text-red-600 hover:underline"
+                  aria-label={`Remove RSVP ${r.name}`}
+                >
+                  Remove
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </details>
+  );
 }
 
 function SessionItem({
@@ -212,35 +299,38 @@ function SessionItem({
 
   if (!editMode) {
     return (
-      <li className="py-3 flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <p className="font-medium text-gray-900">{session.title}</p>
-          <p className="text-sm text-gray-500">
-            {timeLabel(session)} · {joinNames(session.locations)}
-          </p>
-          <p className="text-sm text-gray-500">
-            Hosts: {joinNames(session.hosts)} · {session.numRsvps} RSVPs
-            {flagLabels(session).length > 0
-              ? ` · ${flagLabels(session).join(", ")}`
-              : ""}
-          </p>
+      <li className="py-3 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="font-medium text-gray-900">{session.title}</p>
+            <p className="text-sm text-gray-500">
+              {timeLabel(session)} · {joinNames(session.locations)}
+            </p>
+            <p className="text-sm text-gray-500">
+              Hosts: {joinNames(session.hosts)} · {session.numRsvps} RSVPs
+              {flagLabels(session).length > 0
+                ? ` · ${flagLabels(session).join(", ")}`
+                : ""}
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={() => setEditMode(true)}
+              className={SECONDARY_BUTTON}
+              aria-label={`Edit ${session.title}`}
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => setDeleteMode(true)}
+              className={DANGER_BUTTON}
+              aria-label={`Delete ${session.title}`}
+            >
+              Delete
+            </button>
+          </div>
         </div>
-        <div className="flex gap-2 shrink-0">
-          <button
-            onClick={() => setEditMode(true)}
-            className={SECONDARY_BUTTON}
-            aria-label={`Edit ${session.title}`}
-          >
-            Edit
-          </button>
-          <button
-            onClick={() => setDeleteMode(true)}
-            className={DANGER_BUTTON}
-            aria-label={`Delete ${session.title}`}
-          >
-            Delete
-          </button>
-        </div>
+        <SessionRsvps session={session} onError={onError} />
       </li>
     );
   }

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -75,8 +75,9 @@ export default async function AdminEventDetailPage({
     .filter((l) => l.assigned)
     .map((l) => ({ id: l.id, name: l.name }));
 
-  const sessionRows: SessionRow[] = (await repos.sessions.listByEvent(id)).map(
-    (s) => ({
+  const guestNameById = new Map(allGuests.map((g) => [g.id, g.name]));
+  const sessionRows: SessionRow[] = await Promise.all(
+    (await repos.sessions.listByEvent(id)).map(async (s) => ({
       id: s.id,
       title: s.title,
       description: s.description,
@@ -89,7 +90,11 @@ export default async function AdminEventDetailPage({
       hosts: s.hosts.map((h) => ({ id: h.id, name: h.name })),
       locations: s.locations.map((l) => ({ id: l.id, name: l.name })),
       numRsvps: s.numRsvps,
-    })
+      rsvps: (await repos.rsvps.listBySession(s.id)).map((r) => ({
+        guestId: r.guestId,
+        name: guestNameById.get(r.guestId) ?? "Unknown guest",
+      })),
+    }))
   );
   const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
   const days: SerializedDay[] = (await repos.days.listByEvent(id)).map((d) => ({

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -1152,8 +1152,9 @@ function seedTestData() {
 
   // RSVPs (Conference Gamma only — the server rejects RSVP changes outside
   // the scheduling phase). Guests skip sessions they host and sessions
-  // overlapping one they already RSVP'd to. Bob Test never RSVPs the Opening
-  // Keynote: rsvp.spec.ts uses it as his clean "no prior RSVP" target.
+  // overlapping one they already RSVP'd to. Bob Test and Yuki Tanaka never
+  // RSVP the Opening Keynote: rsvp.spec.ts (Bob) and the admin RSVP-moderation
+  // test (Yuki) use it as their clean "no prior RSVP" target.
   console.log("  🙋 Creating test RSVPs...");
   type SessionRow = (typeof sessionRows)[number];
   const overlaps = (a: SessionRow, b: SessionRow) =>
@@ -1172,7 +1173,12 @@ function seedTestData() {
     );
     for (const session of rsvpTargets) {
       const isKeynote = session.title.startsWith("Opening Keynote");
-      if (isKeynote && guest.name === "Bob Test") continue;
+      if (
+        isKeynote &&
+        (guest.name === "Bob Test" || guest.name === "Yuki Tanaka")
+      ) {
+        continue;
+      }
       if (busy.some((b) => b.id === session.id || overlaps(b, session))) {
         continue;
       }

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -821,6 +821,49 @@ test.describe("Admin UI sessions", () => {
       sessions.getByRole("listitem").filter({ hasText: title })
     ).toHaveCount(0);
   });
+
+  test("removes an RSVP from a session via standard confirm", async ({
+    page,
+  }) => {
+    // Create the RSVP to remove through the public UI first. Yuki Tanaka is
+    // guaranteed a clean "no prior RSVP" state on the keynote by the seed and
+    // is used by no other spec (Bob Test's keynote slot belongs to
+    // rsvp.spec.ts).
+    await loginAndGoto(page, "/Conference-Gamma");
+    await page.getByLabel("My name is:").click();
+    await page.keyboard.type("Yuki Tanaka");
+    await page.getByRole("option", { name: /Yuki Tanaka/i }).click();
+    await page
+      .getByRole("link", { name: /Opening Keynote/ })
+      .first()
+      .click();
+    const dialog = page.getByRole("dialog", { name: "Session details" });
+    await dialog.getByRole("button", { name: "RSVP", exact: true }).click();
+    await expect(dialog.getByRole("button", { name: "Un-RSVP" })).toBeVisible();
+
+    // Remove it again as admin
+    await adminLogin(page);
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Conference Gamma" })
+      .getByRole("link", { name: "Manage" })
+      .click();
+
+    const sessions = page.getByRole("region", { name: "Sessions" });
+    const row = sessions
+      .getByRole("listitem")
+      .filter({ hasText: "Opening Keynote - Conference Gamma" });
+    await expect(row).toBeVisible();
+
+    // Expand the RSVPs disclosure and remove Yuki Tanaka
+    await row.getByText(/^RSVPs \(/).click();
+    await expect(row.getByText("Yuki Tanaka")).toBeVisible();
+    await row.getByRole("button", { name: "Remove RSVP Yuki Tanaka" }).click();
+    await row.getByRole("button", { name: "Confirm" }).click();
+
+    await expect(row.getByText("Yuki Tanaka")).toHaveCount(0);
+  });
 });
 
 async function makeImage(width: number, height: number): Promise<Buffer> {

--- a/tests/integration/admin-rsvps.test.ts
+++ b/tests/integration/admin-rsvps.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { adminRemoveRsvpAction } from "@/app/actions/admin-rsvps";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("adminRemoveRsvpAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("removes a single RSVP, leaving others intact", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const g1 = await createGuest({ name: "Attendee One" });
+    const g2 = await createGuest({ name: "Attendee Two" });
+    const session = await createSession(event.id);
+    await repos.rsvps.create({ sessionId: session.id, guestId: g1.id });
+    await repos.rsvps.create({ sessionId: session.id, guestId: g2.id });
+
+    const result = await adminRemoveRsvpAction({
+      sessionId: session.id,
+      guestId: g1.id,
+    });
+    expect(result.ok).toBe(true);
+
+    const remaining = await repos.rsvps.listBySession(session.id);
+    expect(remaining.map((r) => r.guestId)).toEqual([g2.id]);
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    const guest = await createGuest();
+    const session = await createSession(event.id);
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+    cookieJar.clear();
+
+    const result = await adminRemoveRsvpAction({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+
+  it("errors for an unknown session", async () => {
+    const result = await adminRemoveRsvpAction({
+      sessionId: "no-such-session",
+      guestId: "whoever",
+    });
+    expect(!result.ok && result.error).toBe("Session not found");
+  });
+});


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [e292235](https://github.com/LWCW-Europe/schellingboard/pull/492/commits/e2922359d2b335657a4d11d06dba187dd9a7f48b).

PRs:
* #527
* #526
* #525
* #497
* #496
* #495
* #494
* #493
* ➡️ #492 (this PR, base of the stack — can be merged first)

---

## Description

List a session's RSVPs and remove individual ones via standard confirm.
Reset pending/confirming state in a finally block so a failed remove
doesn't leave the controls stuck disabled.
Part of issue #368.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=e2922359d2b335657a4d11d06dba187dd9a7f48b -->