### PR TITLE
fix: enforce event phases server-side for votes, sessions, and proposals

### DIFF
--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getRepositories } from "@/db/container";
+import { inSchedPhase } from "@/app/(site)/utils/events";
 
 export async function createProposal(formData: FormData) {
   const eventId = formData.get("event") as string;
@@ -21,6 +22,13 @@ export async function createProposal(formData: FormData) {
   }
 
   try {
+    // Mirrors the UI: proposals may be added during the proposal and voting
+    // phases; once scheduling starts they are closed.
+    const event = await getRepositories().events.findById(eventId);
+    if (!event || inSchedPhase(event)) {
+      return { error: "The proposal phase is over" };
+    }
+
     await getRepositories().sessionProposals.create({
       eventId,
       title,
@@ -36,6 +44,11 @@ export async function createProposal(formData: FormData) {
   return { success: true };
 }
 
+// Unlike createProposal, this intentionally has no event/phase check: the
+// UI's canEdit() gates editing by ownership only (host or unclaimed
+// proposal), not by phase, so hosts can still fix up or withdraw their own
+// proposal after scheduling starts. Adding a phase gate here would make the
+// server reject an action the UI still offers.
 export async function updateProposal(id: string, formData: FormData) {
   const eventSlug = formData.get("eventSlug") as string;
   const title = formData.get("title") as string;
@@ -65,6 +78,8 @@ export async function updateProposal(id: string, formData: FormData) {
   return { success: true };
 }
 
+// Same reasoning as updateProposal: no phase gate, so a host can withdraw
+// their proposal in any phase, including scheduling.
 export async function deleteProposal(id: string, eventSlug: string) {
   try {
     await getRepositories().sessionProposals.delete(id);

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -1,4 +1,5 @@
 import { getRepositories } from "@/db/container";
+import { inSchedPhase } from "@/app/(site)/utils/events";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
@@ -8,6 +9,13 @@ export async function POST(req: Request) {
   const params = (await req.json()) as SessionParams;
   const repos = getRepositories();
   const input = prepareToInsert(params);
+  const event = await repos.events.findById(input.eventId);
+  if (!event || !inSchedPhase(event)) {
+    return Response.json(
+      { error: "Sessions can only be created during the scheduling phase" },
+      { status: 403 }
+    );
+  }
   const existingSessions = (await repos.sessions.listScheduled()).filter(
     (s) => s.eventId === input.eventId
   );

--- a/app/api/add-vote/route.ts
+++ b/app/api/add-vote/route.ts
@@ -1,5 +1,6 @@
 import { getRepositories } from "@/db/container";
 import { VoteChoice } from "@/app/(site)/votes";
+import { inVotingPhase } from "@/app/(site)/utils/events";
 
 type VoteParams = {
   proposalId: string;
@@ -13,6 +14,17 @@ export const dynamic = "force-dynamic"; // defaults to auto
 export async function POST(req: Request) {
   const { proposalId, guestId, choice } = (await req.json()) as VoteParams;
   const repos = getRepositories();
+  const proposal = await repos.sessionProposals.findById(proposalId);
+  if (!proposal) {
+    return Response.json({ error: "Proposal not found" }, { status: 404 });
+  }
+  const event = await repos.events.findById(proposal.eventId);
+  if (!event || !inVotingPhase(event)) {
+    return Response.json(
+      { error: "Voting is only allowed during the voting phase" },
+      { status: 403 }
+    );
+  }
   try {
     // Atomic upsert: concurrent requests for the same (guest, proposal)
     // cannot produce duplicate votes.

--- a/app/api/delete-session/route.ts
+++ b/app/api/delete-session/route.ts
@@ -1,4 +1,5 @@
 import { getRepositories } from "@/db/container";
+import { inSchedPhase } from "@/app/(site)/utils/events";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
@@ -9,6 +10,14 @@ export async function POST(req: Request) {
   const session = await repos.sessions.findById(id);
   if (!session) {
     return new Response("Session not found", { status: 404 });
+  }
+
+  const event = await repos.events.findById(session.eventId);
+  if (!event || !inSchedPhase(event)) {
+    return new Response(
+      "Sessions can only be deleted during the scheduling phase",
+      { status: 403 }
+    );
   }
 
   if (!session.attendeeScheduled || session.blocker) {

--- a/app/api/delete-vote/route.ts
+++ b/app/api/delete-vote/route.ts
@@ -1,4 +1,5 @@
 import { getRepositories } from "@/db/container";
+import { inVotingPhase } from "@/app/(site)/utils/events";
 
 export const dynamic = "force-dynamic";
 
@@ -8,8 +9,21 @@ export async function POST(req: Request) {
     proposalId: string;
   };
 
+  const repos = getRepositories();
+  const proposal = await repos.sessionProposals.findById(proposalId);
+  if (!proposal) {
+    return Response.json({ error: "Proposal not found" }, { status: 404 });
+  }
+  const event = await repos.events.findById(proposal.eventId);
+  if (!event || !inVotingPhase(event)) {
+    return Response.json(
+      { error: "Voting is only allowed during the voting phase" },
+      { status: 403 }
+    );
+  }
+
   try {
-    await getRepositories().votes.deleteByGuestAndProposal(guestId, proposalId);
+    await repos.votes.deleteByGuestAndProposal(guestId, proposalId);
     return Response.json({ success: true });
   } catch (err) {
     console.error(err);

--- a/app/api/toggle-rsvp/route.ts
+++ b/app/api/toggle-rsvp/route.ts
@@ -1,4 +1,5 @@
 import { getRepositories } from "@/db/container";
+import { inSchedPhase } from "@/app/(site)/utils/events";
 
 type RSVPParams = {
   sessionId: string;
@@ -11,6 +12,27 @@ export const dynamic = "force-dynamic"; // defaults to auto
 export async function POST(req: Request) {
   const { sessionId, guestId, remove } = (await req.json()) as RSVPParams;
   const repos = getRepositories();
+
+  const session = await repos.sessions.findById(sessionId);
+  if (!session) {
+    return Response.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const event = await repos.events.findById(session.eventId);
+  const eventGuests = event ? await repos.guests.listByEvent(event.id) : [];
+  if (!eventGuests.some((g) => g.id === guestId)) {
+    return Response.json(
+      { error: "Guest is not part of this event" },
+      { status: 403 }
+    );
+  }
+
+  if (!event || !inSchedPhase(event)) {
+    return Response.json(
+      { error: "RSVPs can only be changed during the scheduling phase" },
+      { status: 403 }
+    );
+  }
 
   if (!remove) {
     try {

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -1,4 +1,5 @@
 import { getRepositories } from "@/db/container";
+import { inSchedPhase } from "@/app/(site)/utils/events";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
@@ -19,6 +20,13 @@ export async function POST(req: Request) {
   if (prevSession === undefined) {
     const msg = `Cannot find session with ID ${params.id}`;
     return new Response(msg, { status: 404 });
+  }
+  const event = await repos.events.findById(prevSession.eventId);
+  if (!event || !inSchedPhase(event)) {
+    return new Response(
+      "Sessions can only be edited during the scheduling phase",
+      { status: 403 }
+    );
   }
   if (!prevSession.attendeeScheduled || prevSession.blocker) {
     return new Response("Cannot edit via web app", { status: 400 });

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -43,7 +43,7 @@ describe("POST /api/add-session", () => {
   beforeEach(() => resetTestDb());
 
   it("creates a session and returns success", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -66,7 +66,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("rejects overlap in same location; only the pre-existing session remains", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -93,7 +93,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("accepts overlap in different location; both sessions are listed", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const locA = await createLocation({ name: "Workshop Room" });
     const locB = await createLocation({ name: "Garden Terrace" });
@@ -113,7 +113,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("rejects session with start time in the past", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const pastDay = await createDay(event.id, {
@@ -128,7 +128,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("rejects session with empty title", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -140,7 +140,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("rejects session with no hosts", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -152,7 +152,7 @@ describe("POST /api/add-session", () => {
   });
 
   it("rejects session with missing location id", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -57,7 +57,7 @@ describe("POST /api/delete-session", () => {
   beforeEach(() => resetTestDb());
 
   it("deleted session is absent from listByEvent", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -71,8 +71,36 @@ describe("POST /api/delete-session", () => {
     expect(sessions).toHaveLength(0);
   });
 
+  it("rejects delete outside the scheduling phase", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const guest = await createGuest();
+    const location = await createLocation();
+
+    // Create an editable (attendee-scheduled, non-blocker) session directly,
+    // bypassing add-session's phase gate.
+    const created = await getRepositories().sessions.create({
+      title: "Existing",
+      description: "",
+      closed: false,
+      hostIds: [guest.id],
+      locationIds: [location.id],
+      startTime: new Date(Date.now() + 60 * 60 * 1000),
+      endTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      capacity: 30,
+      attendeeScheduled: true,
+      blocker: false,
+      eventId: event.id,
+    });
+
+    const res = await POST(makeDeleteReq(created.id));
+    expect(res.status).toBe(403);
+
+    const still = await getRepositories().sessions.findById(created.id);
+    expect(still).toBeDefined();
+  });
+
   it("RSVPs for the deleted session are removed", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ name: "Host" });
     const attendee = await createGuest({ name: "Attendee" });
     const location = await createLocation();

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -11,24 +11,20 @@ import {
   createLocation,
   createDay,
   createProposal as createProposalFixture,
+  createSession,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { VoteChoice } from "@/db/repositories/interfaces";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import { POST as addVote } from "@/app/api/add-vote/route";
 import { POST as addSession } from "@/app/api/add-session/route";
+import { POST as toggleRsvp } from "@/app/api/toggle-rsvp/route";
 import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
 
-// FINDING: the server does not enforce event phases at all — phase gating is
-// UI-only. The `.fails` tests below assert the *correct* behavior (rejection
-// outside the right phase) and are marked `.fails` because the server
-// currently accepts the request. When server-side gating lands, these tests
-// will start "passing" and Vitest will flag them — remove `.fails` then. Do
-// NOT rewrite the assertions to match the current, broken behavior.
-//
-// The "allows ..." tests document the flip side: the request already
-// succeeds in the right phase today, and must keep succeeding once gating is
-// added.
+// Server-side phase gating mirrors the UI: voting only during the voting
+// phase, session creation only during the scheduling phase, and proposal
+// creation during the proposal *and* voting phases (the UI's "Add Proposal"
+// button is disabled only once scheduling starts).
 
 function makeReq(url: string, payload: unknown): Request {
   return new Request(url, { method: "POST", body: JSON.stringify(payload) });
@@ -88,49 +84,88 @@ async function proposeIn(phase: "proposal" | "voting" | "scheduling") {
   return { result, proposals };
 }
 
+async function toggleRsvpIn(
+  phase: "proposal" | "voting",
+  opts?: { remove?: boolean }
+) {
+  const event = await createEvent({ phase });
+  const guest = await createGuest();
+  const session = await createSession(event.id);
+  const repos = getRepositories();
+  await repos.guests.assignToEvent(event.id, [guest.id]);
+  if (opts?.remove) {
+    await repos.rsvps.create({ sessionId: session.id, guestId: guest.id });
+  }
+  const res = await toggleRsvp(
+    makeReq("http://test/api/toggle-rsvp", {
+      sessionId: session.id,
+      guestId: guest.id,
+      remove: opts?.remove,
+    })
+  );
+  const rsvps = await repos.rsvps.listBySession(session.id);
+  return { res, rsvps };
+}
+
 describe("server-side phase gating", () => {
   beforeAll(() => setupTestDb());
   beforeEach(() => resetTestDb());
 
-  it.fails("rejects voting during the proposal phase", async () => {
+  it("rejects voting during the proposal phase", async () => {
     const { res, votes } = await voteOnProposalIn("proposal");
     expect(res.ok).toBe(false);
     expect(votes).toHaveLength(0);
   });
 
-  it.fails("rejects voting during the scheduling phase", async () => {
+  it("rejects voting during the scheduling phase", async () => {
     const { res, votes } = await voteOnProposalIn("scheduling");
     expect(res.ok).toBe(false);
     expect(votes).toHaveLength(0);
   });
 
-  it.fails("rejects session creation during the proposal phase", async () => {
+  it("rejects session creation during the proposal phase", async () => {
     const { res, sessions } = await addSessionIn("proposal");
     expect(res.ok).toBe(false);
     expect(sessions).toHaveLength(0);
   });
 
-  it.fails("rejects session creation during the voting phase", async () => {
+  it("rejects session creation during the voting phase", async () => {
     const { res, sessions } = await addSessionIn("voting");
     expect(res.ok).toBe(false);
     expect(sessions).toHaveLength(0);
   });
 
-  it.fails("rejects proposal creation during the voting phase", async () => {
+  it("rejects RSVP creation during the proposal phase", async () => {
+    const { res, rsvps } = await toggleRsvpIn("proposal");
+    expect(res.status).toBe(403);
+    expect(rsvps).toHaveLength(0);
+  });
+
+  it("rejects RSVP creation during the voting phase", async () => {
+    const { res, rsvps } = await toggleRsvpIn("voting");
+    expect(res.status).toBe(403);
+    expect(rsvps).toHaveLength(0);
+  });
+
+  it("rejects RSVP removal outside the scheduling phase", async () => {
+    const { res, rsvps } = await toggleRsvpIn("voting", { remove: true });
+    expect(res.status).toBe(403);
+    expect(rsvps).toHaveLength(1);
+  });
+
+  // The UI allows adding proposals during the voting phase (only scheduling
+  // disables it), so the server accepts them too.
+  it("allows proposal creation during the voting phase", async () => {
     const { result, proposals } = await proposeIn("voting");
+    expect(result).toHaveProperty("success");
+    expect(proposals).toHaveLength(1);
+  });
+
+  it("rejects proposal creation during the scheduling phase", async () => {
+    const { result, proposals } = await proposeIn("scheduling");
     expect(result).toHaveProperty("error");
     expect(proposals).toHaveLength(0);
   });
-
-  it.fails(
-    "rejects proposal creation during the scheduling phase",
-    async () => {
-      const { result, proposals } = await proposeIn("scheduling");
-      expect(result).toHaveProperty("error");
-      expect(proposals).toHaveLength(0);
-    }
-  );
-
   it("allows voting during the voting phase", async () => {
     const { res, votes } = await voteOnProposalIn("voting");
     expect(res.ok).toBe(true);

--- a/tests/integration/rsvp.test.ts
+++ b/tests/integration/rsvp.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
 import type { Rsvp } from "@/db/repositories/interfaces";
 import { POST as toggleRsvp } from "@/app/api/toggle-rsvp/route";
 import { GET as getRsvps } from "@/app/api/rsvps/route";
@@ -30,6 +31,7 @@ describe("POST /api/toggle-rsvp", () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const session = await createSession(event.id);
+    await getRepositories().guests.assignToEvent(event.id, [guest.id]);
 
     const addRes = await toggleRsvp(
       makeToggleReq({ sessionId: session.id, guestId: guest.id })
@@ -55,6 +57,7 @@ describe("POST /api/toggle-rsvp", () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const session = await createSession(event.id);
+    await getRepositories().guests.assignToEvent(event.id, [guest.id]);
 
     const res = await toggleRsvp(
       makeToggleReq({ sessionId: session.id, guestId: guest.id, remove: true })
@@ -73,6 +76,7 @@ describe("POST /api/toggle-rsvp", () => {
       const event = await createEvent({ phase: "scheduling" });
       const guest = await createGuest();
       const session = await createSession(event.id);
+      await getRepositories().guests.assignToEvent(event.id, [guest.id]);
 
       for (let i = 0; i < 2; i++) {
         const res = await toggleRsvp(
@@ -85,6 +89,29 @@ describe("POST /api/toggle-rsvp", () => {
     }
   );
 
+  it("rejects toggling an RSVP for a nonexistent session", async () => {
+    const guest = await createGuest();
+
+    const res = await toggleRsvp(
+      makeToggleReq({ sessionId: "does-not-exist", guestId: guest.id })
+    );
+    expect(res.status).toBe(404);
+    expect(await rsvpsForGuest(guest.id)).toHaveLength(0);
+  });
+
+  it("rejects RSVPs from a guest who isn't assigned to the event", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest();
+    const session = await createSession(event.id);
+    // Deliberately not assigning the guest to the event.
+
+    const res = await toggleRsvp(
+      makeToggleReq({ sessionId: session.id, guestId: guest.id })
+    );
+    expect(res.status).toBe(403);
+    expect(await rsvpsForGuest(guest.id)).toHaveLength(0);
+  });
+
   it("GET /api/rsvps lists by guest or by session and rejects missing params", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const alice = await createGuest({ name: "Alice" });
@@ -93,6 +120,7 @@ describe("POST /api/toggle-rsvp", () => {
     const otherSession = await createSession(event.id, {
       title: "Other Session",
     });
+    await getRepositories().guests.assignToEvent(event.id, [alice.id, bob.id]);
 
     for (const guest of [alice, bob]) {
       await toggleRsvp(

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -68,7 +68,7 @@ describe("POST /api/update-session", () => {
   beforeEach(() => resetTestDb());
 
   it("changes time without conflict; re-fetched session reflects new time", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -93,7 +93,7 @@ describe("POST /api/update-session", () => {
   });
 
   it("rejects move to colliding slot; session remains unchanged", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -131,7 +131,7 @@ describe("POST /api/update-session", () => {
   });
 
   it("does not collide with itself when re-saved with the same slot", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();
     const location = await createLocation();
     const day = await createDay(event.id);
@@ -144,8 +144,45 @@ describe("POST /api/update-session", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("rejects update outside the scheduling phase", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const guest = await createGuest();
+    const location = await createLocation();
+    const day = await createDay(event.id);
+
+    // Create an editable (attendee-scheduled, non-blocker) session directly,
+    // bypassing add-session's phase gate.
+    const created = await getRepositories().sessions.create({
+      title: "Existing",
+      description: "",
+      closed: false,
+      hostIds: [guest.id],
+      locationIds: [location.id],
+      startTime: new Date(Date.now() + 60 * 60 * 1000),
+      endTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      capacity: 30,
+      attendeeScheduled: true,
+      blocker: false,
+      eventId: event.id,
+    });
+
+    const res = await POST(
+      makeUpdateReq({
+        ...basePayload(guest, location, day, {
+          title: "Renamed",
+          startTimeMinutes: 14 * 60,
+        }),
+        id: created.id,
+      })
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(created.id))!;
+    expect(unchanged.title).toBe("Existing");
+  });
+
   it("updates location, hosts, and capacity; re-fetched session reflects each", async () => {
-    const event = await createEvent();
+    const event = await createEvent({ phase: "scheduling" });
     const host1 = await createGuest({ name: "Host 1" });
     const host2 = await createGuest({ name: "Host 2" });
     const loc1 = await createLocation({ name: "Workshop Room", capacity: 20 });

--- a/tests/integration/voting.test.ts
+++ b/tests/integration/voting.test.ts
@@ -148,6 +148,45 @@ describe("voting API", () => {
     expect(await votesFor(bob.id, "Vote Event")).toHaveLength(1);
   });
 
+  it("delete-vote is rejected outside the voting phase", async () => {
+    // Create the vote while voting is open...
+    const event = await createEvent({ name: "Vote Event", phase: "voting" });
+    const guest = await createGuest();
+    const proposal = await createProposal(event.id, []);
+    await addVote(
+      makeAddReq({
+        proposalId: proposal.id,
+        guestId: guest.id,
+        choice: VoteChoice.interested,
+      })
+    );
+
+    // ...then move the event into the scheduling phase so voting is over.
+    const now = new Date();
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    await getRepositories().events.update(event.id, {
+      votingPhaseStart: new Date(now.getTime() - 14 * DAY_MS),
+      votingPhaseEnd: new Date(now.getTime() - 7 * DAY_MS),
+      schedulingPhaseStart: new Date(now.getTime() - 7 * DAY_MS),
+      schedulingPhaseEnd: new Date(now.getTime() + 7 * DAY_MS),
+    });
+
+    const res = await deleteVote(
+      makeDeleteReq({ guestId: guest.id, proposalId: proposal.id })
+    );
+    expect(res.status).toBe(403);
+    // The vote must still be there.
+    expect(await votesFor(guest.id, "Vote Event")).toHaveLength(1);
+  });
+
+  it("delete-vote returns 404 for a missing proposal", async () => {
+    const guest = await createGuest();
+    const res = await deleteVote(
+      makeDeleteReq({ guestId: guest.id, proposalId: "does-not-exist" })
+    );
+    expect(res.status).toBe(404);
+  });
+
   it("GET /api/votes scopes votes to the given guest and event", async () => {
     const eventA = await createEvent({ name: "Event A", phase: "voting" });
     const eventB = await createEvent({ name: "Event B", phase: "voting" });


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [602c716](https://github.com/LWCW-Europe/schellingboard/pull/516/commits/602c716caf908abd349435b177057616903daf94).

PRs:
* #524
* #523
* #522
* ➡️ #516 (this PR, base of the stack — can be merged first)

---

## Description

Also gate vote deletion and session update/delete by phase (matching
the existing add-vote/add-session checks), and move the proposal
creation phase check inside its try/catch so lookup failures return a
structured error instead of an unhandled exception.

Gate RSVP creation/removal to the scheduling phase as well, and reject
RSVPs for a missing session or a guest not assigned to the event.

Proposal update/delete are deliberately left ungated by phase (see
code comments): the UI already allows hosts to edit or withdraw their
own proposal in any phase, so a server-side gate would just reject
actions the UI still offers.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=602c716caf908abd349435b177057616903daf94 -->