### PR TITLE
fix(layout): render VotesProvider inside the Suspense boundary

### DIFF
--- a/app/(site)/[eventSlug]/layout.tsx
+++ b/app/(site)/[eventSlug]/layout.tsx
@@ -10,13 +10,18 @@ export default async function EventLayout({
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await params;
+  // VotesProvider must live inside the Suspense boundary: it fetches votes in
+  // a mount effect, and if that state update lands while the boundary content
+  // below it is still dehydrated (selective hydration under load), React can
+  // get stuck rendering the update without ever committing it, leaving stale
+  // server-rendered HTML (e.g. vote highlights) frozen on screen.
   return (
-    <VotesProvider eventSlug={eventSlug}>
-      <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<div>Loading...</div>}>
+      <VotesProvider eventSlug={eventSlug}>
         <EventLayoutContent eventSlug={eventSlug}>
           {children}
         </EventLayoutContent>
-      </Suspense>
-    </VotesProvider>
+      </VotesProvider>
+    </Suspense>
   );
 }


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [d2f97a4](https://github.com/LWCW-Europe/schellingboard/pull/509/commits/d2f97a4b92c80eaf0c0f444ac5957b22406499e1).

PRs:
* #512
* ➡️ #509 (this PR, base of the stack — can be merged first)

---

## Description

Its mount-effect vote fetch could resolve while the boundary content
was still dehydrated; React then never committed the update, leaving
stale server HTML (white vote buttons) frozen indefinitely.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=d2f97a4b92c80eaf0c0f444ac5957b22406499e1 -->