### PR TITLE
feat: add support for avatars in profiles

### DIFF
--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -54,7 +54,7 @@ export default async function GuestProfilePage(props: {
       </div>
 
       <header className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <Avatar name={guest.name} />
+        <Avatar name={guest.name} image={guest.avatarUrl ?? undefined} />
         <div className="flex flex-col gap-2">
           <h1 className="text-3xl font-bold">{guest.name}</h1>
           {isSessionHost && (

--- a/app/(site)/guests/avatar.tsx
+++ b/app/(site)/guests/avatar.tsx
@@ -1,4 +1,6 @@
 import clsx from "clsx";
+import { DragEventHandler, MouseEventHandler } from "react";
+import Image from "next/image";
 
 function initials(name: string): string {
   return name
@@ -10,16 +12,23 @@ function initials(name: string): string {
 }
 
 /**
- * Renders a placeholder avatar showing the guest's initials. Uploaded avatar
- * images are not supported yet; this is the fallback that will remain visible
- * until a real avatar exists.
+ * Renders the user-uploaded avatar image or a placeholder avatar showing
+ * the guest's initials as a fallback.
  */
 export function Avatar({
+  className,
   name,
   size = "lg",
+  image,
+  onDrop,
+  onClick,
 }: {
+  className?: string;
   name: string;
   size?: "lg" | "sm";
+  image?: string;
+  onDrop?: DragEventHandler<HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLDivElement>;
 }) {
   const dimensions = size === "lg" ? "h-28 w-28 text-3xl" : "h-12 w-12 text-sm";
 
@@ -27,11 +36,24 @@ export function Avatar({
     <div
       aria-hidden="true"
       className={clsx(
+        className,
         dimensions,
-        "shrink-0 rounded-full bg-rose-100 text-rose-600 font-semibold flex items-center justify-center"
+        "shrink-0 rounded-full bg-rose-100 text-rose-600 font-semibold flex items-center justify-center overflow-hidden"
       )}
+      onClick={onClick}
+      onDrop={onDrop}
     >
-      {initials(name) || "?"}
+      {image ? (
+        <Image
+          className="w-full h-full object-cover"
+          src={image}
+          alt={`Profile avatar of ${name}`}
+          width="256"
+          height="256"
+        />
+      ) : (
+        initials(name) || "?"
+      )}
     </div>
   );
 }

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, type SyntheticEvent } from "react";
+import {
+  useState,
+  type SyntheticEvent,
+  useRef,
+  useEffect,
+  useMemo,
+  ButtonHTMLAttributes,
+} from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -8,6 +15,8 @@ import { Input } from "@/app/input";
 import { updateProfileAction } from "@/app/actions/profile";
 import { Avatar } from "../avatar";
 import type { Guest } from "@/db/repositories/interfaces";
+import { resizeImage } from "@/utils/images-client";
+import clsx from "clsx";
 
 export function ProfileForm({ guest }: { guest: Guest }) {
   const router = useRouter();
@@ -15,6 +24,28 @@ export function ProfileForm({ guest }: { guest: Guest }) {
   const [aboutMe, setAboutMe] = useState(guest.aboutMe ?? "");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [avatar, setAvatar] = useState<File | null | undefined>();
+  const [isDragging, setIsDragging] = useState(false);
+  const canvas = useRef<HTMLCanvasElement | null>(null);
+
+  const avatarUrl = useMemo(
+    () => avatar && URL.createObjectURL(avatar),
+    [avatar]
+  );
+
+  useEffect(
+    () => () => {
+      if (avatarUrl) URL.revokeObjectURL(avatarUrl);
+    },
+    [avatarUrl]
+  );
+
+  const resize = async (file: File, maxSize: number) => {
+    return canvas.current
+      ? await resizeImage(canvas.current, file, maxSize)
+      : { blob: file };
+  };
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault();
@@ -26,6 +57,18 @@ export function ProfileForm({ guest }: { guest: Guest }) {
     formData.append("aboutMe", aboutMe);
 
     try {
+      if (avatar === null) {
+        formData.append("avatar", "");
+      } else if (avatar) {
+        const resized = await resize(avatar, 256);
+        if ("error" in resized) {
+          setError(resized.error);
+          return;
+        }
+
+        formData.append("avatar", resized.blob);
+      }
+
       const result = await updateProfileAction(formData);
       if (!result.ok) {
         setError(result.error);
@@ -41,6 +84,28 @@ export function ProfileForm({ guest }: { guest: Guest }) {
     }
   };
 
+  const avatarAreaController: ButtonHTMLAttributes<HTMLButtonElement> = useMemo(
+    () => ({
+      onDrop(e) {
+        e.preventDefault();
+        setAvatar(e.dataTransfer.files?.item(0) ?? null);
+        setIsDragging(false);
+      },
+      onDragOver: function (e) {
+        e.preventDefault();
+        setIsDragging(true);
+      },
+      onDragLeave(e) {
+        e.preventDefault();
+        setIsDragging(false);
+      },
+      onClick() {
+        fileInput.current?.click();
+      },
+    }),
+    [fileInput]
+  );
+
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-4">
       <Link
@@ -51,12 +116,55 @@ export function ProfileForm({ guest }: { guest: Guest }) {
       </Link>
       <h1 className="text-2xl font-bold">Edit profile</h1>
 
+      <canvas ref={canvas} hidden />
+
       <form
         onSubmit={(e) => void handleSubmit(e)}
         className="flex flex-col gap-4"
       >
-        <div className="flex items-center gap-4">
-          <Avatar name={name} size="sm" />
+        <div className="flex items-center gap-4 cursor-pointer">
+          <button
+            className={clsx(
+              "flex items-center gap-4 cursor-pointer pe-4 border-solid border-e",
+              "hover:text-rose-500 active:text-rose-600 drop:boder-rose-400",
+              "transition-outline duration-200 ease-in-out outline-gray-500 outline-dashed outline-0",
+              isDragging
+                ? "cursor-grabbing outline-4 rounded-full border-transparent"
+                : "border-gray-500"
+            )}
+            type="button"
+            {...avatarAreaController}
+          >
+            <Avatar
+              name={name}
+              size="sm"
+              image={
+                avatarUrl === null
+                  ? undefined
+                  : avatarUrl
+                    ? avatarUrl
+                    : guest.avatarUrl
+                      ? guest.avatarUrl
+                      : undefined
+              }
+            />
+            <label htmlFor={`${guest.id}-image`}>Change profile picture</label>
+          </button>
+          <button
+            type="button"
+            className="text-rose-400 hover:text-rose-500 active:text-rose-600 cursor-pointer"
+            onClick={() => setAvatar(null)}
+          >
+            Reset
+          </button>
+          <input
+            id={`${guest.id}-image`}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            ref={fileInput}
+            hidden
+            onChange={(e) => setAvatar(e.target.files?.item(0) ?? null)}
+          />
         </div>
 
         <div className="flex flex-col gap-1">

--- a/app/(site)/guests/page.tsx
+++ b/app/(site)/guests/page.tsx
@@ -34,7 +34,11 @@ export default async function GuestsPage() {
                 href={`/guests/${guest.id}`}
                 className="flex items-center gap-4 py-3 hover:bg-gray-50 rounded-md px-2"
               >
-                <Avatar name={guest.name} size="sm" />
+                <Avatar
+                  name={guest.name}
+                  size="sm"
+                  image={guest.avatarUrl ?? undefined}
+                />
                 <span className="font-medium text-gray-900">{guest.name}</span>
               </Link>
             </li>

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
+import { getImageRepositories } from "@/utils/images";
 
 export type ProfileActionResult = { ok: true } | { ok: false; error: string };
 
@@ -11,6 +12,13 @@ export async function updateProfileAction(
 ): Promise<ProfileActionResult> {
   const name = ((formData.get("name") as string | null) ?? "").trim();
   const aboutMe = (formData.get("aboutMe") as string | null)?.trim() ?? null;
+  const avatarEntry = formData.get("avatar");
+  const avatarFile =
+    avatarEntry === ""
+      ? null
+      : avatarEntry instanceof File && avatarEntry.size > 0
+        ? avatarEntry
+        : undefined;
 
   const cookieStore = await cookies();
   const currentUser = cookieStore.get("user")?.value;
@@ -23,11 +31,32 @@ export async function updateProfileAction(
   }
 
   const { guests } = getRepositories();
-  if (!(await guests.findById(currentUser))) {
+  const currentProfile = await guests.findById(currentUser);
+  if (!currentProfile) {
     return { ok: false, error: "Profile not found" };
   }
 
-  await guests.updateProfile(currentUser, { name, aboutMe: aboutMe });
+  const { avatars } = getImageRepositories();
+
+  let avatarUrl: string | undefined | null =
+    avatarFile === null ? null : (currentProfile.avatarUrl ?? null);
+
+  if (avatarFile) {
+    const avatarBuffer = await avatars.validate(
+      Buffer.from(await avatarFile.arrayBuffer())
+    );
+    if ("error" in avatarBuffer) {
+      return { ok: false, error: avatarBuffer.error };
+    }
+
+    avatarUrl = await avatars.save(
+      currentUser,
+      avatarBuffer.buffer,
+      avatarBuffer.ext
+    );
+  }
+
+  await guests.updateProfile(currentUser, { name, aboutMe, avatarUrl });
 
   revalidatePath(`/guests/${currentUser}`);
   revalidatePath("/guests");

--- a/app/media/avatars/[filename]/route.ts
+++ b/app/media/avatars/[filename]/route.ts
@@ -1,0 +1,22 @@
+// Serves user-uploaded location images from UPLOADS_DIR. URLs carry a
+// ?v= cache-buster set on upload, so responses can be cached aggressively.
+import { NextRequest, NextResponse } from "next/server";
+import { getImageRepositories } from "@/utils/images";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> }
+) {
+  const { filename } = await params;
+
+  const image = await getImageRepositories().avatars.read(filename);
+  if (!image) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+  return new NextResponse(new Uint8Array(image.data), {
+    headers: {
+      "Content-Type": image.contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -75,6 +75,7 @@ export type Guest<PI extends GuestPrivateInfo | void = void> = {
   name: string;
   // Public: shown on the guest's profile to anyone who can view it.
   aboutMe?: string | null;
+  avatarUrl?: string | null;
   info: PI;
 };
 
@@ -95,7 +96,7 @@ export interface GuestsRepository {
   // Usage: a user updates their own profile (name and public aboutMe).
   updateProfile(
     id: string,
-    data: { name: string; aboutMe: string | null }
+    data: { name: string; aboutMe: string | null; avatarUrl: string | null }
   ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;
@@ -293,4 +294,14 @@ export interface VotesRepository {
     proposalId: string,
     guestIds: string[]
   ): Promise<void>;
+}
+
+// ── Images ─────────────────────────────────────────────────────────────────────
+
+export interface ImageResourceRepository<Id> {
+  validate(
+    buffer: Buffer
+  ): Promise<{ buffer: Buffer; ext: string } | { error: string }>;
+  save(id: Id, buffer: Buffer, ext: string): Promise<string>;
+  delete(id: Id): Promise<void>;
 }

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -12,6 +12,7 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
     id: row.id,
     name: row.name,
     aboutMe: row.aboutMe,
+    avatarUrl: row.avatarUrl,
     info: { email: row.email },
   };
 }
@@ -32,6 +33,8 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .select({
         id: schema.guests.id,
         name: schema.guests.name,
+        avatarUrl: schema.guests.avatarUrl,
+        aboutMe: schema.guests.aboutMe,
       })
       .from(schema.guests)
       .innerJoin(
@@ -93,11 +96,15 @@ export class SqliteGuestsRepository implements GuestsRepository {
 
   async updateProfile(
     id: string,
-    data: { name: string; aboutMe: string | null }
+    data: { name: string; aboutMe: string | null; avatarUrl: string | null }
   ): Promise<CompleteGuest | undefined> {
     const result = this.db
       .update(schema.guests)
-      .set({ name: data.name, aboutMe: data.aboutMe })
+      .set({
+        name: data.name,
+        aboutMe: data.aboutMe,
+        avatarUrl: data.avatarUrl,
+      })
       .where(eq(schema.guests.id, id))
       .run();
     if (result.changes === 0) return undefined;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -9,7 +9,8 @@ export const guests = sqliteTable("guests", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull(),
-  aboutMe: text("aboutMe"),
+  aboutMe: text("about_me"),
+  avatarUrl: text("avatar_url"),
 });
 
 export const events = sqliteTable("events", {

--- a/drizzle/0007_unknown_chamber.sql
+++ b/drizzle/0007_unknown_chamber.sql
@@ -1,1 +1,3 @@
-ALTER TABLE `guests` ADD `aboutMe` text;
+ALTER TABLE `guests` ADD `about_me` text;
+--> statement-breakpoint
+ALTER TABLE `guests` ADD `avatar_url` text;

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
+import sharp from "sharp";
 
 async function selectCurrentUser(page: import("@playwright/test").Page) {
   // The proposals page has a "My name is:" selector backed by a combobox.
@@ -9,37 +10,104 @@ async function selectCurrentUser(page: import("@playwright/test").Page) {
   await page.keyboard.press("Escape");
 }
 
-test("lists guests and edits the current user's profile", async ({ page }) => {
-  await login(page);
-  await page.goto("/Conference-Alpha/proposals");
+async function makeImage(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },
+  })
+    .png()
+    .toBuffer();
+}
 
-  // Identify as Alice, then reach the attendees page via the header link.
-  await selectCurrentUser(page);
-  await page.getByRole("link", { name: /Participants/i }).click();
-  await expect(page).toHaveURL(/\/guests$/);
+test.describe("Edit profile", () => {
+  test.describe.configure({ mode: "serial" });
 
-  // All guests are listed.
-  await expect(page.getByRole("link", { name: "Alice Test" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Charlie Test" })).toBeVisible();
+  test("lists guests and edits the current user's profile", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
 
-  // Edit profile always targets the current user (Alice).
-  await page.getByRole("link", { name: /Edit profile/i }).click();
-  await expect(page).toHaveURL(/\/guests\/edit$/);
-  await expect(
-    page.getByRole("heading", { name: /Edit profile/i })
-  ).toBeVisible();
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+    await expect(page).toHaveURL(/\/guests$/);
 
-  const aboutMe = `Conference enthusiast ${Date.now()}`;
-  await page.getByLabel("About me").fill(aboutMe);
-  await page.getByRole("button", { name: /^Save$/ }).click();
+    // All guests are listed.
+    await expect(page.getByRole("link", { name: "Alice Test" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Charlie Test" })
+    ).toBeVisible();
 
-  // Lands on Alice's profile with the new About me text.
-  await expect(page).toHaveURL(/\/guests\/[^/]+$/);
-  await expect(
-    page.getByRole("heading", { level: 1, name: "Alice Test" })
-  ).toBeVisible();
-  await expect(page.getByText(aboutMe)).toBeVisible();
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+    await expect(page).toHaveURL(/\/guests\/edit$/);
+    await expect(
+      page.getByRole("heading", { name: /Edit profile/i })
+    ).toBeVisible();
+
+    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    await page.getByLabel("About me").fill(aboutMe);
+    // hidden inputs aren't interactable through `getByLabel` in playwright
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "square.png",
+      mimeType: "image/png",
+      buffer: await makeImage(800, 800),
+    });
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    // Lands on Alice's profile with the new About me text.
+    await expect(page).toHaveURL(/\/guests\/[^/]+$/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Alice Test" })
+    ).toBeVisible();
+    await expect(page.getByText(aboutMe)).toBeVisible();
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeVisible();
+  });
+
+  test("avatar doesn't change on profile about me edit", async ({ page }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+
+    // Reset the avatar
+    const aboutMe = `Conference enthusiast ${Date.now()}`;
+    await page.getByLabel("About me").fill(aboutMe);
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeVisible();
+  });
+
+  test("shows no image when the user avatar is reset", async ({ page }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    // Identify as Alice, then reach the attendees page via the header link.
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+
+    // Edit profile always targets the current user (Alice).
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+
+    // Reset the avatar
+    await page.getByRole("button", { name: /^Reset$/ }).click();
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    await expect(
+      page.getByAltText("Profile avatar of Alice Test")
+    ).toBeHidden();
+    await expect(page.getByText(/^AT$/)).toBeVisible();
+  });
 });
 
 test("shows an error on the edit page when no user is selected", async ({

--- a/tests/helpers/utils.ts
+++ b/tests/helpers/utils.ts
@@ -1,0 +1,14 @@
+import sharp from "sharp";
+
+export async function createImageFile(
+  width: number,
+  height: number,
+  name: string
+): Promise<File> {
+  const buffer = await sharp({
+    create: { width, height, channels: 3, background: { r: 1, g: 2, b: 3 } },
+  })
+    .png()
+    .toBuffer();
+  return new File([new Uint8Array(buffer)], name, { type: "image/png" });
+}

--- a/tests/integration/admin-locations.test.ts
+++ b/tests/integration/admin-locations.test.ts
@@ -10,7 +10,6 @@ import {
 import fs from "fs";
 import os from "os";
 import path from "path";
-import sharp from "sharp";
 
 const cookieJar = new Map<string, string>();
 
@@ -42,6 +41,7 @@ import {
   deleteLocationAction,
   moveLocationAction,
 } from "@/app/actions/admin-locations";
+import { createImageFile } from "@/tests/helpers/utils";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
 
@@ -69,12 +69,7 @@ async function makeImageFile(
   height: number,
   name = "room.png"
 ): Promise<File> {
-  const buffer = await sharp({
-    create: { width, height, channels: 3, background: { r: 1, g: 2, b: 3 } },
-  })
-    .png()
-    .toBuffer();
-  return new File([new Uint8Array(buffer)], name, { type: "image/png" });
+  return createImageFile(width, height, name);
 }
 
 let uploadsDir: string;

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -21,18 +21,21 @@ describe("guest profile repositories", () => {
       const updated = await guests.updateProfile(guest.id, {
         name: "New Name",
         aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
       });
 
       expect(updated).toMatchObject({
         id: guest.id,
         name: "New Name",
         aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
         info: { email: "g@test.example" },
       });
       const fetched = await guests.findById(guest.id);
       expect(fetched).toMatchObject({
         name: "New Name",
         aboutMe: "I love unconferences.",
+        avatarUrl: "/media/uploads/avatar.png",
       });
     });
   });

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  vi,
+  afterEach,
+} from "vitest";
 
 const cookieJar = new Map<string, string>();
 
@@ -20,12 +28,19 @@ import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { updateProfileAction } from "@/app/actions/profile";
+import { createImageFile } from "@/tests/helpers/utils";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import sharp from "sharp";
 
-function form(fields: Record<string, string>): FormData {
+function form(fields: Record<string, string | Blob>): FormData {
   const fd = new FormData();
   for (const [k, v] of Object.entries(fields)) fd.append(k, v);
   return fd;
 }
+
+let uploadsDir: string;
 
 describe("updateProfileAction", () => {
   beforeAll(() => setupTestDb());
@@ -33,6 +48,13 @@ describe("updateProfileAction", () => {
   beforeEach(() => {
     resetTestDb();
     cookieJar.clear();
+    uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-test-"));
+    vi.stubEnv("UPLOADS_DIR", uploadsDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(uploadsDir, { recursive: true, force: true });
   });
 
   it("updates name and aboutMe for the current user", async () => {
@@ -44,5 +66,63 @@ describe("updateProfileAction", () => {
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
     expect(updated).toMatchObject({ name: "New Name", aboutMe: "Hello there" });
+  });
+
+  it("updates name, aboutMe and avatar for the current user", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(256, 256, "avatar.png"),
+      })
+    );
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated).toMatchObject({
+      name: "New Name",
+      aboutMe: "Hello there",
+    });
+    expect(updated?.avatarUrl).toMatch(
+      new RegExp(`^/media/avatars/${updated?.id}\\.png\\?v=\\d+$`)
+    );
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    expect(fs.existsSync(imagePath)).toBe(true);
+  });
+
+  it("resizes avatar to 256 and keeps extension", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(512, 512, "avatar.png"),
+      })
+    );
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    expect(fs.existsSync(imagePath)).toBe(true);
+    const imageMetadata = await sharp(fs.readFileSync(imagePath)).metadata();
+    expect(imageMetadata).toMatchObject({
+      width: 256,
+      height: 256,
+      format: "png",
+    });
+  });
+
+  it("rejects images smaller than 256x256", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction(
+      form({
+        name: "New Name",
+        aboutMe: "Hello there",
+        avatar: await createImageFile(128, 128, "avatar.png"),
+      })
+    );
+    expect(result).toMatchObject({ ok: false });
   });
 });

--- a/utils/images-client.ts
+++ b/utils/images-client.ts
@@ -1,0 +1,78 @@
+function drawCover(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  destWidth: number,
+  destHeight: number
+) {
+  const sourceAspect = sourceWidth / sourceHeight;
+  const destAspect = destWidth / destHeight;
+
+  let sx = 0;
+  let sy = 0;
+  let sw = sourceWidth;
+  let sh = sourceHeight;
+
+  if (sourceAspect > destAspect) {
+    // Source is wider: crop left/right
+    sw = sourceHeight * destAspect;
+    sx = (sourceWidth - sw) / 2;
+  } else {
+    // Source is taller: crop top/bottom
+    sh = sourceWidth / destAspect;
+    sy = (sourceHeight - sh) / 2;
+  }
+
+  ctx.drawImage(image, sx, sy, sw, sh, 0, 0, destWidth, destHeight);
+}
+
+function toBlob(canvas: HTMLCanvasElement, file: File) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create blob"));
+        }
+      },
+      file.type.startsWith("image/") ? file.type : "image/jpeg",
+      0.9
+    );
+  })
+    .then((blob) => ({ blob }))
+    .catch((e) => {
+      console.error(e);
+      return { error: "Failed to resize image" };
+    });
+}
+
+export async function resizeImage(
+  canvas: HTMLCanvasElement,
+  file: File,
+  maxSize: number
+): Promise<{ blob: Blob } | { error: string }> {
+  const bitmap = await createImageBitmap(file);
+
+  canvas.width = maxSize;
+  canvas.height = maxSize;
+
+  const ctx = canvas.getContext("2d")!;
+
+  try {
+    drawCover(
+      ctx,
+      bitmap,
+      bitmap.width,
+      bitmap.height,
+      canvas.width,
+      canvas.height
+    );
+  } catch (e) {
+    console.error(e);
+    return { error: "Failed to draw image" };
+  }
+
+  return toBlob(canvas, file);
+}

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -1,0 +1,165 @@
+import { ImageResourceRepository } from "@/db/repositories/interfaces";
+import sharp, { FormatEnum, Metadata, Sharp } from "sharp";
+import fs from "fs/promises";
+import path from "path";
+
+// Images are stored on the filesystem under UPLOADS_DIR
+// (a persistent volume in production), not in public/,
+// because public/ is baked into the build and lost on redeploy.
+
+// Avatar images are uploaded through the /guests/edit UI
+// They are served by app/media/avatar/[filename]/route.ts.
+
+const FORMAT_EXTENSIONS: Partial<Record<keyof FormatEnum, string>> = {
+  jpeg: "jpg",
+  png: "png",
+  webp: "webp",
+};
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const MIN_IMAGE_WIDTH = 400;
+
+export abstract class BaseImageResourceRepository<
+  Id extends string,
+> implements ImageResourceRepository<Id> {
+  readonly maxImageBytes = MAX_IMAGE_BYTES;
+  readonly minImageWidth: number = MIN_IMAGE_WIDTH;
+  abstract readonly directory: string;
+
+  get dirPath() {
+    return path.join(process.env.UPLOADS_DIR ?? "./uploads", this.directory);
+  }
+
+  protected abstract getEndpoint(filename: string): string;
+
+  /**
+   * Validates format and size
+   * Returns the canonical file extension on success, or an error message.
+   */
+  async validate(
+    buffer: Buffer
+  ): Promise<{ ext: string; buffer: Buffer } | { error: string }> {
+    if (buffer.byteLength > this.maxImageBytes) {
+      const mb = new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: 2,
+      }).format(this.maxImageBytes / 1_000_000);
+      return {
+        error: `Image is too large (max ${mb} MB)`,
+      };
+    }
+
+    let decodedImage: Sharp;
+    let metadata: Metadata;
+    try {
+      decodedImage = sharp(buffer);
+      metadata = await decodedImage.metadata();
+    } catch {
+      return { error: "File is not a valid image" };
+    }
+
+    const { width, format } = metadata;
+
+    const ext = FORMAT_EXTENSIONS[format];
+
+    if (!ext) {
+      return { error: "Unsupported image format (use JPEG, PNG, or WebP)" };
+    }
+    if (width < this.minImageWidth) {
+      return { error: `Image is too small (min ${this.minImageWidth}px wide)` };
+    }
+
+    try {
+      // strips EXIF, ICC profiles, XMP, IPTC, GPS data, and other metadata from images
+      const newBuffer = await this.decodeImage(
+        decodedImage,
+        metadata
+      ).toBuffer();
+
+      return { ext, buffer: newBuffer };
+    } catch {
+      return { error: "Unable to decode image" };
+    }
+  }
+
+  protected decodeImage(image: Sharp, metadata: Metadata): Sharp {
+    return image.rotate().toFormat(metadata.format);
+  }
+
+  /** Removes all stored image files for the ID, if any. */
+  async delete(id: Id): Promise<void> {
+    const dir = this.dirPath;
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch {
+      return;
+    }
+    await Promise.all(
+      entries
+        .filter((name) => name.startsWith(`${id}.`))
+        .map((name) => fs.unlink(path.join(dir, name)).catch(() => {}))
+    );
+  }
+
+  /**
+   * Stores the image as <ID>.<ext>, replacing any previous image for
+   * the ID. Returns the public URL (with a cache-busting version).
+   */
+  async save(id: Id, buffer: Buffer, ext: string): Promise<string> {
+    const dir = this.dirPath;
+    await fs.mkdir(dir, { recursive: true });
+    await this.delete(id);
+    const filename = `${id}.${ext}`;
+    await fs.writeFile(path.join(dir, filename), buffer);
+    return `${this.getEndpoint(filename)}?v=${Date.now()}`;
+  }
+
+  /**
+   * Resolves a requested filename to a stored image, guarding against path
+   * traversal. Returns undefined for invalid or missing files.
+   */
+  async read(
+    filename: string
+  ): Promise<{ data: Buffer; contentType: string } | undefined> {
+    if (!SAFE_FILENAME.test(filename)) return undefined;
+
+    filename = path.join(this.dirPath, filename);
+    try {
+      const data = await fs.readFile(filename);
+      const ext = filename.split(".").pop()!;
+      return { data, contentType: CONTENT_TYPES[ext] };
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+const SAFE_FILENAME = /^[A-Za-z0-9_-]+\.(jpg|png|webp)$/;
+
+const CONTENT_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+export class AvatarImageResourceRepository extends BaseImageResourceRepository<string> {
+  override directory = "avatars";
+
+  override minImageWidth = 256;
+
+  protected override getEndpoint(filename: string): string {
+    return `/media/avatars/${filename}`;
+  }
+
+  override decodeImage(image: Sharp, metadata: Metadata): Sharp {
+    return super
+      .decodeImage(image, metadata)
+      .resize(256, 256, { fit: "cover" });
+  }
+}
+
+export function getImageRepositories() {
+  return {
+    avatars: new AvatarImageResourceRepository(),
+  };
+}


### PR DESCRIPTION
This introduces avatars in user profiles. It also introduces the notion of an `ImageRepository` that could also be used for locations as well. 

This also renames the SQL column `guests.aboutMe` to `guests.about_me` for consistency.

advances #369
