### PR TITLE
fix(admin): bulk-validate guest ids and accept duplicates in assignGuestsToEventAction

### DIFF
--- a/app/actions/admin-guest-events.ts
+++ b/app/actions/admin-guest-events.ts
@@ -23,15 +23,19 @@ export async function assignGuestsToEventAction(input: {
 }): Promise<AdminActionResult> {
   if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
 
-  const event = await getRepositories().events.findById(input.eventId);
+  const { events, guests } = getRepositories();
+  const event = await events.findById(input.eventId);
   if (!event) return { ok: false, error: "Event not found" };
 
-  for (const guestId of input.guestIds) {
-    const guest = await getRepositories().guests.findById(guestId);
-    if (!guest) return { ok: false, error: "Guest not found" };
+  const uniqueGuestIds = [...new Set(input.guestIds)];
+  if (uniqueGuestIds.length > 0) {
+    const existing = await guests.findExistingIds(uniqueGuestIds);
+    if (existing.length !== uniqueGuestIds.length) {
+      return { ok: false, error: "Guest not found" };
+    }
   }
 
-  await getRepositories().guests.assignToEvent(input.eventId, input.guestIds);
+  await guests.assignToEvent(input.eventId, input.guestIds);
   revalidateEventPaths(input.eventId);
   return { ok: true };
 }

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -91,6 +91,7 @@ export interface GuestsRepository {
   ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;
+  findExistingIds(ids: string[]): Promise<string[]>;
   assignToEvent(eventId: string, guestIds: string[]): Promise<void>;
   removeFromEvent(eventId: string, guestIds: string[]): Promise<void>;
 }

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -86,6 +86,16 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return { id, ...data };
   }
 
+  async findExistingIds(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+    return this.db
+      .select({ id: schema.guests.id })
+      .from(schema.guests)
+      .where(inArray(schema.guests.id, ids))
+      .all()
+      .map((r) => r.id);
+  }
+
   async assignToEvent(eventId: string, guestIds: string[]): Promise<void> {
     if (guestIds.length === 0) return;
     this.db

--- a/tests/integration/admin-guest-events.test.ts
+++ b/tests/integration/admin-guest-events.test.ts
@@ -158,6 +158,20 @@ describe("assignGuestsToEventAction", () => {
     });
     expect(!result.ok && result.error).toBe("Guest not found");
   });
+
+  it("accepts duplicate guest ids", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+
+    const result = await assignGuestsToEventAction({
+      eventId: event.id,
+      guestIds: [g1.id, g1.id],
+    });
+    expect(result.ok).toBe(true);
+
+    const assigned = await getRepositories().guests.listByEvent(event.id);
+    expect(assigned.map((g) => g.id)).toEqual([g1.id]);
+  });
 });
 
 describe("removeGuestsFromEventAction", () => {


### PR DESCRIPTION
Mirrors the locations pattern: replaces N sequential findById calls
with one findExistingIds query, and dedupes input ids before
comparing counts so repeated ids aren't misreported as missing.

<!-- jip:pushed-commit=f5c74f185227398f558eb51bd716a6d0755a7a59 -->