### PR TITLE
fix: resolve event slugs without lossy name reconstruction

### DIFF
--- a/app/(site)/[eventSlug]/layout-content.tsx
+++ b/app/(site)/[eventSlug]/layout-content.tsx
@@ -1,5 +1,4 @@
 import { cookies } from "next/headers";
-import { eventSlugToName } from "@/utils/utils";
 import { getRepositories } from "@/db/container";
 import { EventProviderWrapper } from "./event-provider-wrapper";
 import type { DayWithSessions } from "@/app/(site)/context";
@@ -11,9 +10,8 @@ export async function EventLayoutContent({
   eventSlug: string;
   children: React.ReactNode;
 }) {
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/page.tsx
+++ b/app/(site)/[eventSlug]/page.tsx
@@ -1,6 +1,5 @@
 import { EventPhase, getCurrentPhase } from "../utils/events";
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import EventPage from "./event-page";
 import { redirect } from "next/navigation";
 
@@ -8,11 +7,10 @@ export default async function Page(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getRepositories().events.findByName(eventName);
+  const event = await getRepositories().events.findBySlug(eventSlug);
 
   if (!event) {
-    return "Event not found: " + eventName;
+    return "Event not found: " + eventSlug;
   }
 
   const phase = getCurrentPhase(event);
@@ -22,6 +20,6 @@ export default async function Page(props: {
   } else if (phase === EventPhase.VOTING || phase === EventPhase.PROPOSAL) {
     redirect(`/${eventSlug}/proposals`);
   } else {
-    return "Event unavailable: " + eventName;
+    return "Event unavailable: " + event.name;
   }
 }

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,5 +1,4 @@
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
 import { notFound } from "next/navigation";
 
@@ -10,9 +9,8 @@ export default async function EditProposalPage({
 }) {
   const { eventSlug, proposalId } = await params;
 
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/new/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/new/page.tsx
@@ -1,5 +1,4 @@
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "../../session-proposal-form";
 
 export default async function NewProposalPage({
@@ -9,9 +8,8 @@ export default async function NewProposalPage({
 }) {
   const { eventSlug } = await params;
 
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { ProposalActionBar } from "./proposal-action-bar";
 import { ProposalTable } from "./proposal-table";
 import { UserSelect } from "@/app/(site)/user-select";
@@ -19,10 +18,8 @@ export default async function ProposalsPage({
   const { eventSlug } = await params;
   const { viewProposal } = await searchParams;
 
-  // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
@@ -3,13 +3,11 @@ import Link from "next/link";
 
 import { QuickVoting } from "./quick-voting";
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 
 export default async function ProposalQuickVoting(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const eventName = eventSlugToName(eventSlug);
   const currentUser = (await cookies()).get("user")?.value;
   if (!currentUser) {
     return (
@@ -26,7 +24,7 @@ export default async function ProposalQuickVoting(props: {
   }
 
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
   if (!event) {
     return <div>Event not found</div>;
   }
@@ -46,7 +44,7 @@ export default async function ProposalQuickVoting(props: {
       guests={guests}
       currentUser={currentUser}
       initialVotes={votes}
-      eventName={eventName}
+      eventName={event.name}
       eventSlug={eventSlug}
     />
   );

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import { cookies } from "next/headers";
 
-import { eventSlugToName } from "@/utils/utils";
 import { SessionForm } from "./session-form";
 import { getRepositories } from "@/db/container";
 
@@ -10,10 +9,9 @@ export async function renderSessionForm(props: {
 }) {
   const { eventSlug } = await props.params;
   const currentUser = (await cookies()).get("user")?.value;
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
 
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
   if (!event) {
     return <div>Event not found</div>;
   }

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -16,7 +16,7 @@ import type {
   Rsvp,
 } from "@/db/repositories/interfaces";
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
-import { DEFAULT_BREAK_MINUTES } from "@/utils/utils";
+import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 
 export type DayWithSessions = Day & { sessions: Session[] };
 
@@ -302,9 +302,6 @@ export function VotesProvider({
   const [votes, setVotes] = useState<Vote[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Convert eventSlug to eventName (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
-
   useEffect(() => {
     const fetchVotes = async () => {
       if (!user) {
@@ -314,9 +311,7 @@ export function VotesProvider({
 
       setIsLoading(true);
       try {
-        const response = await fetch(
-          `/api/votes?user=${user}&event=${eventName}`
-        );
+        const response = await fetch(votesApiUrl(user, eventSlug));
         if (response.ok) {
           const fetchedVotes = (await response.json()) as Vote[];
           setVotes((prev) => {
@@ -343,7 +338,7 @@ export function VotesProvider({
     };
 
     void fetchVotes();
-  }, [user, eventName]);
+  }, [user, eventSlug]);
 
   const addVote = (vote: Vote) => {
     setVotes((prev) => {

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -10,9 +10,9 @@ const NO_STORE = { headers: { "cache-control": "no-store" } };
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const user = searchParams.get("user");
-  const eventName = searchParams.get("event");
+  const eventSlug = searchParams.get("event");
 
-  if (!user || !eventName) {
+  if (!user || !eventSlug) {
     return NextResponse.json(
       { error: "User and event parameters are required" },
       { ...NO_STORE, status: 400 }
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const repos = getRepositories();
-    const event = await repos.events.findByName(eventName);
+    const event = await repos.events.findBySlug(eventSlug);
     if (!event) {
       return NextResponse.json(
         { error: "Event not found" },

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -55,6 +55,12 @@ export interface EventsRepository {
   list(): Promise<Event[]>;
   findById(id: string): Promise<Event | undefined>;
   findByName(name: string): Promise<Event | undefined>;
+  /**
+   * Finds the event whose slugified name matches the given slug. Returns
+   * undefined if no event matches or the slug is ambiguous (slugification is
+   * lossy, so multiple names can share a slug).
+   */
+  findBySlug(slug: string): Promise<Event | undefined>;
   create(data: Omit<Event, "id">): Promise<Event>;
   update(
     id: string,

--- a/db/repositories/sqlite/events.ts
+++ b/db/repositories/sqlite/events.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
+import { eventNameToSlug } from "@/utils/utils";
 import type { Event, EventsRepository } from "../interfaces";
 
 type EventRow = typeof schema.events.$inferInsert;
@@ -64,6 +65,16 @@ export class SqliteEventsRepository implements EventsRepository {
       .where(eq(schema.events.name, name))
       .get();
     return row ? rowToEvent(row) : undefined;
+  }
+
+  async findBySlug(slug: string): Promise<Event | undefined> {
+    // Slugification is lossy ("My-Event" and "My Event" share a slug), so the
+    // slug cannot be reversed; match by slugifying each name instead. If the
+    // slug is ambiguous (several names share it), treat it as unresolvable
+    // rather than silently picking an arbitrary event.
+    const events = await this.list();
+    const matches = events.filter((e) => eventNameToSlug(e.name) === slug);
+    return matches.length === 1 ? matches[0] : undefined;
   }
 
   async create(data: Omit<Event, "id">): Promise<Event> {

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -107,6 +107,35 @@ describe("events repo", () => {
     });
   });
 
+  describe("findBySlug", () => {
+    it("finds an event by its slugified name", async () => {
+      const event = await createEvent({ name: "Test Event" });
+      const found = await getRepositories().events.findBySlug("Test-Event");
+      expect(found?.id).toBe(event.id);
+    });
+
+    it("finds an event whose name contains hyphens", async () => {
+      const event = await createEvent({ name: "My-Event 2026" });
+      const found = await getRepositories().events.findBySlug("My-Event-2026");
+      expect(found?.id).toBe(event.id);
+    });
+
+    it("returns undefined for an unknown slug", async () => {
+      await createEvent({ name: "Test Event" });
+      expect(
+        await getRepositories().events.findBySlug("No-Such")
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when two event names slugify to the same slug", async () => {
+      await createEvent({ name: "My Event" });
+      await createEvent({ name: "My-Event" });
+      expect(
+        await getRepositories().events.findBySlug("My-Event")
+      ).toBeUndefined();
+    });
+  });
+
   describe("delete", () => {
     it("deletes the event", async () => {
       const event = await createEvent();

--- a/tests/integration/voting.test.ts
+++ b/tests/integration/voting.test.ts
@@ -22,11 +22,11 @@ function makeDeleteReq(payload: unknown): Request {
   });
 }
 
-// Read surface: GET /api/votes?user=<guestId>&event=<eventName>
-async function votesFor(guestId: string, eventName: string): Promise<Vote[]> {
+// Read surface: GET /api/votes?user=<guestId>&event=<eventSlug>
+async function votesFor(guestId: string, eventSlug: string): Promise<Vote[]> {
   const res = await getVotes(
     new NextRequest(
-      `http://test/api/votes?user=${guestId}&event=${encodeURIComponent(eventName)}`
+      `http://test/api/votes?user=${guestId}&event=${encodeURIComponent(eventSlug)}`
     )
   );
   expect(res.ok).toBe(true);
@@ -51,7 +51,7 @@ describe("voting API", () => {
     );
     expect(res.ok).toBe(true);
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0]).toMatchObject({
       proposalId: proposal.id,
@@ -76,7 +76,7 @@ describe("voting API", () => {
       expect(res.ok).toBe(true);
     }
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0].choice).toBe(VoteChoice.skip);
   });
@@ -118,7 +118,7 @@ describe("voting API", () => {
       choice: VoteChoice.maybe,
     });
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0].choice).toBe(VoteChoice.maybe);
   });
@@ -144,8 +144,8 @@ describe("voting API", () => {
     );
     expect(res.ok).toBe(true);
 
-    expect(await votesFor(alice.id, "Vote Event")).toHaveLength(0);
-    expect(await votesFor(bob.id, "Vote Event")).toHaveLength(1);
+    expect(await votesFor(alice.id, "Vote-Event")).toHaveLength(0);
+    expect(await votesFor(bob.id, "Vote-Event")).toHaveLength(1);
   });
 
   it("delete-vote is rejected outside the voting phase", async () => {
@@ -176,7 +176,7 @@ describe("voting API", () => {
     );
     expect(res.status).toBe(403);
     // The vote must still be there.
-    expect(await votesFor(guest.id, "Vote Event")).toHaveLength(1);
+    expect(await votesFor(guest.id, "Vote-Event")).toHaveLength(1);
   });
 
   it("delete-vote returns 404 for a missing proposal", async () => {
@@ -209,9 +209,29 @@ describe("voting API", () => {
       })
     );
 
-    const votesA = await votesFor(guest.id, "Event A");
+    const votesA = await votesFor(guest.id, "Event-A");
     expect(votesA).toHaveLength(1);
     expect(votesA[0].proposalId).toBe(proposalA.id);
+  });
+
+  it("GET /api/votes finds events whose name contains hyphens", async () => {
+    const event = await createEvent({
+      name: "Vote-Event 2026",
+      phase: "voting",
+    });
+    const guest = await createGuest();
+    const proposal = await createProposal(event.id, []);
+
+    await addVote(
+      makeAddReq({
+        proposalId: proposal.id,
+        guestId: guest.id,
+        choice: VoteChoice.interested,
+      })
+    );
+
+    const votes = await votesFor(guest.id, "Vote-Event-2026");
+    expect(votes).toHaveLength(1);
   });
 
   it("GET /api/votes requires user and event and rejects unknown events", async () => {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -3,11 +3,11 @@ import {
   durationMinusBreak,
   formatDuration,
   eventNameToSlug,
-  eventSlugToName,
   dateOnDay,
   getPercentThroughDay,
   getNumHalfHours,
   getStartTimePlusBreak,
+  votesApiUrl,
 } from "@/utils/utils";
 import type { Day, Session } from "@/db/repositories/interfaces";
 
@@ -45,7 +45,7 @@ describe("formatDuration", () => {
     expect(formatDuration(120, true)).toBe("2 hours"));
 });
 
-// ── eventNameToSlug / eventSlugToName ────────────────────────────────────────
+// ── eventNameToSlug ──────────────────────────────────────────────────────────
 
 describe("eventNameToSlug", () => {
   it("replaces spaces with hyphens", () =>
@@ -53,20 +53,26 @@ describe("eventNameToSlug", () => {
 
   it("multiple spaces", () =>
     expect(eventNameToSlug("Foo Bar Baz")).toBe("Foo-Bar-Baz"));
+
+  it("keeps hyphens already in the name", () =>
+    expect(eventNameToSlug("My-Event 2026")).toBe("My-Event-2026"));
 });
 
-describe("eventSlugToName", () => {
-  it("replaces hyphens with spaces", () =>
-    expect(eventSlugToName("My-Event")).toBe("My Event"));
+// ── votesApiUrl ──────────────────────────────────────────────────────────────
 
-  it("round-trips simple names", () => {
-    const name = "Conference Alpha";
-    expect(eventSlugToName(eventNameToSlug(name))).toBe(name);
-  });
+describe("votesApiUrl", () => {
+  it("builds the votes query for plain values", () =>
+    expect(votesApiUrl("guest1", "My-Event")).toBe(
+      "/api/votes?user=guest1&event=My-Event"
+    ));
 
-  it("documents lossy behavior: hyphen in original name becomes space", () => {
-    // "My-Event" as a name slugifies to "My-Event", which reads back as "My Event"
-    expect(eventSlugToName(eventNameToSlug("My-Event"))).toBe("My Event");
+  it("encodes reserved URL characters so the slug survives query parsing", () => {
+    // "Food & Drinks" slugifies to "Food-&-Drinks"; unencoded, the server
+    // would parse event as "Food-" and drop "-Drinks" into a bogus param.
+    const url = votesApiUrl("guest1", "Food-&-Drinks");
+    const params = new URL(url, "http://test").searchParams;
+    expect(params.get("event")).toBe("Food-&-Drinks");
+    expect(params.get("user")).toBe("guest1");
   });
 });
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -28,12 +28,23 @@ export const dateOnDay = (date: Date, day: Day) => {
   );
 };
 
+/**
+ * Slugification is lossy ("My-Event" and "My Event" share a slug), so it
+ * cannot be reversed. To resolve a slug back to an event, use
+ * `EventsRepository.findBySlug`, which matches by slugifying each name.
+ */
 export function eventNameToSlug(name: string): string {
   return name.replace(/ /g, "-");
 }
 
-export function eventSlugToName(slug: string): string {
-  return slug.replace(/-/g, " ");
+/**
+ * URL for fetching a guest's votes. Encodes both values: event slugs keep
+ * every non-space character of the event name (see eventNameToSlug), so
+ * reserved URL characters like "&" would otherwise corrupt the query string.
+ */
+export function votesApiUrl(user: string, eventSlug: string): string {
+  const params = new URLSearchParams({ user, event: eventSlug });
+  return `/api/votes?${params.toString()}`;
 }
 
 /**


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [943e0ba](https://github.com/LWCW-Europe/schellingboard/pull/522/commits/943e0bab936b9aefec85d444c8273b18cf3bc1ae).

PRs:
* #524
* #523
* ➡️ #522 (this PR, base of the stack — can be merged first)

---

## Description

eventSlugToName turned hyphens into spaces, so events with hyphens in
their name were unreachable. Replace it with events.findBySlug, which
matches by slugifying each name, and pass the slug (not a reconstructed
name) to /api/votes.

Also changes the GET /api/votes `event` query parameter from an event
name to a slug.

URL-encode the votes query string (slugs can contain reserved
characters like "&"), and treat ambiguous slugs (two event names
slugifying to the same value) as unresolvable instead of silently
picking the first match.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=943e0bab936b9aefec85d444c8273b18cf3bc1ae -->