### PR TITLE
fix(api): mark votes and rsvps responses uncacheable

### DIFF
--- a/app/api/rsvps/route.ts
+++ b/app/api/rsvps/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRepositories } from "@/db/container";
 
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response
+// and show stale RSVPs after a reload.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const user = searchParams.get("user");
@@ -9,7 +15,7 @@ export async function GET(request: NextRequest) {
   if (!user && !session) {
     return NextResponse.json(
       { error: "user or session parameter is required" },
-      { status: 400 }
+      { ...NO_STORE, status: 400 }
     );
   }
 
@@ -18,12 +24,12 @@ export async function GET(request: NextRequest) {
     const rsvps = user
       ? await repos.rsvps.listByGuest(user)
       : await repos.rsvps.listBySession(session!);
-    return NextResponse.json(rsvps);
+    return NextResponse.json(rsvps, NO_STORE);
   } catch (error) {
     console.error("Error fetching RSVPs:", error);
     return NextResponse.json(
       { error: "Failed to fetch RSVPs" },
-      { status: 500 }
+      { ...NO_STORE, status: 500 }
     );
   }
 }

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRepositories } from "@/db/container";
 
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response
+// and show stale votes after a reload.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const user = searchParams.get("user");
@@ -9,7 +15,7 @@ export async function GET(request: NextRequest) {
   if (!user || !eventName) {
     return NextResponse.json(
       { error: "User and event parameters are required" },
-      { status: 400 }
+      { ...NO_STORE, status: 400 }
     );
   }
 
@@ -17,15 +23,18 @@ export async function GET(request: NextRequest) {
     const repos = getRepositories();
     const event = await repos.events.findByName(eventName);
     if (!event) {
-      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Event not found" },
+        { ...NO_STORE, status: 404 }
+      );
     }
     const votes = await repos.votes.listByGuestAndEvent(user, event.id);
-    return NextResponse.json(votes);
+    return NextResponse.json(votes, NO_STORE);
   } catch (error) {
     console.error("Error fetching votes:", error);
     return NextResponse.json(
       { error: "Failed to fetch votes" },
-      { status: 500 }
+      { ...NO_STORE, status: 500 }
     );
   }
 }


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [4a957aa](https://github.com/LWCW-Europe/schellingboard/pull/510/commits/4a957aac74d5eae2cea6c32c99d8f7dbeec9b4bb).

PRs:
* #512
* ➡️ #510 (this PR, base of the stack — can be merged first)

---

## Description

Covers error responses too: 404 is heuristically cacheable per RFC
9111, so a stale "Event not found" could outlive the event being
created.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=4a957aac74d5eae2cea6c32c99d8f7dbeec9b4bb -->