### PR TITLE
ci: enforce coverage thresholds in CI and local runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
-      - name: Test
-        run: make test
+      - name: Test (with coverage thresholds)
+        run: make test-coverage
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ format: install
 format-check: install
 	bun x prettier --check .
 
-precommit: format lint typecheck test test-e2e
+precommit: format lint typecheck test-coverage test-e2e
 
 clean:
 	rm -rf .next

--- a/db/container.ts
+++ b/db/container.ts
@@ -71,6 +71,7 @@ export function getRepositories(): Repositories {
 }
 
 export function resetRepositories(): void {
+  _sqlite?.close();
   _sqlite = null;
   _repositories = null;
 }
@@ -82,8 +83,19 @@ export function serializeDb(): Buffer {
 }
 
 export function restoreDb(snapshot: Buffer): void {
-  _sqlite = new Database(snapshot);
-  // Enforce foreign keys on every connection (see getRepositories).
-  _sqlite.pragma("foreign_keys = ON");
-  _repositories = buildRepositories(_sqlite);
+  const conn = new Database(snapshot);
+  try {
+    // Enforce foreign keys on every connection (see getRepositories).
+    conn.pragma("foreign_keys = ON");
+    // Deserialization is lazy: force a read so a corrupt snapshot fails here,
+    // while the current connection is still intact.
+    conn.pragma("schema_version");
+    const repositories = buildRepositories(conn);
+    _sqlite?.close();
+    _sqlite = conn;
+    _repositories = repositories;
+  } catch (e) {
+    conn.close();
+    throw e;
+  }
 }

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createDay,
+  createProposal as createProposalFixture,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { VoteChoice } from "@/db/repositories/interfaces";
+import type { SessionParams } from "@/app/api/session-form-utils";
+import { POST as addVote } from "@/app/api/add-vote/route";
+import { POST as addSession } from "@/app/api/add-session/route";
+import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
+
+// FINDING: the server does not enforce event phases at all — phase gating is
+// UI-only. The `.fails` tests below assert the *correct* behavior (rejection
+// outside the right phase) and are marked `.fails` because the server
+// currently accepts the request. When server-side gating lands, these tests
+// will start "passing" and Vitest will flag them — remove `.fails` then. Do
+// NOT rewrite the assertions to match the current, broken behavior.
+//
+// The "allows ..." tests document the flip side: the request already
+// succeeds in the right phase today, and must keep succeeding once gating is
+// added.
+
+function makeReq(url: string, payload: unknown): Request {
+  return new Request(url, { method: "POST", body: JSON.stringify(payload) });
+}
+
+async function voteOnProposalIn(phase: "proposal" | "voting" | "scheduling") {
+  const event = await createEvent({ phase });
+  const guest = await createGuest();
+  const proposal = await createProposalFixture(event.id, []);
+
+  const res = await addVote(
+    makeReq("http://test/api/add-vote", {
+      proposalId: proposal.id,
+      guestId: guest.id,
+      choice: VoteChoice.interested,
+    })
+  );
+  const votes = await getRepositories().votes.listByGuestAndEvent(
+    guest.id,
+    event.id
+  );
+  return { res, votes };
+}
+
+async function addSessionIn(phase: "proposal" | "voting" | "scheduling") {
+  const event = await createEvent({ phase });
+  const guest = await createGuest();
+  const location = await createLocation();
+  const day = await createDay(event.id);
+
+  const payload: SessionParams = {
+    title: "Premature Session",
+    description: "",
+    closed: false,
+    hosts: [guest],
+    location,
+    day,
+    startTimeMinutes: 10 * 60,
+    duration: 60,
+    timezone: "UTC",
+  };
+  const res = await addSession(makeReq("http://test/api/add-session", payload));
+  const sessions = await getRepositories().sessions.listByEvent(event.id);
+  return { res, sessions };
+}
+
+async function proposeIn(phase: "proposal" | "voting" | "scheduling") {
+  const event = await createEvent({ phase });
+  const fd = new FormData();
+  fd.set("event", event.id);
+  fd.set("eventSlug", "test-event");
+  fd.set("title", "Late Proposal");
+  const result = await createProposal(fd);
+  const proposals = await getRepositories().sessionProposals.listByEvent(
+    event.id
+  );
+  return { result, proposals };
+}
+
+describe("server-side phase gating", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it.fails("rejects voting during the proposal phase", async () => {
+    const { res, votes } = await voteOnProposalIn("proposal");
+    expect(res.ok).toBe(false);
+    expect(votes).toHaveLength(0);
+  });
+
+  it.fails("rejects voting during the scheduling phase", async () => {
+    const { res, votes } = await voteOnProposalIn("scheduling");
+    expect(res.ok).toBe(false);
+    expect(votes).toHaveLength(0);
+  });
+
+  it.fails("rejects session creation during the proposal phase", async () => {
+    const { res, sessions } = await addSessionIn("proposal");
+    expect(res.ok).toBe(false);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it.fails("rejects session creation during the voting phase", async () => {
+    const { res, sessions } = await addSessionIn("voting");
+    expect(res.ok).toBe(false);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it.fails("rejects proposal creation during the voting phase", async () => {
+    const { result, proposals } = await proposeIn("voting");
+    expect(result).toHaveProperty("error");
+    expect(proposals).toHaveLength(0);
+  });
+
+  it.fails(
+    "rejects proposal creation during the scheduling phase",
+    async () => {
+      const { result, proposals } = await proposeIn("scheduling");
+      expect(result).toHaveProperty("error");
+      expect(proposals).toHaveLength(0);
+    }
+  );
+
+  it("allows voting during the voting phase", async () => {
+    const { res, votes } = await voteOnProposalIn("voting");
+    expect(res.ok).toBe(true);
+    expect(votes).toHaveLength(1);
+  });
+
+  it("allows session creation during the scheduling phase", async () => {
+    const { res, sessions } = await addSessionIn("scheduling");
+    expect(res.ok).toBe(true);
+    expect(sessions).toHaveLength(1);
+  });
+
+  it("allows proposal creation during the proposal phase", async () => {
+    const { result, proposals } = await proposeIn("proposal");
+    expect(result).toEqual({ success: true });
+    expect(proposals).toHaveLength(1);
+  });
+});

--- a/tests/integration/proposals.test.ts
+++ b/tests/integration/proposals.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createProposal as createProposalFixture,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import {
+  createProposal,
+  updateProposal,
+} from "@/app/(site)/[eventSlug]/proposals/actions";
+
+function proposalForm(fields: Record<string, string | string[]>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+describe("createProposal", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("creates a proposal with hosts and duration, readable via listByEvent", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+
+    const result = await createProposal(
+      proposalForm({
+        event: event.id,
+        eventSlug: "test-event",
+        title: "My Proposal",
+        description: "A description",
+        hosts: [host.id],
+        durationMinutes: "60",
+      })
+    );
+    expect(result).toEqual({ success: true });
+
+    const proposals = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      title: "My Proposal",
+      description: "A description",
+      durationMinutes: 60,
+    });
+    expect(proposals[0].hosts.map((h) => h.id)).toEqual([host.id]);
+  });
+
+  it("rejects a missing title and leaves the event's proposals unchanged", async () => {
+    const event = await createEvent();
+
+    const result = await createProposal(
+      proposalForm({ event: event.id, eventSlug: "test-event", title: "" })
+    );
+    expect(result).toHaveProperty("error");
+
+    const proposals = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    expect(proposals).toHaveLength(0);
+  });
+
+  it("rejects a missing event", async () => {
+    const result = await createProposal(
+      proposalForm({ eventSlug: "test-event", title: "No Event" })
+    );
+    expect(result).toHaveProperty("error");
+  });
+});
+
+describe("updateProposal", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("updates title, description, hosts, and duration", async () => {
+    const event = await createEvent();
+    const alice = await createGuest({ name: "Alice" });
+    const bob = await createGuest({ name: "Bob" });
+    const proposal = await createProposalFixture(event.id, [alice.id], {
+      title: "Original",
+      durationMinutes: 30,
+    });
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({
+        eventSlug: "test-event",
+        title: "Updated",
+        description: "New description",
+        hosts: [alice.id, bob.id],
+        durationMinutes: "90",
+      })
+    );
+    expect(result).toEqual({ success: true });
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after).toMatchObject({
+      title: "Updated",
+      description: "New description",
+      durationMinutes: 90,
+    });
+    expect(after?.hosts.map((h) => h.id).sort()).toEqual(
+      [alice.id, bob.id].sort()
+    );
+  });
+
+  it("removes all hosts and clears the duration", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    const proposal = await createProposalFixture(event.id, [host.id], {
+      durationMinutes: 60,
+    });
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({
+        eventSlug: "test-event",
+        title: proposal.title,
+        durationMinutes: "",
+      })
+    );
+    expect(result).toEqual({ success: true });
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.hosts).toEqual([]);
+    expect(after?.durationMinutes).toBeUndefined();
+  });
+
+  it("rejects a missing title and leaves the proposal unchanged", async () => {
+    const event = await createEvent();
+    const proposal = await createProposalFixture(event.id, [], {
+      title: "Keep Me",
+    });
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "" })
+    );
+    expect(result).toHaveProperty("error");
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Keep Me");
+  });
+});

--- a/tests/integration/rsvp.test.ts
+++ b/tests/integration/rsvp.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import type { Rsvp } from "@/db/repositories/interfaces";
+import { POST as toggleRsvp } from "@/app/api/toggle-rsvp/route";
+import { GET as getRsvps } from "@/app/api/rsvps/route";
+
+function makeToggleReq(payload: unknown): Request {
+  return new Request("http://test/api/toggle-rsvp", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+// Read surface: GET /api/rsvps?user=<guestId>
+async function rsvpsForGuest(guestId: string): Promise<Rsvp[]> {
+  const res = await getRsvps(
+    new NextRequest(`http://test/api/rsvps?user=${guestId}`)
+  );
+  expect(res.ok).toBe(true);
+  return (await res.json()) as Rsvp[];
+}
+
+describe("POST /api/toggle-rsvp", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("adds an RSVP when absent and removes it when remove is set", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest();
+    const session = await createSession(event.id);
+
+    const addRes = await toggleRsvp(
+      makeToggleReq({ sessionId: session.id, guestId: guest.id })
+    );
+    expect(addRes.ok).toBe(true);
+
+    const afterAdd = await rsvpsForGuest(guest.id);
+    expect(afterAdd).toHaveLength(1);
+    expect(afterAdd[0]).toMatchObject({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+
+    const removeRes = await toggleRsvp(
+      makeToggleReq({ sessionId: session.id, guestId: guest.id, remove: true })
+    );
+    expect(removeRes.ok).toBe(true);
+
+    expect(await rsvpsForGuest(guest.id)).toHaveLength(0);
+  });
+
+  it("removing an absent RSVP is a no-op", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest();
+    const session = await createSession(event.id);
+
+    const res = await toggleRsvp(
+      makeToggleReq({ sessionId: session.id, guestId: guest.id, remove: true })
+    );
+    expect(res.ok).toBe(true);
+    expect(await rsvpsForGuest(guest.id)).toHaveLength(0);
+  });
+
+  // FINDING: rsvps has no unique constraint on (sessionId, guestId) and the
+  // route inserts blindly, so a repeated add duplicates the RSVP and inflates
+  // attendee counts. Expected behavior is one RSVP per (guest, session) pair.
+  // Remove `.fails` once the server enforces uniqueness (upsert or constraint).
+  it.fails(
+    "adding twice keeps a single RSVP per (guest, session)",
+    async () => {
+      const event = await createEvent({ phase: "scheduling" });
+      const guest = await createGuest();
+      const session = await createSession(event.id);
+
+      for (let i = 0; i < 2; i++) {
+        const res = await toggleRsvp(
+          makeToggleReq({ sessionId: session.id, guestId: guest.id })
+        );
+        expect(res.ok).toBe(true);
+      }
+
+      expect(await rsvpsForGuest(guest.id)).toHaveLength(1);
+    }
+  );
+
+  it("GET /api/rsvps lists by guest or by session and rejects missing params", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const alice = await createGuest({ name: "Alice" });
+    const bob = await createGuest({ name: "Bob" });
+    const session = await createSession(event.id);
+    const otherSession = await createSession(event.id, {
+      title: "Other Session",
+    });
+
+    for (const guest of [alice, bob]) {
+      await toggleRsvp(
+        makeToggleReq({ sessionId: session.id, guestId: guest.id })
+      );
+    }
+    await toggleRsvp(
+      makeToggleReq({ sessionId: otherSession.id, guestId: alice.id })
+    );
+
+    const aliceRsvps = await rsvpsForGuest(alice.id);
+    expect(aliceRsvps.map((r) => r.sessionId).sort()).toEqual(
+      [session.id, otherSession.id].sort()
+    );
+
+    const bySession = await getRsvps(
+      new NextRequest(`http://test/api/rsvps?session=${session.id}`)
+    );
+    expect(bySession.ok).toBe(true);
+    const sessionRsvps = (await bySession.json()) as Rsvp[];
+    expect(sessionRsvps.map((r) => r.guestId).sort()).toEqual(
+      [alice.id, bob.id].sort()
+    );
+
+    const missing = await getRsvps(new NextRequest("http://test/api/rsvps"));
+    expect(missing.status).toBe(400);
+  });
+});

--- a/tests/integration/voting.test.ts
+++ b/tests/integration/voting.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createProposal } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { VoteChoice, type Vote } from "@/db/repositories/interfaces";
+import { POST as addVote } from "@/app/api/add-vote/route";
+import { POST as deleteVote } from "@/app/api/delete-vote/route";
+import { GET as getVotes } from "@/app/api/votes/route";
+
+function makeAddReq(payload: unknown): Request {
+  return new Request("http://test/api/add-vote", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+function makeDeleteReq(payload: unknown): Request {
+  return new Request("http://test/api/delete-vote", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+// Read surface: GET /api/votes?user=<guestId>&event=<eventName>
+async function votesFor(guestId: string, eventName: string): Promise<Vote[]> {
+  const res = await getVotes(
+    new NextRequest(
+      `http://test/api/votes?user=${guestId}&event=${encodeURIComponent(eventName)}`
+    )
+  );
+  expect(res.ok).toBe(true);
+  return (await res.json()) as Vote[];
+}
+
+describe("voting API", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("add-vote creates a vote visible via GET /api/votes", async () => {
+    const event = await createEvent({ name: "Vote Event", phase: "voting" });
+    const guest = await createGuest();
+    const proposal = await createProposal(event.id, []);
+
+    const res = await addVote(
+      makeAddReq({
+        proposalId: proposal.id,
+        guestId: guest.id,
+        choice: VoteChoice.interested,
+      })
+    );
+    expect(res.ok).toBe(true);
+
+    const votes = await votesFor(guest.id, "Vote Event");
+    expect(votes).toHaveLength(1);
+    expect(votes[0]).toMatchObject({
+      proposalId: proposal.id,
+      guestId: guest.id,
+      choice: VoteChoice.interested,
+    });
+  });
+
+  it("repeated add-vote for the same (guest, proposal) replaces instead of duplicating", async () => {
+    const event = await createEvent({ name: "Vote Event", phase: "voting" });
+    const guest = await createGuest();
+    const proposal = await createProposal(event.id, []);
+
+    for (const choice of [
+      VoteChoice.interested,
+      VoteChoice.maybe,
+      VoteChoice.skip,
+    ]) {
+      const res = await addVote(
+        makeAddReq({ proposalId: proposal.id, guestId: guest.id, choice })
+      );
+      expect(res.ok).toBe(true);
+    }
+
+    const votes = await votesFor(guest.id, "Vote Event");
+    expect(votes).toHaveLength(1);
+    expect(votes[0].choice).toBe(VoteChoice.skip);
+  });
+
+  it("delete-vote removes only the deleting guest's vote", async () => {
+    const event = await createEvent({ name: "Vote Event", phase: "voting" });
+    const alice = await createGuest({ name: "Alice" });
+    const bob = await createGuest({ name: "Bob" });
+    const proposal = await createProposal(event.id, []);
+
+    for (const guest of [alice, bob]) {
+      await addVote(
+        makeAddReq({
+          proposalId: proposal.id,
+          guestId: guest.id,
+          choice: VoteChoice.interested,
+        })
+      );
+    }
+
+    const res = await deleteVote(
+      makeDeleteReq({ guestId: alice.id, proposalId: proposal.id })
+    );
+    expect(res.ok).toBe(true);
+
+    expect(await votesFor(alice.id, "Vote Event")).toHaveLength(0);
+    expect(await votesFor(bob.id, "Vote Event")).toHaveLength(1);
+  });
+
+  it("GET /api/votes scopes votes to the given guest and event", async () => {
+    const eventA = await createEvent({ name: "Event A", phase: "voting" });
+    const eventB = await createEvent({ name: "Event B", phase: "voting" });
+    const guest = await createGuest();
+    const proposalA = await createProposal(eventA.id, []);
+    const proposalB = await createProposal(eventB.id, []);
+
+    await addVote(
+      makeAddReq({
+        proposalId: proposalA.id,
+        guestId: guest.id,
+        choice: VoteChoice.interested,
+      })
+    );
+    await addVote(
+      makeAddReq({
+        proposalId: proposalB.id,
+        guestId: guest.id,
+        choice: VoteChoice.maybe,
+      })
+    );
+
+    const votesA = await votesFor(guest.id, "Event A");
+    expect(votesA).toHaveLength(1);
+    expect(votesA[0].proposalId).toBe(proposalA.id);
+  });
+
+  it("GET /api/votes requires user and event and rejects unknown events", async () => {
+    const missingParams = await getVotes(
+      new NextRequest("http://test/api/votes?user=someone")
+    );
+    expect(missingParams.status).toBe(400);
+
+    const unknownEvent = await getVotes(
+      new NextRequest("http://test/api/votes?user=someone&event=No%20Such")
+    );
+    expect(unknownEvent.status).toBe(404);
+  });
+
+  it("proposal tallies reflect mixed interested/maybe/skip votes", async () => {
+    const event = await createEvent({ name: "Vote Event", phase: "voting" });
+    const guests = await Promise.all([
+      createGuest({ name: "G1" }),
+      createGuest({ name: "G2" }),
+      createGuest({ name: "G3" }),
+      createGuest({ name: "G4" }),
+    ]);
+    const proposal = await createProposal(event.id, []);
+    const other = await createProposal(event.id, []);
+
+    const choices = [
+      VoteChoice.interested,
+      VoteChoice.interested,
+      VoteChoice.maybe,
+      VoteChoice.skip,
+    ];
+    for (let i = 0; i < guests.length; i++) {
+      await addVote(
+        makeAddReq({
+          proposalId: proposal.id,
+          guestId: guests[i].id,
+          choice: choices[i],
+        })
+      );
+    }
+
+    const proposals = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    const tallied = proposals.find((p) => p.id === proposal.id)!;
+    // votesCount counts every vote, including skips
+    expect(tallied.votesCount).toBe(4);
+    expect(tallied.interestedVotesCount).toBe(2);
+    expect(tallied.maybeVotesCount).toBe(1);
+
+    const untouched = proposals.find((p) => p.id === other.id)!;
+    expect(untouched.votesCount).toBe(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,11 +9,14 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],
+      exclude: ["tests/**"],
+      // Slightly below actual coverage (see `make test-coverage`) so real
+      // regressions fail while small refactors don't. Ratchet up over time.
       thresholds: {
-        statements: 60,
-        branches: 50,
-        functions: 50,
-        lines: 60,
+        statements: 85,
+        branches: 84,
+        functions: 80,
+        lines: 85,
       },
     },
   },


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [54c7564](https://github.com/LWCW-Europe/schellingboard/pull/514/commits/54c7564a66d242ac495d035dc40542db7ec4a4aa).

PRs:
* ➡️ #514 (this PR, depends on the ones below ⬇️)
* #511

---

## Description

Raise vitest coverage thresholds to just below actual coverage and
exclude test helpers from the report, so meaningful regressions in
tested code fail CI. The CI test job now runs make test-coverage.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=54c7564a66d242ac495d035dc40542db7ec4a4aa -->