### PR TITLE
fix: Suppress hydration warnings

### DIFF
--- a/app/admin/events/events-manager.tsx
+++ b/app/admin/events/events-manager.tsx
@@ -6,6 +6,12 @@ import { Input } from "@/app/input";
 import type { Event } from "@/db/repositories/interfaces";
 import { createEventAction, type EventInput } from "@/app/actions/admin-events";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/admin/buttons";
+import dynamic from "next/dynamic";
+
+const ClientTimestamp = dynamic(
+  () => import("@/app/client-only/ClientTimestamp"),
+  { ssr: false }
+);
 
 const DEFAULT_FORM: EventInput = {
   name: "",
@@ -195,8 +201,8 @@ export function EventsManager({ events }: { events: Event[] }) {
                   {event.name}
                 </p>
                 <p className="text-sm text-gray-500">
-                  {event.start.toLocaleDateString()} –{" "}
-                  {event.end.toLocaleDateString()}
+                  <ClientTimestamp timestamp={event.start} /> –{" "}
+                  <ClientTimestamp timestamp={event.end} />
                   {" · "}
                   {event.timezone}
                 </p>

--- a/app/client-only/ClientTimestamp.tsx
+++ b/app/client-only/ClientTimestamp.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function ClientTimestamp({ timestamp }: { timestamp: Date }) {
+  return (
+    <time dateTime={timestamp.toISOString()}>
+      {timestamp.toLocaleDateString()}
+    </time>
+  );
+}


### PR DESCRIPTION
`toLocaleDateString` may cause hydration warnings if the client has a different locale from the server. This ~suppresses~ circumvents these warnings using dynamic importing

fixes #498