### PR TITLE
Email infrastructure

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -11,4 +11,4 @@ UPLOADS_DIR=./uploads-test/
 # To skip tests that send emails, set these to blank in .env.test.local.
 MAILPIT_API_URL=http://localhost:8025
 SMTP_URL=smtp://localhost:1025
-SMTP_FROM=mailer-test@test.example
+SMTP_FROM='Test <mailer-test@test.example>'

--- a/.env.test
+++ b/.env.test
@@ -7,3 +7,8 @@ ADMIN_PASSWORD=admintest
 AUTH_SECRET=test-only-do-not-use-in-production-7f4c8e2a1b9d6f3e
 DATABASE_URL=file:./data.test.db
 UPLOADS_DIR=./uploads-test/
+
+# To skip tests that send emails, set these to blank in .env.test.local.
+MAILPIT_API_URL=http://localhost:8025
+SMTP_URL=smtp://localhost:1025
+SMTP_FROM=mailer-test@test.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      # The mailer integration test sends real email to mailpit (see
+      # CONTRIBUTING.md § Running tests). Same pinned image as
+      # docker-compose.yml.
+      mailpit:
+        image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd "/mailpit readyz"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,12 +80,14 @@ has its own layout and only requires the admin password (not `SITE_PASSWORD`).
 
 ### Optional
 
-| Variable         | Description                                                                                                                        |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `SITE_PASSWORD`  | Enables site-wide password protection. Omit to disable.                                                                            |
-| `ADMIN_PASSWORD` | Enables the admin UI at `/admin`. Omit to disable (admin routes return a diagnostic message).                                      |
-| `AUTH_SECRET`    | HMAC secret used to sign auth cookies. Required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Use ≥32 random bytes.             |
-| `UPLOADS_DIR`    | Directory for admin-uploaded files (location images). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist. |
+| Variable         | Description                                                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SITE_PASSWORD`  | Enables site-wide password protection. Omit to disable.                                                                                                                                    |
+| `ADMIN_PASSWORD` | Enables the admin UI at `/admin`. Omit to disable (admin routes return a diagnostic message).                                                                                              |
+| `AUTH_SECRET`    | HMAC secret used to sign auth cookies. Required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Use ≥32 random bytes.                                                                     |
+| `UPLOADS_DIR`    | Directory for admin-uploaded files (location images). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist.                                                         |
+| `SMTP_URL`       | SMTP connection URL (e.g. `smtp://localhost:1025`) used to send email. Omit to disable email sending. Supports [nodemailer URL options](https://nodemailer.com/smtp/) as query parameters. |
+| `SMTP_FROM`      | Sender address for outgoing email (e.g. `SchellingBoard <noreply@example.org>`). Required when `SMTP_URL` is set.                                                                          |
 
 `NEXT_PUBLIC_` variables are exposed to the browser; all others are server-side only.
 
@@ -164,6 +166,8 @@ make test-e2e-headed     # Run E2E tests (headed, for local dev)
 ```
 
 **Warning**: E2E tests reset the test database before each run. Do not run against production data.
+
+By default, `make test` tests that we can successfully send email to a local [mailpit](https://mailpit.axllent.org/) (start it with `docker compose up mailpit`). You can skip that test by setting `MAILPIT_API_URL` to blank in `.env.test.local`.
 
 Install Playwright browsers before first use:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,14 +80,13 @@ has its own layout and only requires the admin password (not `SITE_PASSWORD`).
 
 ### Optional
 
-| Variable         | Description                                                                                                                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SITE_PASSWORD`  | Enables site-wide password protection. Omit to disable.                                                                                                                                    |
-| `ADMIN_PASSWORD` | Enables the admin UI at `/admin`. Omit to disable (admin routes return a diagnostic message).                                                                                              |
-| `AUTH_SECRET`    | HMAC secret used to sign auth cookies. Required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Use ≥32 random bytes.                                                                     |
-| `UPLOADS_DIR`    | Directory for admin-uploaded files (location images). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist.                                                         |
-| `SMTP_URL`       | SMTP connection URL (e.g. `smtp://localhost:1025`) used to send email. Omit to disable email sending. Supports [nodemailer URL options](https://nodemailer.com/smtp/) as query parameters. |
-| `SMTP_FROM`      | Sender address for outgoing email (e.g. `SchellingBoard <noreply@example.org>`). Required when `SMTP_URL` is set.                                                                          |
+| Variable         | Description                                                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `SITE_PASSWORD`  | Enables site-wide password protection. Omit to disable.                                                                            |
+| `ADMIN_PASSWORD` | Enables the admin UI at `/admin`. Omit to disable (admin routes return a diagnostic message).                                      |
+| `AUTH_SECRET`    | HMAC secret used to sign auth cookies. Required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Use ≥32 random bytes.             |
+| `UPLOADS_DIR`    | Directory for admin-uploaded files (location images). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist. |
+| `SMTP_*`         | See "email variables" below.                                                                                                       |
 
 `NEXT_PUBLIC_` variables are exposed to the browser; all others are server-side only.
 
@@ -96,6 +95,23 @@ Generate a fresh `AUTH_SECRET`:
 ```bash
 openssl rand -base64 32
 ```
+
+### Email variables
+
+If you don't want to send email from the app, leave all of these options blank
+(unset or empty string). If you do want to send email, set `SMTP_FROM` and
+exactly one of `SMTP_URL` and `SMTP_HOST`. If you set `HOST`, you may optionally
+set `PORT`/`USER`/`PASSWORD`/`SECURE`.
+
+| Variable        | Description                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SMTP_FROM`     | Sender address for outgoing email (e.g. `SchellingBoard <noreply@example.org>`).                                                                                                             |
+| `SMTP_URL`      | SMTP connection URL (e.g. `smtp://localhost:1025`) used to send email. Supports [nodemailer URL options](https://nodemailer.com/smtp/) as query parameters.                                  |
+| `SMTP_HOST`     | SMTP server hostname.                                                                                                                                                                        |
+| `SMTP_PORT`     | SMTP server port (defaults to 465 with `SECURE=true` or 587 otherwise).                                                                                                                      |
+| `SMTP_USER`     | SMTP username.                                                                                                                                                                               |
+| `SMTP_PASSWORD` | SMTP password.                                                                                                                                                                               |
+| `SMTP_SECURE`   | One of `true` (wrap SMTP inside TLS), `false` (upgrade to TLS after connecting, if supported by the server), or `requireTLS` (default; upgrade after connecting, and fail if not supported). |
 
 ## Development Commands
 

--- a/app/actions/admin-guests.ts
+++ b/app/actions/admin-guests.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { sendMail } from "@/utils/mailer";
 
 export type AdminActionResult = { ok: true } | { ok: false; error: string };
 
@@ -76,5 +77,29 @@ export async function deleteGuestAction(input: {
 
   await guests.delete(input.id);
   revalidatePath("/admin/users");
+  return { ok: true };
+}
+
+export async function sendTestEmailAction(input: {
+  id: string;
+}): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const { guests } = getRepositories();
+  const guest = await guests.findById(input.id);
+  if (!guest) return { ok: false, error: "User not found" };
+
+  try {
+    await sendMail({
+      to: guest.info.email,
+      subject: "Test email",
+      text: "test email",
+    });
+  } catch (err) {
+    console.error("Failed to send test email:", err);
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Failed to send test email: ${detail}` };
+  }
+
   return { ok: true };
 }

--- a/app/admin/guests-manager.tsx
+++ b/app/admin/guests-manager.tsx
@@ -8,6 +8,7 @@ import {
   createGuestAction,
   updateGuestAction,
   deleteGuestAction,
+  sendTestEmailAction,
 } from "../actions/admin-guests";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON, DANGER_BUTTON } from "./buttons";
 
@@ -82,6 +83,8 @@ function GuestRow({
   const [name, setName] = useState(guest.name);
   const [email, setEmail] = useState(guest.info.email);
   const [isPending, startTransition] = useTransition();
+  const [isSendingEmail, startEmailTransition] = useTransition();
+  const [emailSent, setEmailSent] = useState(false);
 
   const startEdit = () => {
     setName(guest.name);
@@ -107,6 +110,19 @@ function GuestRow({
     startTransition(async () => {
       const result = await deleteGuestAction({ id: guest.id });
       onError(result.ok ? null : result.error);
+    });
+  };
+
+  const handleSendTestEmail = () => {
+    setEmailSent(false);
+    startEmailTransition(async () => {
+      const result = await sendTestEmailAction({ id: guest.id });
+      if (!result.ok) {
+        onError(result.error);
+      } else {
+        onError(null);
+        setEmailSent(true);
+      }
     });
   };
 
@@ -185,6 +201,17 @@ function GuestRow({
         <div className="flex gap-2">
           <button onClick={startEdit} className={SECONDARY_BUTTON}>
             Edit
+          </button>
+          <button
+            onClick={handleSendTestEmail}
+            disabled={isSendingEmail}
+            className={SECONDARY_BUTTON}
+          >
+            {isSendingEmail
+              ? "Sending..."
+              : emailSent
+                ? "Sent!"
+                : "Send test email"}
           </button>
           <button
             onClick={() => {

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "moment-timezone": "^0.6.2",
         "nanoid": "^5.1.16",
         "next": "^16",
+        "nodemailer": "^9.0.3",
         "react": "^19",
         "react-dom": "^19",
         "sharp": "^0.35.2",
@@ -33,6 +34,7 @@
         "@types/lodash": "^4.17.24",
         "@types/luxon": "^3.7.2",
         "@types/node": "^26",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
@@ -418,6 +420,8 @@
     "@types/luxon": ["@types/luxon@3.7.2", "", {}, "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q=="],
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
@@ -972,6 +976,8 @@
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+
+    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,25 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  # Mailpit[1] is a service that receives email locally and shows it in a web
+  # UI. You probably only need to run it if you want to send email from a
+  # development app.
+  #
+  # We give it a profile[2] so that plain `docker compose up` doesn't start it.
+  # You can do either
+  #
+  #     docker compose --profile dev up  # starts `app` too
+  #     docker compose up mailpit        # only starts mailpit
+  #
+  # [1]: https://mailpit.axllent.org/
+  # [2]: https://docs.docker.com/compose/how-tos/profiles/
+  mailpit:
+    image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
+    profiles:
+      - dev
+    ports:
+      - "1025:1025" # SMTP
+      - "8025:8025" # web UI
+
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       DATABASE_URL: file:/data/data.db
       SITE_PASSWORD: ${SITE_PASSWORD:-}
       AUTH_SECRET: ${AUTH_SECRET:-}
+      SMTP_URL: ${SMTP_URL:-}
+      SMTP_FROM: ${SMTP_FROM:-}
     logging:
       driver: json-file
       options:
@@ -33,6 +35,7 @@ services:
   # [1]: https://mailpit.axllent.org/
   # [2]: https://docs.docker.com/compose/how-tos/profiles/
   mailpit:
+    # If you update this pin, update it in .github/workflows/ci.yml too.
     image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
     profiles:
       - dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       SITE_PASSWORD: ${SITE_PASSWORD:-}
       AUTH_SECRET: ${AUTH_SECRET:-}
       SMTP_URL: ${SMTP_URL:-}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_SECURE: ${SMTP_SECURE:-}
       SMTP_FROM: ${SMTP_FROM:-}
     logging:
       driver: json-file

--- a/docs/adr/0002-testing-strategy.md
+++ b/docs/adr/0002-testing-strategy.md
@@ -63,11 +63,11 @@ table schema. Asserting on raw rows means a schema rename breaks the test
 even when user-visible behavior is unchanged — the failure mode this ADR
 is meant to avoid.
 
-The only things mocked are the Next.js boundary primitives that don't
-belong in a unit process: `redirect()` from `next/navigation` (recorded
-instead of thrown) and `revalidatePath()` from `next/cache` (no-op).
-Everything else — repos, schema, migrations, Drizzle, `better-sqlite3` —
-is the real production code path.
+The only things mocked are email sending, and the Next.js boundary primitives
+that don't belong in a unit process: `redirect()` from `next/navigation`
+(recorded instead of thrown) and `revalidatePath()` from `next/cache` (no-op).
+Everything else — repos, schema, migrations, Drizzle, `better-sqlite3` — is the
+real production code path.
 
 ### 3. End-to-end tests — Playwright, existing runner
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,10 @@
+import { initMailer } from "@/utils/mailer";
+
+export function register() {
+  // If we run this app in an edge runtime[1] in future, it won't support email.
+  // So don't init in that case.
+  // [1]: https://nextjs.org/docs/app/api-reference/edge
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    initMailer();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment-timezone": "^0.6.2",
     "nanoid": "^5.1.16",
     "next": "^16",
+    "nodemailer": "^9.0.3",
     "react": "^19",
     "react-dom": "^19",
     "sharp": "^0.35.2"
@@ -32,6 +33,7 @@
     "@types/lodash": "^4.17.24",
     "@types/luxon": "^3.7.2",
     "@types/node": "^26",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.62.1",

--- a/tests/integration/admin-guests.test.ts
+++ b/tests/integration/admin-guests.test.ts
@@ -24,6 +24,10 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -33,11 +37,13 @@ import {
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { createAdminAuthCookie } from "@/utils/auth";
+import { sendMail } from "@/utils/mailer";
 import { VoteChoice } from "@/db/repositories/interfaces";
 import {
   createGuestAction,
   updateGuestAction,
   deleteGuestAction,
+  sendTestEmailAction,
 } from "@/app/actions/admin-guests";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
@@ -53,6 +59,7 @@ describe("admin guest actions", () => {
   beforeEach(async () => {
     resetTestDb();
     cookieJar.clear();
+    vi.mocked(sendMail).mockReset();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
     await loginAsAdmin();
@@ -93,6 +100,16 @@ describe("admin guest actions", () => {
         error: "Unauthorized",
       });
       expect(await getRepositories().guests.findById(guest.id)).toBeDefined();
+    });
+
+    it("rejects sendTestEmailAction without an admin cookie", async () => {
+      const guest = await createGuest();
+      cookieJar.clear();
+      expect(await sendTestEmailAction({ id: guest.id })).toEqual({
+        ok: false,
+        error: "Unauthorized",
+      });
+      expect(sendMail).not.toHaveBeenCalled();
     });
   });
 
@@ -259,6 +276,35 @@ describe("admin guest actions", () => {
         await repos.votes.listByGuestAndEvent(otherGuest.id, event.id)
       ).toHaveLength(1);
       expect(await repos.rsvps.listByGuest(otherGuest.id)).toHaveLength(1);
+    });
+  });
+
+  describe("sendTestEmailAction", () => {
+    it("sends a test email to the guest's address", async () => {
+      const guest = await createGuest({ email: "guest@test.example" });
+      const result = await sendTestEmailAction({ id: guest.id });
+      expect(result).toEqual({ ok: true });
+      expect(sendMail).toHaveBeenCalledWith({
+        to: "guest@test.example",
+        subject: "Test email",
+        text: "test email",
+      });
+    });
+
+    it("errors for an unknown id", async () => {
+      const result = await sendTestEmailAction({ id: "does-not-exist" });
+      expect(result).toEqual({ ok: false, error: "User not found" });
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it("returns a helpful error when sending fails", async () => {
+      vi.mocked(sendMail).mockRejectedValueOnce(new Error("boom"));
+      const guest = await createGuest();
+      const result = await sendTestEmailAction({ id: guest.id });
+      expect(result).toEqual({
+        ok: false,
+        error: "Failed to send test email: boom",
+      });
     });
   });
 });

--- a/tests/integration/mailer.test.ts
+++ b/tests/integration/mailer.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
+
+// Runs only when MAILPIT_API_URL points at a mailpit instance (e.g.
+// http://localhost:8025 via `docker compose up mailpit`). SMTP_URL and
+// SMTP_FROM come from the environment too; .env.test sets all three.
+// Skips when MAILPIT_API_URL is unset or empty; fails when it is set but
+// mailpit is unreachable.
+const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
+
+type MessageSummary = {
+  ID: string;
+  From: { Address: string };
+  To: { Address: string }[];
+  Subject: string;
+};
+
+async function mailpitGet(path: string): Promise<unknown> {
+  const res = await fetch(new URL(path, MAILPIT_API_URL));
+  if (!res.ok) {
+    throw new Error(`Mailpit API ${path} returned ${res.status}`);
+  }
+  return res.json();
+}
+
+async function searchBySubject(subject: string): Promise<MessageSummary[]> {
+  const query = encodeURIComponent(`subject:"${subject}"`);
+  const result = (await mailpitGet(`/api/v1/search?query=${query}`)) as {
+    messages: MessageSummary[];
+  };
+  return result.messages;
+}
+
+describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
+  beforeEach(() => {
+    resetMailer();
+    initMailer();
+    console.warn(
+      "This test fails if you don't have Mailpit running. If you want to skip the test instead of running Mailpit, set `MAILPIT_API_URL=''`."
+    );
+  });
+
+  it("delivers an email that mailpit receives", async () => {
+    // Unique subject so the test finds its own message without wiping the
+    // mailbox, which may hold a developer's other mail.
+    const subject = `Integration test ${Date.now()}`;
+    await sendMail({
+      to: "recipient@test.example",
+      subject,
+      text: "test email body",
+    });
+
+    // The SMTP transaction is complete, but allow mailpit a moment to index.
+    await expect
+      .poll(() => searchBySubject(subject), {
+        timeout: 1000 /* milliseconds */,
+      })
+      .toHaveLength(1);
+
+    const [summary] = await searchBySubject(subject);
+    expect(summary.From.Address).toBe(process.env.SMTP_FROM);
+    expect(summary.To).toEqual([
+      expect.objectContaining({ Address: "recipient@test.example" }),
+    ]);
+
+    const message = (await mailpitGet(`/api/v1/message/${summary.ID}`)) as {
+      Text: string;
+    };
+    expect(message.Text.trim()).toBe("test email body");
+  });
+});

--- a/tests/integration/mailer.test.ts
+++ b/tests/integration/mailer.test.ts
@@ -1,16 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
 
-// Runs only when MAILPIT_API_URL points at a mailpit instance (e.g.
-// http://localhost:8025 via `docker compose up mailpit`). SMTP_URL and
-// SMTP_FROM come from the environment too; .env.test sets all three.
-// Skips when MAILPIT_API_URL is unset or empty; fails when it is set but
-// mailpit is unreachable.
+// This suite runs only when MAILPIT_API_URL points at a mailpit instance (e.g.
+// http://localhost:8025 via `docker compose up mailpit`). Skips when
+// MAILPIT_API_URL is unset or empty; fails when it's set but mailpit is
+// unreachable.
 const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
 
 type MessageSummary = {
   ID: string;
-  From: { Address: string };
+  From: { Name: string; Address: string };
   To: { Address: string }[];
   Subject: string;
 };
@@ -33,12 +32,18 @@ async function searchBySubject(subject: string): Promise<MessageSummary[]> {
 
 describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
   beforeEach(() => {
+    // Fix the sender rather than using the environment's SMTP_FROM, whose
+    // format (bare address or `Name <address>`) the assertions would
+    // otherwise depend on.
+    vi.stubEnv("SMTP_FROM", "Test Sender <sender@test.example>");
     resetMailer();
     initMailer();
     console.warn(
       "This test fails if you don't have Mailpit running. If you want to skip the test instead of running Mailpit, set `MAILPIT_API_URL=''`."
     );
   });
+
+  afterEach(() => vi.unstubAllEnvs());
 
   it("delivers an email that mailpit receives", async () => {
     // Unique subject so the test finds its own message without wiping the
@@ -58,7 +63,10 @@ describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
       .toHaveLength(1);
 
     const [summary] = await searchBySubject(subject);
-    expect(summary.From.Address).toBe(process.env.SMTP_FROM);
+    expect(summary.From).toMatchObject({
+      Name: "Test Sender",
+      Address: "sender@test.example",
+    });
     expect(summary.To).toEqual([
       expect.objectContaining({ Address: "recipient@test.example" }),
     ]);

--- a/tests/unit/mailer.test.ts
+++ b/tests/unit/mailer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const transportSendMail = vi.fn();
+
+vi.mock("nodemailer", () => ({
+  default: {
+    createTransport: vi.fn(() => ({ sendMail: transportSendMail })),
+  },
+}));
+
+import nodemailer from "nodemailer";
+import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
+
+const MESSAGE = {
+  to: "guest@test.example",
+  subject: "Test email",
+  text: "test email",
+};
+
+describe("mailer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMailer();
+    vi.stubEnv("SMTP_URL", "smtp://localhost:1025");
+    vi.stubEnv("SMTP_FROM", "SchellingBoard <noreply@test.example>");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("initMailer", () => {
+    it("throws when SMTP_URL is set but SMTP_FROM is not", () => {
+      vi.stubEnv("SMTP_FROM", "");
+      expect(() => initMailer()).toThrow(
+        "SMTP_FROM must be set when SMTP_URL is set"
+      );
+    });
+
+    it("throws when SMTP_FROM is set but SMTP_URL is not", () => {
+      vi.stubEnv("SMTP_URL", "");
+      expect(() => initMailer()).toThrow(
+        "SMTP_URL must be set when SMTP_FROM is set"
+      );
+    });
+
+    it("creates the transport using SMTP_URL", () => {
+      initMailer();
+      expect(nodemailer.createTransport).toHaveBeenCalledWith(
+        "smtp://localhost:1025"
+      );
+    });
+
+    it("does not create a transport when SMTP_URL is not set (email disabled)", () => {
+      vi.stubEnv("SMTP_URL", "");
+      vi.stubEnv("SMTP_FROM", "");
+      expect(() => initMailer()).not.toThrow();
+      expect(nodemailer.createTransport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendMail", () => {
+    it("throws when the mailer has not been initialized", async () => {
+      await expect(sendMail(MESSAGE)).rejects.toThrow(
+        "Mailer has not been initialized"
+      );
+      expect(transportSendMail).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when email sending is disabled", async () => {
+      vi.stubEnv("SMTP_URL", "");
+      vi.stubEnv("SMTP_FROM", "");
+      initMailer();
+      await expect(sendMail(MESSAGE)).resolves.toBeUndefined();
+      expect(transportSendMail).not.toHaveBeenCalled();
+    });
+
+    it("reuses the transport created at init across sends", async () => {
+      initMailer();
+      await sendMail(MESSAGE);
+      await sendMail(MESSAGE);
+      expect(nodemailer.createTransport).toHaveBeenCalledTimes(1);
+      expect(transportSendMail).toHaveBeenCalledTimes(2);
+      expect(transportSendMail).toHaveBeenCalledWith(
+        expect.objectContaining(MESSAGE)
+      );
+    });
+
+    it("uses the SMTP_FROM captured at init as the sender", async () => {
+      vi.stubEnv("SMTP_FROM", "Events Team <events@test.example>");
+      initMailer();
+      vi.stubEnv("SMTP_FROM", "changed-later@test.example");
+      await sendMail(MESSAGE);
+      expect(transportSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({ from: "Events Team <events@test.example>" })
+      );
+    });
+  });
+});

--- a/tests/unit/mailer.test.ts
+++ b/tests/unit/mailer.test.ts
@@ -9,7 +9,12 @@ vi.mock("nodemailer", () => ({
 }));
 
 import nodemailer from "nodemailer";
-import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
+import {
+  initMailer,
+  resetMailer,
+  sendMail,
+  smtpTransportConfig,
+} from "@/utils/mailer";
 
 const MESSAGE = {
   to: "guest@test.example",
@@ -17,29 +22,138 @@ const MESSAGE = {
   text: "test email",
 };
 
+describe("smtpTransportConfig", () => {
+  it("returns null when no SMTP variables are set", () => {
+    expect(smtpTransportConfig({})).toBeNull();
+  });
+
+  it("treats empty strings as unset", () => {
+    expect(
+      smtpTransportConfig({ SMTP_URL: "", SMTP_HOST: "", SMTP_SECURE: "" })
+    ).toBeNull();
+    expect(
+      smtpTransportConfig({ SMTP_URL: "smtp://localhost:1025", SMTP_HOST: "" })
+    ).toEqual({ tag: "url", url: "smtp://localhost:1025" });
+  });
+
+  it("returns the URL when SMTP_URL is set", () => {
+    expect(smtpTransportConfig({ SMTP_URL: "smtp://localhost:1025" })).toEqual({
+      tag: "url",
+      url: "smtp://localhost:1025",
+    });
+  });
+
+  it("throws when SMTP_URL is combined with an individual setting", () => {
+    expect(() =>
+      smtpTransportConfig({ SMTP_URL: "smtp://x", SMTP_HOST: "mail.example" })
+    ).toThrow("not both");
+    expect(() =>
+      smtpTransportConfig({ SMTP_URL: "smtp://x", SMTP_SECURE: "true" })
+    ).toThrow("not both");
+  });
+
+  it("builds settings from SMTP_HOST alone, requiring TLS by default", () => {
+    expect(smtpTransportConfig({ SMTP_HOST: "mail.example" })).toEqual({
+      tag: "object",
+      settings: { host: "mail.example", secure: false, requireTLS: true },
+    });
+  });
+
+  it("builds settings from all individual variables", () => {
+    expect(
+      smtpTransportConfig({
+        SMTP_HOST: "mail.example",
+        SMTP_PORT: "2525",
+        SMTP_USER: "mailer",
+        SMTP_PASSWORD: "hunter2",
+        SMTP_SECURE: "true",
+      })
+    ).toEqual({
+      tag: "object",
+      settings: {
+        host: "mail.example",
+        port: 2525,
+        auth: { user: "mailer", pass: "hunter2" },
+        secure: true,
+      },
+    });
+  });
+
+  it('maps SMTP_SECURE "true" to wrap SMTP inside TLS', () => {
+    expect(
+      smtpTransportConfig({ SMTP_HOST: "mail.example", SMTP_SECURE: "true" })
+    ).toEqual({
+      tag: "object",
+      settings: { host: "mail.example", secure: true },
+    });
+  });
+
+  it('maps SMTP_SECURE "false" to opportunistic TLS', () => {
+    expect(
+      smtpTransportConfig({ SMTP_HOST: "mail.example", SMTP_SECURE: "false" })
+    ).toEqual({
+      tag: "object",
+      settings: { host: "mail.example", secure: false },
+    });
+  });
+
+  it('maps SMTP_SECURE "requireTLS" to require upgrading to TLS', () => {
+    expect(
+      smtpTransportConfig({
+        SMTP_HOST: "mail.example",
+        SMTP_SECURE: "requireTLS",
+      })
+    ).toEqual({
+      tag: "object",
+      settings: { host: "mail.example", secure: false, requireTLS: true },
+    });
+  });
+
+  it("throws when individual settings are given without SMTP_HOST", () => {
+    expect(() => smtpTransportConfig({ SMTP_PORT: "2525" })).toThrow(
+      "SMTP_HOST"
+    );
+  });
+
+  it("throws on an invalid SMTP_SECURE", () => {
+    expect(() =>
+      smtpTransportConfig({ SMTP_HOST: "mail.example", SMTP_SECURE: "yes" })
+    ).toThrow("SMTP_SECURE");
+  });
+
+  it("throws on a non-numeric SMTP_PORT", () => {
+    expect(() =>
+      smtpTransportConfig({ SMTP_HOST: "mail.example", SMTP_PORT: "smtp" })
+    ).toThrow("SMTP_PORT");
+  });
+});
+
 describe("mailer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMailer();
     vi.stubEnv("SMTP_URL", "smtp://localhost:1025");
     vi.stubEnv("SMTP_FROM", "SchellingBoard <noreply@test.example>");
+    // Ensure individual SMTP_* variables from the developer's environment
+    // don't leak into these tests.
+    vi.stubEnv("SMTP_HOST", "");
+    vi.stubEnv("SMTP_PORT", "");
+    vi.stubEnv("SMTP_USER", "");
+    vi.stubEnv("SMTP_PASSWORD", "");
+    vi.stubEnv("SMTP_SECURE", "");
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   describe("initMailer", () => {
-    it("throws when SMTP_URL is set but SMTP_FROM is not", () => {
+    it("throws when SMTP is configured but SMTP_FROM is not", () => {
       vi.stubEnv("SMTP_FROM", "");
-      expect(() => initMailer()).toThrow(
-        "SMTP_FROM must be set when SMTP_URL is set"
-      );
+      expect(() => initMailer()).toThrow("must be set");
     });
 
     it("throws when SMTP_FROM is set but SMTP_URL is not", () => {
       vi.stubEnv("SMTP_URL", "");
-      expect(() => initMailer()).toThrow(
-        "SMTP_URL must be set when SMTP_FROM is set"
-      );
+      expect(() => initMailer()).toThrow("must be set");
     });
 
     it("creates the transport using SMTP_URL", () => {
@@ -49,7 +163,42 @@ describe("mailer", () => {
       );
     });
 
-    it("does not create a transport when SMTP_URL is not set (email disabled)", () => {
+    it("creates the transport using SMTP_HOST", () => {
+      vi.stubEnv("SMTP_URL", "");
+      vi.stubEnv("SMTP_HOST", "mail.example");
+      initMailer();
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({
+        host: "mail.example",
+        secure: false,
+        requireTLS: true,
+      });
+    });
+
+    it("creates the transport using SMTP_HOST and other variables", () => {
+      vi.stubEnv("SMTP_URL", "");
+      vi.stubEnv("SMTP_HOST", "mail.example");
+      vi.stubEnv("SMTP_PORT", "123");
+      vi.stubEnv("SMTP_USER", "user");
+      vi.stubEnv("SMTP_PASSWORD", "pass");
+      vi.stubEnv("SMTP_SECURE", "true");
+      initMailer();
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({
+        host: "mail.example",
+        port: 123,
+        auth: {
+          user: "user",
+          pass: "pass",
+        },
+        secure: true,
+      });
+    });
+
+    it("throws when SMTP_URL and SMTP_HOST are both set", () => {
+      vi.stubEnv("SMTP_HOST", "mail.example");
+      expect(() => initMailer()).toThrow("not both");
+    });
+
+    it("does not create a transport when SMTP is not configured (email disabled)", () => {
       vi.stubEnv("SMTP_URL", "");
       vi.stubEnv("SMTP_FROM", "");
       expect(() => initMailer()).not.toThrow();

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -1,6 +1,80 @@
 import nodemailer, { type Transporter } from "nodemailer";
+import type SMTPTransport from "nodemailer/lib/smtp-transport";
 
 type Mailer = { transport: Transporter; from: string };
+
+export type SmtpTransportConfig =
+  | { tag: "url"; url: string }
+  | { tag: "object"; settings: SMTPTransport.Options };
+
+// Decides how the SMTP transport should be created from the environment:
+// from a connection URL (SMTP_URL) or from individual settings (SMTP_HOST/
+// PORT/USER/PASSWORD/SECURE). Returns null when neither is configured.
+// Empty strings are treated as unset.
+export function smtpTransportConfig(env: {
+  SMTP_URL?: string;
+  SMTP_HOST?: string;
+  SMTP_PORT?: string;
+  SMTP_USER?: string;
+  SMTP_PASSWORD?: string;
+  SMTP_SECURE?: string;
+}): SmtpTransportConfig | null {
+  const url = env.SMTP_URL || undefined;
+  const host = env.SMTP_HOST || undefined;
+  const port = env.SMTP_PORT || undefined;
+  const user = env.SMTP_USER || undefined;
+  const password = env.SMTP_PASSWORD || undefined;
+  const secure = env.SMTP_SECURE || undefined;
+
+  const hasIndividualSettings =
+    host !== undefined ||
+    port !== undefined ||
+    user !== undefined ||
+    password !== undefined ||
+    secure !== undefined;
+
+  if (url && hasIndividualSettings) {
+    throw new Error(
+      "Set either SMTP_URL or SMTP_HOST/PORT/USER/PASSWORD/SECURE, not both"
+    );
+  }
+  if (url) return { tag: "url", url };
+  if (!hasIndividualSettings) return null;
+  if (!host) {
+    throw new Error(
+      "SMTP_HOST must be set when SMTP_PORT, SMTP_USER, SMTP_PASSWORD, or SMTP_SECURE is set"
+    );
+  }
+
+  const settings: SMTPTransport.Options = { host };
+  if (port !== undefined) {
+    const parsed = Number(port);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(`SMTP_PORT must be a positive integer, got "${port}"`);
+    }
+    settings.port = parsed;
+  }
+  if (user !== undefined || password !== undefined) {
+    settings.auth = { user: user ?? "", pass: password ?? "" };
+  }
+  switch (secure ?? "requireTLS") {
+    case "true":
+      settings.secure = true;
+      break;
+    case "false":
+      settings.secure = false;
+      break;
+    case "requireTLS":
+      settings.secure = false;
+      settings.requireTLS = true;
+      break;
+    default:
+      throw new Error(
+        `SMTP_SECURE must be "true", "false" or "requireTLS", got "${secure}"`
+      );
+  }
+  return { tag: "object", settings };
+}
 
 type MailerState = { configured: true; mailer: Mailer } | { configured: false };
 
@@ -11,23 +85,34 @@ const g = globalThis as typeof globalThis & { __mailerState?: MailerState };
 // Called on server startup so a half-configured mailer fails the boot instead
 // of the first send.
 export function initMailer(): void {
-  const smtpUrl = process.env.SMTP_URL;
+  const transportConfig = smtpTransportConfig({
+    SMTP_URL: process.env.SMTP_URL,
+    SMTP_HOST: process.env.SMTP_HOST,
+    SMTP_PORT: process.env.SMTP_PORT,
+    SMTP_USER: process.env.SMTP_USER,
+    SMTP_PASSWORD: process.env.SMTP_PASSWORD,
+    SMTP_SECURE: process.env.SMTP_SECURE,
+  });
   const from = process.env.SMTP_FROM;
-  if (!smtpUrl && !from) {
-    console.warn("SMTP_URL is not set - email sending is disabled");
+  if (!transportConfig && !from) {
+    console.warn("SMTP is not configured - email sending is disabled");
     g.__mailerState = { configured: false };
     return;
   }
   if (!from) {
-    throw new Error("SMTP_FROM must be set when SMTP_URL is set");
+    throw new Error("SMTP_FROM must be set when SMTP is configured");
   }
-  if (!smtpUrl) {
-    throw new Error("SMTP_URL must be set when SMTP_FROM is set");
+  if (!transportConfig) {
+    throw new Error("SMTP_URL or SMTP_HOST must be set when SMTP_FROM is set");
   }
   g.__mailerState = {
     configured: true,
     mailer: {
-      transport: nodemailer.createTransport(smtpUrl),
+      transport: nodemailer.createTransport(
+        transportConfig.tag === "url"
+          ? transportConfig.url
+          : transportConfig.settings
+      ),
       from,
     },
   };
@@ -59,7 +144,7 @@ export async function sendMail(options: {
   const mailer = getMailer();
   if (!mailer) {
     console.warn(
-      `SMTP_URL is not set - not sending email "${options.subject}" to ${options.to}`
+      `SMTP is not configured - not sending email "${options.subject}" to ${options.to}`
     );
     return;
   }

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -1,0 +1,73 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+type Mailer = { transport: Transporter; from: string };
+
+type MailerState = { configured: true; mailer: Mailer } | { configured: false };
+
+// Singletons need to be assigned to globalThis, not simply module-level
+// variables. See https://github.com/vercel/next.js/discussions/68572.
+const g = globalThis as typeof globalThis & { __mailerState?: MailerState };
+
+// Called on server startup so a half-configured mailer fails the boot instead
+// of the first send.
+export function initMailer(): void {
+  const smtpUrl = process.env.SMTP_URL;
+  const from = process.env.SMTP_FROM;
+  if (!smtpUrl && !from) {
+    console.warn("SMTP_URL is not set - email sending is disabled");
+    g.__mailerState = { configured: false };
+    return;
+  }
+  if (!from) {
+    throw new Error("SMTP_FROM must be set when SMTP_URL is set");
+  }
+  if (!smtpUrl) {
+    throw new Error("SMTP_URL must be set when SMTP_FROM is set");
+  }
+  g.__mailerState = {
+    configured: true,
+    mailer: {
+      transport: nodemailer.createTransport(smtpUrl),
+      from,
+    },
+  };
+}
+
+// For tests only.
+export function resetMailer(): void {
+  delete g.__mailerState;
+}
+
+function getMailer(): Mailer | null {
+  const state = g.__mailerState;
+  if (!state) {
+    throw new Error("Mailer has not been initialized");
+  }
+  return state.configured ? state.mailer : null;
+}
+
+// Send an email. Requires `initMailer` to have been called first. If email
+// sending is disabled, logs a warning, with no way for the caller to tell.
+//
+// Currently doesn't give access to most nodemailer message options, notably
+// including html email.
+export async function sendMail(options: {
+  to: string;
+  subject: string;
+  text: string;
+}): Promise<void> {
+  const mailer = getMailer();
+  if (!mailer) {
+    console.warn(
+      `SMTP_URL is not set - not sending email "${options.subject}" to ${options.to}`
+    );
+    return;
+  }
+  const { transport, from } = mailer;
+  await transport.sendMail({
+    from,
+    to: options.to,
+    subject: options.subject,
+    text: options.text,
+  });
+}

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -143,9 +143,8 @@ export async function sendMail(options: {
 }): Promise<void> {
   const mailer = getMailer();
   if (!mailer) {
-    console.warn(
-      `SMTP is not configured - not sending email "${options.subject}" to ${options.to}`
-    );
+    // Don't include details of the email, to avoid putting PII in logs.
+    console.warn("SMTP is not configured - not sending email");
     return;
   }
   const { transport, from } = mailer;


### PR DESCRIPTION
#391

This adds a button next to each user on the admin "users" page, to send an email to that user. Obviously we'll get rid of that when we actually have emails to send, and maybe we don't merge it at all.

Currently only sends text email. I assume we want html email too when we actually start sending email. That has enough design decisions that it should be a separate PR. Nodemailer also has lots of other message options that we don't currently get, like attachments.

Some design decisions (feel free to question):

* Has an integration test to make sure we successfully send mail, using mailpit's API to confirm receipt. It runs by default, so that we're unlikely to accidentally fail to run them in CI. Downside: people who don't want to run those tests need a .env.test.local.

* But for testing the email-sending endpoint, it uses mocks. That conflicts with ADR 2 a bit, but IMO it's correct (I don't think anything else we currently test is similar, so it's reasonable to have a different strategy here). An alternative is to force engineers to have mailpit running when they run tests.

* Throws an error on startup if email is configured incorrectly. Warns on startup, and warns again every time we try to send an email, if it's not configured at all. (Engineers should be able to run without mailpit, as long as they're not currently working on email.) "Correct" config means setting `SMTP_FROM` and exactly one of `SMTP_URL` or `SMTP_HOST`; the other SMTP vars can optionally be set iff `SMTP_HOST` is set. "Not configured at all" means all the SMTP vars are unset. "Unset" is either absent or empty.