### PR TITLE
feat: store event slugs with a unique constraint

### DIFF
--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -21,12 +21,11 @@ const GUTTER = "2.5rem";
 // JS, no scroll listeners — just `position: sticky` inside the scroll container
 // that wraps every day (see `EventDisplay`).
 export function DayGrid(props: {
-  eventName: string;
   locations: Location[];
   day: DayWithSessions;
   guests: Guest[];
 }) {
-  const { eventName, day, locations, guests } = props;
+  const { day, locations, guests } = props;
   const { event } = useContext(EventContext);
   const timezone = event?.timezone ?? "UTC";
   const searchParams = useSearchParams();
@@ -139,7 +138,6 @@ export function DayGrid(props: {
           guests={guests}
           day={day}
           location={location}
-          eventName={eventName}
         />
       ))}
     </div>

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -14,7 +14,6 @@ import { useState, useContext } from "react";
 import { EventContext } from "../context";
 import { hasPhases } from "@/app/(site)/utils/events";
 import Link from "next/link";
-import { eventNameToSlug } from "@/utils/utils";
 import { SessionModal } from "./session-modal";
 
 export function EventDisplay() {
@@ -25,8 +24,6 @@ export function EventDisplay() {
   const [search, setSearch] = useState("");
 
   if (!event) return <div>No event data available</div>;
-
-  const eventSlug = eventNameToSlug(event.name);
 
   const daysForEvent = days.filter((day) => day.eventId === event.id);
   const locationsForEvent = locations;
@@ -69,7 +66,7 @@ export function EventDisplay() {
         {hasPhases(event) && (
           <div className="mb-5">
             <Link
-              href={`/${eventNameToSlug(event.name)}/proposals`}
+              href={`/${event.slug}/proposals`}
               className={`bg-rose-400 hover:bg-rose-500 transition-colors text-white px-4 py-2 rounded-md flex items-center gap-2 max-w-fit`}
             >
               <ClipboardDocumentListIcon className="h-4 w-4" />
@@ -103,7 +100,6 @@ export function EventDisplay() {
               day={day}
               locations={locationsForEvent}
               guests={guests}
-              eventName={event.name}
             />
           ))}
         </div>
@@ -116,14 +112,14 @@ export function EventDisplay() {
                 search={search}
                 locations={locationsForEvent}
                 rsvps={view === "rsvp" ? rsvps : []}
-                eventSlug={eventSlug}
+                eventSlug={event.slug}
               />
             </div>
           ))}
         </div>
       )}
       {viewSession && (
-        <SessionModal sessionId={viewSession} eventSlug={eventSlug} />
+        <SessionModal sessionId={viewSession} eventSlug={event.slug} />
       )}
     </div>
   );

--- a/app/(site)/[eventSlug]/layout-content.tsx
+++ b/app/(site)/[eventSlug]/layout-content.tsx
@@ -1,5 +1,4 @@
 import { cookies } from "next/headers";
-import { eventSlugToName } from "@/utils/utils";
 import { getRepositories } from "@/db/container";
 import { EventProviderWrapper } from "./event-provider-wrapper";
 import type { DayWithSessions } from "@/app/(site)/context";
@@ -11,9 +10,8 @@ export async function EventLayoutContent({
   eventSlug: string;
   children: React.ReactNode;
 }) {
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/location-col.tsx
+++ b/app/(site)/[eventSlug]/location-col.tsx
@@ -5,13 +5,12 @@ import { getNumHalfHours } from "@/utils/utils";
 import clsx from "clsx";
 
 export function LocationCol(props: {
-  eventName: string;
   sessions: Session[];
   location: Location;
   day: DayWithSessions;
   guests: Guest[];
 }) {
-  const { eventName, sessions, location, day, guests } = props;
+  const { sessions, location, day, guests } = props;
   const sessionsWithBlanks = insertBlankSessions(sessions, day);
   const numHalfHours = getNumHalfHours(day.start, day.end);
   return (
@@ -25,7 +24,6 @@ export function LocationCol(props: {
         {sessionsWithBlanks.map((session) => {
           return (
             <SessionBlock
-              eventName={eventName}
               day={day}
               key={session.startTime?.toISOString() ?? session.id}
               session={session}

--- a/app/(site)/[eventSlug]/page.tsx
+++ b/app/(site)/[eventSlug]/page.tsx
@@ -1,6 +1,5 @@
 import { EventPhase, getCurrentPhase } from "../utils/events";
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import EventPage from "./event-page";
 import { redirect } from "next/navigation";
 
@@ -8,11 +7,10 @@ export default async function Page(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const eventName = eventSlugToName(eventSlug);
-  const event = await getRepositories().events.findByName(eventName);
+  const event = await getRepositories().events.findBySlug(eventSlug);
 
   if (!event) {
-    return "Event not found: " + eventName;
+    return "Event not found: " + eventSlug;
   }
 
   const phase = getCurrentPhase(event);
@@ -22,6 +20,6 @@ export default async function Page(props: {
   } else if (phase === EventPhase.VOTING || phase === EventPhase.PROPOSAL) {
     redirect(`/${eventSlug}/proposals`);
   } else {
-    return "Event unavailable: " + eventName;
+    return "Event unavailable: " + event.name;
   }
 }

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,5 +1,4 @@
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
 import { notFound } from "next/navigation";
 
@@ -10,9 +9,8 @@ export default async function EditProposalPage({
 }) {
   const { eventSlug, proposalId } = await params;
 
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/new/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/new/page.tsx
@@ -1,5 +1,4 @@
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { SessionProposalForm } from "../../session-proposal-form";
 
 export default async function NewProposalPage({
@@ -9,9 +8,8 @@ export default async function NewProposalPage({
 }) {
   const { eventSlug } = await params;
 
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 import { ProposalActionBar } from "./proposal-action-bar";
 import { ProposalTable } from "./proposal-table";
 import { UserSelect } from "@/app/(site)/user-select";
@@ -19,10 +18,8 @@ export default async function ProposalsPage({
   const { eventSlug } = await params;
   const { viewProposal } = await searchParams;
 
-  // Convert slug to event name (simple conversion for now)
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
 
   if (!event) {
     return <div>Event not found</div>;

--- a/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
@@ -3,13 +3,11 @@ import Link from "next/link";
 
 import { QuickVoting } from "./quick-voting";
 import { getRepositories } from "@/db/container";
-import { eventSlugToName } from "@/utils/utils";
 
 export default async function ProposalQuickVoting(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const eventName = eventSlugToName(eventSlug);
   const currentUser = (await cookies()).get("user")?.value;
   if (!currentUser) {
     return (
@@ -26,7 +24,7 @@ export default async function ProposalQuickVoting(props: {
   }
 
   const repos = getRepositories();
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
   if (!event) {
     return <div>Event not found</div>;
   }
@@ -46,7 +44,7 @@ export default async function ProposalQuickVoting(props: {
       guests={guests}
       currentUser={currentUser}
       initialVotes={votes}
-      eventName={eventName}
+      eventName={event.name}
       eventSlug={eventSlug}
     />
   );

--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -11,24 +11,19 @@ import { useContext, useState } from "react";
 import { CurrentUserModal, ConfirmationModal } from "../modals";
 import { UserContext, EventContext, useBreakMinutes } from "../context";
 import { sessionsOverlap } from "../session_utils";
-import {
-  eventNameToSlug,
-  getStartTimePlusBreak,
-  TIME_FORMAT,
-} from "@/utils/utils";
+import { getStartTimePlusBreak, TIME_FORMAT } from "@/utils/utils";
 import { LockIcon } from "../lock-icon";
 import { viewSessionLinkFromOwner } from "./modal-nav";
 
 export function SessionBlock(props: {
-  eventName: string;
   session: Session;
   location: Location;
   day: DayWithSessions;
   guests: Guest[];
 }) {
-  const { eventName, session, location, day, guests } = props;
-  const eventSlug = eventNameToSlug(eventName);
+  const { session, location, day, guests } = props;
   const { rsvpdForSession, event } = useContext(EventContext);
+  const eventSlug = event?.slug ?? "";
   const timezone = event?.timezone ?? "UTC";
   const { user } = useContext(UserContext);
   const rsvpd = rsvpdForSession(session.id + (user ? "" : ""));

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 import { cookies } from "next/headers";
 
-import { eventSlugToName } from "@/utils/utils";
 import { SessionForm } from "./session-form";
 import { getRepositories } from "@/db/container";
 
@@ -10,10 +9,9 @@ export async function renderSessionForm(props: {
 }) {
   const { eventSlug } = await props.params;
   const currentUser = (await cookies()).get("user")?.value;
-  const eventName = eventSlugToName(eventSlug);
   const repos = getRepositories();
 
-  const event = await repos.events.findByName(eventName);
+  const event = await repos.events.findBySlug(eventSlug);
   if (!event) {
     return <div>Event not found</div>;
   }

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -14,7 +14,6 @@ import {
   convertParamDateTime,
   dateOnDay,
   getStartTimePlusBreak,
-  eventNameToSlug,
   formatDuration,
   durationMinusBreak,
   TIME_FORMAT,
@@ -276,9 +275,9 @@ export function SessionForm(props: {
     });
     if (res.ok) {
       const actionType = sessionID ? "updated" : "added";
-      await revalidateEvent(eventNameToSlug(eventName));
+      await revalidateEvent(event.slug);
       router.push(
-        `/${eventNameToSlug(eventName)}/add-session/confirmation?actionType=${actionType}`
+        `/${event.slug}/add-session/confirmation?actionType=${actionType}`
       );
       console.log(`Session ${actionType} successfully`);
     } else {
@@ -311,10 +310,8 @@ export function SessionForm(props: {
     });
     if (res.ok) {
       console.log("Session deleted successfully");
-      await revalidateEvent(eventNameToSlug(eventName));
-      router.push(
-        `/${eventNameToSlug(eventName)}/edit-session/deletion-confirmation`
-      );
+      await revalidateEvent(event.slug);
+      router.push(`/${event.slug}/edit-session/deletion-confirmation`);
     } else {
       let errorMessage = "Failed to delete session";
       try {
@@ -351,7 +348,7 @@ export function SessionForm(props: {
     <div className="flex flex-col gap-4">
       <Link
         className="bg-rose-400 text-white font-semibold py-2 px-4 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
-        href={`/${eventNameToSlug(eventName)}`}
+        href={`/${event.slug}`}
       >
         Back to schedule
       </Link>
@@ -493,10 +490,7 @@ export function SessionForm(props: {
         <p className="text-sm text-gray-600">
           This session was scheduled from a proposal. See it{" "}
           <Link
-            {...viewProposalLinkFromElsewhere(
-              eventNameToSlug(eventName),
-              session.proposalId
-            )}
+            {...viewProposalLinkFromElsewhere(event.slug, session.proposalId)}
             className="text-rose-500 underline hover:text-rose-600 transition-colors"
           >
             here

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -16,7 +16,7 @@ import type {
   Rsvp,
 } from "@/db/repositories/interfaces";
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
-import { DEFAULT_BREAK_MINUTES } from "@/utils/utils";
+import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 
 export type DayWithSessions = Day & { sessions: Session[] };
 
@@ -302,9 +302,6 @@ export function VotesProvider({
   const [votes, setVotes] = useState<Vote[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Convert eventSlug to eventName (simple conversion for now)
-  const eventName = eventSlug.replace(/-/g, " ");
-
   useEffect(() => {
     const fetchVotes = async () => {
       if (!user) {
@@ -314,9 +311,7 @@ export function VotesProvider({
 
       setIsLoading(true);
       try {
-        const response = await fetch(
-          `/api/votes?user=${user}&event=${eventName}`
-        );
+        const response = await fetch(votesApiUrl(user, eventSlug));
         if (response.ok) {
           const fetchedVotes = (await response.json()) as Vote[];
           setVotes((prev) => {
@@ -343,7 +338,7 @@ export function VotesProvider({
     };
 
     void fetchVotes();
-  }, [user, eventName]);
+  }, [user, eventSlug]);
 
   const addVote = (vote: Vote) => {
     setVotes((prev) => {

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -3,7 +3,6 @@ import Footer from "../footer";
 import { UserProvider } from "./context";
 import clsx from "clsx";
 import { getRepositories } from "@/db/container";
-import { eventNameToSlug } from "@/utils/utils";
 import { cookies } from "next/headers";
 import {
   AUTH_COOKIE_NAME,
@@ -27,7 +26,7 @@ export default async function SiteLayout({
   const multipleEvents = events.length > 1;
   const navItems = events.map((e) => ({
     name: e.name,
-    href: `/${eventNameToSlug(e.name)}`,
+    href: `/${e.slug}`,
     icon: e.icon ?? null,
   }));
 

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -3,7 +3,6 @@ export const dynamic = "force-dynamic";
 import SummaryPage from "./summary-page";
 import { getRepositories } from "@/db/container";
 import { redirect } from "next/navigation";
-import { eventNameToSlug } from "@/utils/utils";
 
 export default async function Home() {
   const repos = getRepositories();
@@ -14,7 +13,7 @@ export default async function Home() {
   if (sortedEvents.length > 1) {
     return <SummaryPage events={sortedEvents} />;
   } else if (sortedEvents.length === 1) {
-    const eventSlug = eventNameToSlug(sortedEvents[0].name);
+    const eventSlug = sortedEvents[0].slug;
     redirect(`/${eventSlug}`);
   } else {
     return <p>No events found.</p>;

--- a/app/(site)/summary-page.tsx
+++ b/app/(site)/summary-page.tsx
@@ -7,7 +7,6 @@ import {
 import { DateTime } from "luxon";
 import Link from "next/link";
 import type { Event } from "@/db/repositories/interfaces";
-import { eventNameToSlug } from "@/utils/utils";
 import { CONSTS } from "@/utils/constants";
 
 export default function SummaryPage(props: { events: Event[] }) {
@@ -47,7 +46,7 @@ export default function SummaryPage(props: { events: Event[] }) {
               </div>
               <p className="text-gray-900 mt-2">{event.description}</p>
               <Link
-                href={`/${eventNameToSlug(event.name)}`}
+                href={`/${event.slug}`}
                 className="font-semibold text-rose-400 hover:text-rose-500 flex gap-1 items-center text-sm justify-end mt-2"
               >
                 View schedule

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
+import { eventNameToSlug } from "@/utils/utils";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import type { Event } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
@@ -36,7 +37,7 @@ function parseDate(value: string | undefined): Date | undefined {
   return isNaN(d.getTime()) ? undefined : d;
 }
 
-type ParsedEvent = Omit<Event, "id">;
+type ParsedEvent = Omit<Event, "id" | "slug">;
 type ParseResult = { data: ParsedEvent } | { error: string };
 
 function parseEventInput(input: EventInput): ParseResult {
@@ -84,6 +85,10 @@ function parseEventInput(input: EventInput): ParseResult {
   };
 }
 
+// Top-level route segments served by this app (see app/); an event slug
+// matching one of these would shadow or be shadowed by that route.
+const RESERVED_SLUGS = new Set(["admin", "api", "login", "media"]);
+
 export async function createEventAction(
   input: EventInput
 ): Promise<AdminActionResult> {
@@ -92,7 +97,42 @@ export async function createEventAction(
   const parsed = parseEventInput(input);
   if ("error" in parsed) return { ok: false, error: parsed.error };
 
-  await getRepositories().events.create(parsed.data);
+  const { events } = getRepositories();
+  const slug = eventNameToSlug(parsed.data.name);
+  if (!slug) {
+    return { ok: false, error: "Name must contain a letter or number" };
+  }
+  if (RESERVED_SLUGS.has(slug.toLowerCase())) {
+    return {
+      ok: false,
+      error: `"${slug}" is a reserved URL and cannot be used as an event name`,
+    };
+  }
+  const existing = await events.findBySlug(slug);
+  if (existing) {
+    return {
+      ok: false,
+      error: `An event with the URL "${slug}" already exists ("${existing.name}")`,
+    };
+  }
+
+  try {
+    await events.create(parsed.data);
+  } catch (e) {
+    // A concurrent create can win the race between the findBySlug check
+    // above and this insert; translate the constraint violation into the
+    // same friendly error instead of surfacing a 500.
+    if (
+      e instanceof Error &&
+      e.message.includes("UNIQUE constraint failed: events.slug")
+    ) {
+      return {
+        ok: false,
+        error: `An event with the URL "${slug}" already exists`,
+      };
+    }
+    throw e;
+  }
   revalidatePath("/admin");
   revalidatePath("/admin/events");
   return { ok: true };

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -10,9 +10,9 @@ const NO_STORE = { headers: { "cache-control": "no-store" } };
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const user = searchParams.get("user");
-  const eventName = searchParams.get("event");
+  const eventSlug = searchParams.get("event");
 
-  if (!user || !eventName) {
+  if (!user || !eventSlug) {
     return NextResponse.json(
       { error: "User and event parameters are required" },
       { ...NO_STORE, status: 400 }
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const repos = getRepositories();
-    const event = await repos.events.findByName(eventName);
+    const event = await repos.events.findBySlug(eventSlug);
     if (!event) {
       return NextResponse.json(
         { error: "Event not found" },

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -55,6 +55,12 @@ export interface EventsRepository {
   list(): Promise<Event[]>;
   findById(id: string): Promise<Event | undefined>;
   findByName(name: string): Promise<Event | undefined>;
+  /**
+   * Finds the event whose slugified name matches the given slug. Returns
+   * undefined if no event matches or the slug is ambiguous (slugification is
+   * lossy, so multiple names can share a slug).
+   */
+  findBySlug(slug: string): Promise<Event | undefined>;
   create(data: Omit<Event, "id">): Promise<Event>;
   update(
     id: string,

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -35,6 +35,11 @@ export interface DaysRepository {
 export type Event = {
   id: string;
   name: string;
+  /**
+   * URL segment for the event. Derived from the name at creation and stable
+   * afterwards (renames don't change it), so shared links keep working.
+   */
+  slug: string;
   description: string;
   website: string;
   start: Date;
@@ -55,16 +60,16 @@ export interface EventsRepository {
   list(): Promise<Event[]>;
   findById(id: string): Promise<Event | undefined>;
   findByName(name: string): Promise<Event | undefined>;
-  /**
-   * Finds the event whose slugified name matches the given slug. Returns
-   * undefined if no event matches or the slug is ambiguous (slugification is
-   * lossy, so multiple names can share a slug).
-   */
+  /** Finds the event with the given slug. Slugs are unique. */
   findBySlug(slug: string): Promise<Event | undefined>;
-  create(data: Omit<Event, "id">): Promise<Event>;
+  /**
+   * Creates the event with a slug derived from its name. Rejects when another
+   * event already has that slug (unique constraint).
+   */
+  create(data: Omit<Event, "id" | "slug">): Promise<Event>;
   update(
     id: string,
-    patch: Partial<Omit<Event, "id">>
+    patch: Partial<Omit<Event, "id" | "slug">>
   ): Promise<Event | undefined>;
   /** Deletes the event and all records referencing it (cascades via DB FK). */
   delete(id: string): Promise<void>;

--- a/db/repositories/sqlite/events.ts
+++ b/db/repositories/sqlite/events.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
+import { eventNameToSlug } from "@/utils/utils";
 import type { Event, EventsRepository } from "../interfaces";
 
 type EventRow = typeof schema.events.$inferInsert;
@@ -64,6 +65,16 @@ export class SqliteEventsRepository implements EventsRepository {
       .where(eq(schema.events.name, name))
       .get();
     return row ? rowToEvent(row) : undefined;
+  }
+
+  async findBySlug(slug: string): Promise<Event | undefined> {
+    // Slugification is lossy ("My-Event" and "My Event" share a slug), so the
+    // slug cannot be reversed; match by slugifying each name instead. If the
+    // slug is ambiguous (several names share it), treat it as unresolvable
+    // rather than silently picking an arbitrary event.
+    const events = await this.list();
+    const matches = events.filter((e) => eventNameToSlug(e.name) === slug);
+    return matches.length === 1 ? matches[0] : undefined;
   }
 
   async create(data: Omit<Event, "id">): Promise<Event> {

--- a/db/repositories/sqlite/events.ts
+++ b/db/repositories/sqlite/events.ts
@@ -13,6 +13,7 @@ function rowToEvent(row: typeof schema.events.$inferSelect): Event {
   return {
     id: row.id,
     name: row.name,
+    slug: row.slug,
     description: row.description,
     website: row.website,
     start: new Date(row.start),
@@ -68,22 +69,23 @@ export class SqliteEventsRepository implements EventsRepository {
   }
 
   async findBySlug(slug: string): Promise<Event | undefined> {
-    // Slugification is lossy ("My-Event" and "My Event" share a slug), so the
-    // slug cannot be reversed; match by slugifying each name instead. If the
-    // slug is ambiguous (several names share it), treat it as unresolvable
-    // rather than silently picking an arbitrary event.
-    const events = await this.list();
-    const matches = events.filter((e) => eventNameToSlug(e.name) === slug);
-    return matches.length === 1 ? matches[0] : undefined;
+    const row = this.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.slug, slug))
+      .get();
+    return row ? rowToEvent(row) : undefined;
   }
 
-  async create(data: Omit<Event, "id">): Promise<Event> {
+  async create(data: Omit<Event, "id" | "slug">): Promise<Event> {
     const id = nanoid();
+    const slug = eventNameToSlug(data.name);
     this.db
       .insert(schema.events)
       .values({
         id,
         name: data.name,
+        slug,
         description: data.description,
         website: data.website,
         start: data.start.toISOString(),
@@ -100,12 +102,12 @@ export class SqliteEventsRepository implements EventsRepository {
         icon: data.icon ?? null,
       })
       .run();
-    return { id, ...data };
+    return { id, slug, ...data };
   }
 
   async update(
     id: string,
-    patch: Partial<Omit<Event, "id">>
+    patch: Partial<Omit<Event, "id" | "slug">>
   ): Promise<Event | undefined> {
     const existing = await this.findById(id);
     if (!existing) return undefined;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -14,24 +14,31 @@ export const guests = sqliteTable("guests", {
   avatarUrl: text("avatar_url"),
 });
 
-export const events = sqliteTable("events", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  description: text("description").notNull().default(""),
-  website: text("website").notNull().default(""),
-  start: text("start").notNull(),
-  end: text("end").notNull(),
-  proposalPhaseStart: text("proposal_phase_start"),
-  proposalPhaseEnd: text("proposal_phase_end"),
-  votingPhaseStart: text("voting_phase_start"),
-  votingPhaseEnd: text("voting_phase_end"),
-  schedulingPhaseStart: text("scheduling_phase_start"),
-  schedulingPhaseEnd: text("scheduling_phase_end"),
-  maxSessionDuration: integer("max_session_duration").notNull().default(120),
-  breakMinutes: integer("break_minutes").notNull().default(10),
-  timezone: text("timezone").notNull().default("UTC"),
-  icon: text("icon"),
-});
+export const events = sqliteTable(
+  "events",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    // Set from the name at creation and stable afterwards, so URLs survive
+    // renames. Unique: two events must never resolve to the same URL.
+    slug: text("slug").notNull(),
+    description: text("description").notNull().default(""),
+    website: text("website").notNull().default(""),
+    start: text("start").notNull(),
+    end: text("end").notNull(),
+    proposalPhaseStart: text("proposal_phase_start"),
+    proposalPhaseEnd: text("proposal_phase_end"),
+    votingPhaseStart: text("voting_phase_start"),
+    votingPhaseEnd: text("voting_phase_end"),
+    schedulingPhaseStart: text("scheduling_phase_start"),
+    schedulingPhaseEnd: text("scheduling_phase_end"),
+    maxSessionDuration: integer("max_session_duration").notNull().default(120),
+    breakMinutes: integer("break_minutes").notNull().default(10),
+    timezone: text("timezone").notNull().default("UTC"),
+    icon: text("icon"),
+  },
+  (table) => [uniqueIndex("events_slug_unique").on(table.slug)]
+);
 
 export const eventGuests = sqliteTable(
   "event_guests",

--- a/drizzle/0009_sleepy_aqueduct.sql
+++ b/drizzle/0009_sleepy_aqueduct.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `__new_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`description` text DEFAULT '' NOT NULL,
+	`website` text DEFAULT '' NOT NULL,
+	`start` text NOT NULL,
+	`end` text NOT NULL,
+	`proposal_phase_start` text,
+	`proposal_phase_end` text,
+	`voting_phase_start` text,
+	`voting_phase_end` text,
+	`scheduling_phase_start` text,
+	`scheduling_phase_end` text,
+	`max_session_duration` integer DEFAULT 120 NOT NULL,
+	`break_minutes` integer DEFAULT 10 NOT NULL,
+	`timezone` text DEFAULT 'UTC' NOT NULL,
+	`icon` text
+);--> statement-breakpoint
+INSERT INTO `__new_events` (`id`, `name`, `slug`, `description`, `website`, `start`, `end`, `proposal_phase_start`, `proposal_phase_end`, `voting_phase_start`, `voting_phase_end`, `scheduling_phase_start`, `scheduling_phase_end`, `max_session_duration`, `break_minutes`, `timezone`, `icon`)
+SELECT `id`, `name`, replace(`name`, ' ', '-'), `description`, `website`, `start`, `end`, `proposal_phase_start`, `proposal_phase_end`, `voting_phase_start`, `voting_phase_end`, `scheduling_phase_start`, `scheduling_phase_end`, `max_session_duration`, `break_minutes`, `timezone`, `icon` FROM `events`;--> statement-breakpoint
+DROP TABLE `events`;--> statement-breakpoint
+ALTER TABLE `__new_events` RENAME TO `events`;--> statement-breakpoint
+-- Names that differ only in space-vs-dash backfill to the same slug (they used
+-- to resolve to the same URL). Keep one row per slug and suffix the rest with
+-- their unique id so the index below cannot fail.
+UPDATE `events` SET `slug` = `slug` || '-' || `id`
+WHERE `id` NOT IN (SELECT min(`id`) FROM `events` GROUP BY `slug`);--> statement-breakpoint
+CREATE UNIQUE INDEX `events_slug_unique` ON `events` (`slug`);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,878 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "27425456-36e1-4a01-9897-e6139f6fd9b3",
+  "prevId": "d8e89b10-e0e2-4c9e-acf9-bb36e185fae0",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attendee_scheduled": {
+          "name": "attendee_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782451329873,
       "tag": "0008_unknown_chamber",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1783287753472,
+      "tag": "0009_sleepy_aqueduct",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "url";
 import { DateTime } from "luxon";
 import * as schema from "@/db/schema";
 import { resolveDbPath, runMigrations } from "@/db/migrate";
+import { eventNameToSlug } from "@/utils/utils";
 import { VoteChoice } from "@/db/repositories/interfaces";
 
 const TZ = "Europe/Berlin";
@@ -817,6 +818,7 @@ function seedTestData() {
   const eventRows = eventConfigs.map((config, index) => ({
     id: nanoid(),
     name: config.name,
+    slug: eventNameToSlug(config.name),
     description: config.description,
     icon: config.icon,
     website: `test-event-${index + 1}.example.com`,

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -11,6 +11,10 @@ import { sanitizeGuest } from "@/utils/guests";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// Date.now() alone can collide when two events are created in the same
+// millisecond, violating the unique event slug.
+let eventCounter = 0;
+
 export async function createEvent(opts?: {
   phase?: "proposal" | "voting" | "scheduling";
   name?: string;
@@ -59,7 +63,7 @@ export async function createEvent(opts?: {
   const end = new Date(start.getTime() + 2 * DAY_MS);
 
   return events.create({
-    name: opts?.name ?? `Test Event ${Date.now()}`,
+    name: opts?.name ?? `Test Event ${++eventCounter}`,
     description: "",
     website: "",
     start,

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -107,6 +107,30 @@ describe("events repo", () => {
     });
   });
 
+  describe("slug", () => {
+    it("stores the slugified name on create", async () => {
+      const event = await createEvent({ name: "My-Event 2026" });
+      expect(event.slug).toBe("My-Event-2026");
+      const fetched = await getRepositories().events.findById(event.id);
+      expect(fetched?.slug).toBe("My-Event-2026");
+    });
+
+    it("rejects a second event whose name slugifies to the same slug", async () => {
+      await createEvent({ name: "My Event" });
+      await expect(createEvent({ name: "My-Event" })).rejects.toThrow(
+        /unique/i
+      );
+    });
+
+    it("keeps the slug when the event is renamed", async () => {
+      const event = await createEvent({ name: "Old Name" });
+      await getRepositories().events.update(event.id, { name: "New Name" });
+      const found = await getRepositories().events.findBySlug("Old-Name");
+      expect(found?.id).toBe(event.id);
+      expect(found?.name).toBe("New Name");
+    });
+  });
+
   describe("findBySlug", () => {
     it("finds an event by its slugified name", async () => {
       const event = await createEvent({ name: "Test Event" });
@@ -124,14 +148,6 @@ describe("events repo", () => {
       await createEvent({ name: "Test Event" });
       expect(
         await getRepositories().events.findBySlug("No-Such")
-      ).toBeUndefined();
-    });
-
-    it("returns undefined when two event names slugify to the same slug", async () => {
-      await createEvent({ name: "My Event" });
-      await createEvent({ name: "My-Event" });
-      expect(
-        await getRepositories().events.findBySlug("My-Event")
       ).toBeUndefined();
     });
   });
@@ -246,6 +262,21 @@ describe("event actions", () => {
       });
     });
 
+    it("rejects a duplicate event name", async () => {
+      await createEventAction(VALID_EVENT_INPUT);
+      const result = await createEventAction(VALID_EVENT_INPUT);
+      expect(!result.ok && result.error).toMatch(/already exists/i);
+    });
+
+    it("rejects a name that collides with an existing event's slug", async () => {
+      await createEventAction(VALID_EVENT_INPUT); // "Test Event"
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        name: "Test-Event",
+      });
+      expect(!result.ok && result.error).toMatch(/already exists/i);
+    });
+
     it("requires a name", async () => {
       const result = await createEventAction({
         ...VALID_EVENT_INPUT,
@@ -299,6 +330,61 @@ describe("event actions", () => {
         breakMinutes: "-5",
       });
       expect(!result.ok && result.error).toMatch(/break/i);
+    });
+
+    it("sanitizes unsafe characters out of the stored slug", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        name: "A/B Workshop",
+      });
+      expect(result.ok).toBe(true);
+      const event = await getRepositories().events.findBySlug("A-B-Workshop");
+      expect(event?.name).toBe("A/B Workshop");
+    });
+
+    it("rejects a name whose slug would collide with a reserved route", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        name: "admin",
+      });
+      expect(!result.ok && result.error).toMatch(/reserved/i);
+    });
+
+    it("rejects reserved routes case-insensitively", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        name: "API",
+      });
+      expect(!result.ok && result.error).toMatch(/reserved/i);
+    });
+
+    it("returns a friendly error when a concurrent create wins the slug race", async () => {
+      // Simulate a concurrent request inserting the same slug after this
+      // request's findBySlug pre-check passes but before its insert runs,
+      // so the loser hits the DB unique constraint instead of the pre-check.
+      const events = getRepositories().events;
+      const originalFindBySlug = events.findBySlug.bind(events);
+      const spy = vi
+        .spyOn(events, "findBySlug")
+        .mockImplementationOnce(async (slug) => {
+          const found = await originalFindBySlug(slug);
+          await createEvent({ name: VALID_EVENT_INPUT.name });
+          return found;
+        });
+      try {
+        const result = await createEventAction(VALID_EVENT_INPUT);
+        expect(!result.ok && result.error).toMatch(/already exists/i);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("rejects a name with no URL-safe characters", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        name: "///",
+      });
+      expect(!result.ok && result.error).toMatch(/letter or number/i);
     });
   });
 

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -107,6 +107,35 @@ describe("events repo", () => {
     });
   });
 
+  describe("findBySlug", () => {
+    it("finds an event by its slugified name", async () => {
+      const event = await createEvent({ name: "Test Event" });
+      const found = await getRepositories().events.findBySlug("Test-Event");
+      expect(found?.id).toBe(event.id);
+    });
+
+    it("finds an event whose name contains hyphens", async () => {
+      const event = await createEvent({ name: "My-Event 2026" });
+      const found = await getRepositories().events.findBySlug("My-Event-2026");
+      expect(found?.id).toBe(event.id);
+    });
+
+    it("returns undefined for an unknown slug", async () => {
+      await createEvent({ name: "Test Event" });
+      expect(
+        await getRepositories().events.findBySlug("No-Such")
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when two event names slugify to the same slug", async () => {
+      await createEvent({ name: "My Event" });
+      await createEvent({ name: "My-Event" });
+      expect(
+        await getRepositories().events.findBySlug("My-Event")
+      ).toBeUndefined();
+    });
+  });
+
   describe("delete", () => {
     it("deletes the event", async () => {
       const event = await createEvent();

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -5,25 +5,35 @@ import os from "os";
 import path from "path";
 import { runMigrations } from "@/db/migrate";
 
-// Writes a minimal Drizzle migrations folder containing a single migration.
-// Statements are separated by the Drizzle statement-breakpoint marker.
-function writeMigration(dir: string, statements: string[]): void {
+// Writes a minimal Drizzle migrations folder. Each entry is one migration's
+// statements, separated by the Drizzle statement-breakpoint marker.
+function writeMigrations(dir: string, migrations: string[][]): void {
   fs.mkdirSync(path.join(dir, "meta"), { recursive: true });
   const journal = {
     version: "7",
     dialect: "sqlite",
-    entries: [
-      { idx: 0, version: "6", when: 1, tag: "0000_test", breakpoints: true },
-    ],
+    entries: migrations.map((_, idx) => ({
+      idx,
+      version: "6",
+      when: idx + 1,
+      tag: `000${idx}_test`,
+      breakpoints: true,
+    })),
   };
   fs.writeFileSync(
     path.join(dir, "meta", "_journal.json"),
     JSON.stringify(journal)
   );
-  fs.writeFileSync(
-    path.join(dir, "0000_test.sql"),
-    statements.join("--> statement-breakpoint\n")
-  );
+  migrations.forEach((statements, idx) => {
+    fs.writeFileSync(
+      path.join(dir, `000${idx}_test.sql`),
+      statements.join("--> statement-breakpoint\n")
+    );
+  });
+}
+
+function writeMigration(dir: string, statements: string[]): void {
+  writeMigrations(dir, [statements]);
 }
 
 describe("runMigrations", () => {
@@ -70,6 +80,100 @@ describe("runMigrations", () => {
     ]);
 
     expect(() => runMigrations(sqlite, tmpDir)).toThrow(/foreign key/i);
+  });
+
+  // The events table as it exists just before the slug migration, so the real
+  // migration runs against realistic data.
+  const preSlugEventsTable = `CREATE TABLE \`events\` (
+      \`id\` text PRIMARY KEY NOT NULL,
+      \`name\` text NOT NULL,
+      \`description\` text DEFAULT '' NOT NULL,
+      \`website\` text DEFAULT '' NOT NULL,
+      \`start\` text NOT NULL,
+      \`end\` text NOT NULL,
+      \`proposal_phase_start\` text,
+      \`proposal_phase_end\` text,
+      \`voting_phase_start\` text,
+      \`voting_phase_end\` text,
+      \`scheduling_phase_start\` text,
+      \`scheduling_phase_end\` text,
+      \`max_session_duration\` integer DEFAULT 120 NOT NULL,
+      \`timezone\` text DEFAULT 'UTC' NOT NULL,
+      \`icon\` text,
+      \`break_minutes\` integer DEFAULT 10 NOT NULL
+    );`;
+
+  function readSlugMigration(): string[] {
+    const drizzleDir = path.join(process.cwd(), "drizzle");
+    const file = fs
+      .readdirSync(drizzleDir)
+      .filter((f) => /^\d+_.*\.sql$/.test(f))
+      .find((f) =>
+        fs
+          .readFileSync(path.join(drizzleDir, f), "utf8")
+          .includes("events_slug_unique")
+      );
+    expect(file, "event slug migration not found").toBeDefined();
+    return fs
+      .readFileSync(path.join(drizzleDir, file!), "utf8")
+      .split("--> statement-breakpoint\n");
+  }
+
+  it("the slug migration backfills event slugs on an existing database", () => {
+    writeMigrations(tmpDir, [
+      [
+        preSlugEventsTable,
+        `INSERT INTO events (id, name, start, end) VALUES
+           ('e1', 'My-Event 2026', '2026-01-01', '2026-01-02'),
+           ('e2', 'Other Event', '2026-02-01', '2026-02-02');`,
+      ],
+      readSlugMigration(),
+    ]);
+
+    runMigrations(sqlite, tmpDir);
+
+    const rows = sqlite
+      .prepare("SELECT id, name, slug FROM events ORDER BY id")
+      .all();
+    expect(rows).toEqual([
+      { id: "e1", name: "My-Event 2026", slug: "My-Event-2026" },
+      { id: "e2", name: "Other Event", slug: "Other-Event" },
+    ]);
+    // The unique index must survive the rebuild.
+    expect(() =>
+      sqlite
+        .prepare(
+          "INSERT INTO events (id, name, slug, start, end) VALUES ('e3', 'x', 'Other-Event', 's', 'e')"
+        )
+        .run()
+    ).toThrow(/unique/i);
+  });
+
+  it("the slug migration disambiguates events whose names collide as slugs", () => {
+    // Pre-slug, "My Event" and "My-Event" both resolved to the same URL, so
+    // such pairs can exist. The migration must not die on CREATE UNIQUE INDEX;
+    // it keeps one clean slug and suffixes the others with their id.
+    writeMigrations(tmpDir, [
+      [
+        preSlugEventsTable,
+        `INSERT INTO events (id, name, start, end) VALUES
+           ('e1', 'My Event', '2026-01-01', '2026-01-02'),
+           ('e2', 'My-Event', '2026-02-01', '2026-02-02'),
+           ('e3', 'My Event', '2026-03-01', '2026-03-02');`,
+      ],
+      readSlugMigration(),
+    ]);
+
+    expect(() => runMigrations(sqlite, tmpDir)).not.toThrow();
+
+    const rows = sqlite
+      .prepare("SELECT id, name, slug FROM events ORDER BY id")
+      .all();
+    expect(rows).toEqual([
+      { id: "e1", name: "My Event", slug: "My-Event" },
+      { id: "e2", name: "My-Event", slug: "My-Event-e2" },
+      { id: "e3", name: "My Event", slug: "My-Event-e3" },
+    ]);
   });
 
   it("leaves foreign key enforcement enabled afterwards", () => {

--- a/tests/integration/voting.test.ts
+++ b/tests/integration/voting.test.ts
@@ -22,11 +22,11 @@ function makeDeleteReq(payload: unknown): Request {
   });
 }
 
-// Read surface: GET /api/votes?user=<guestId>&event=<eventName>
-async function votesFor(guestId: string, eventName: string): Promise<Vote[]> {
+// Read surface: GET /api/votes?user=<guestId>&event=<eventSlug>
+async function votesFor(guestId: string, eventSlug: string): Promise<Vote[]> {
   const res = await getVotes(
     new NextRequest(
-      `http://test/api/votes?user=${guestId}&event=${encodeURIComponent(eventName)}`
+      `http://test/api/votes?user=${guestId}&event=${encodeURIComponent(eventSlug)}`
     )
   );
   expect(res.ok).toBe(true);
@@ -51,7 +51,7 @@ describe("voting API", () => {
     );
     expect(res.ok).toBe(true);
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0]).toMatchObject({
       proposalId: proposal.id,
@@ -76,7 +76,7 @@ describe("voting API", () => {
       expect(res.ok).toBe(true);
     }
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0].choice).toBe(VoteChoice.skip);
   });
@@ -118,7 +118,7 @@ describe("voting API", () => {
       choice: VoteChoice.maybe,
     });
 
-    const votes = await votesFor(guest.id, "Vote Event");
+    const votes = await votesFor(guest.id, "Vote-Event");
     expect(votes).toHaveLength(1);
     expect(votes[0].choice).toBe(VoteChoice.maybe);
   });
@@ -144,8 +144,8 @@ describe("voting API", () => {
     );
     expect(res.ok).toBe(true);
 
-    expect(await votesFor(alice.id, "Vote Event")).toHaveLength(0);
-    expect(await votesFor(bob.id, "Vote Event")).toHaveLength(1);
+    expect(await votesFor(alice.id, "Vote-Event")).toHaveLength(0);
+    expect(await votesFor(bob.id, "Vote-Event")).toHaveLength(1);
   });
 
   it("delete-vote is rejected outside the voting phase", async () => {
@@ -176,7 +176,7 @@ describe("voting API", () => {
     );
     expect(res.status).toBe(403);
     // The vote must still be there.
-    expect(await votesFor(guest.id, "Vote Event")).toHaveLength(1);
+    expect(await votesFor(guest.id, "Vote-Event")).toHaveLength(1);
   });
 
   it("delete-vote returns 404 for a missing proposal", async () => {
@@ -209,9 +209,29 @@ describe("voting API", () => {
       })
     );
 
-    const votesA = await votesFor(guest.id, "Event A");
+    const votesA = await votesFor(guest.id, "Event-A");
     expect(votesA).toHaveLength(1);
     expect(votesA[0].proposalId).toBe(proposalA.id);
+  });
+
+  it("GET /api/votes finds events whose name contains hyphens", async () => {
+    const event = await createEvent({
+      name: "Vote-Event 2026",
+      phase: "voting",
+    });
+    const guest = await createGuest();
+    const proposal = await createProposal(event.id, []);
+
+    await addVote(
+      makeAddReq({
+        proposalId: proposal.id,
+        guestId: guest.id,
+        choice: VoteChoice.interested,
+      })
+    );
+
+    const votes = await votesFor(guest.id, "Vote-Event-2026");
+    expect(votes).toHaveLength(1);
   });
 
   it("GET /api/votes requires user and event and rejects unknown events", async () => {

--- a/tests/unit/event-phases.test.ts
+++ b/tests/unit/event-phases.test.ts
@@ -10,6 +10,7 @@ function makeEvent(overrides: Partial<Event>): Event {
   return {
     id: "e1",
     name: "Test",
+    slug: "Test",
     description: "",
     website: "",
     start: ahead(30),

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -3,11 +3,11 @@ import {
   durationMinusBreak,
   formatDuration,
   eventNameToSlug,
-  eventSlugToName,
   dateOnDay,
   getPercentThroughDay,
   getNumHalfHours,
   getStartTimePlusBreak,
+  votesApiUrl,
 } from "@/utils/utils";
 import type { Day, Session } from "@/db/repositories/interfaces";
 
@@ -45,7 +45,7 @@ describe("formatDuration", () => {
     expect(formatDuration(120, true)).toBe("2 hours"));
 });
 
-// ── eventNameToSlug / eventSlugToName ────────────────────────────────────────
+// ── eventNameToSlug ──────────────────────────────────────────────────────────
 
 describe("eventNameToSlug", () => {
   it("replaces spaces with hyphens", () =>
@@ -53,20 +53,26 @@ describe("eventNameToSlug", () => {
 
   it("multiple spaces", () =>
     expect(eventNameToSlug("Foo Bar Baz")).toBe("Foo-Bar-Baz"));
+
+  it("keeps hyphens already in the name", () =>
+    expect(eventNameToSlug("My-Event 2026")).toBe("My-Event-2026"));
 });
 
-describe("eventSlugToName", () => {
-  it("replaces hyphens with spaces", () =>
-    expect(eventSlugToName("My-Event")).toBe("My Event"));
+// ── votesApiUrl ──────────────────────────────────────────────────────────────
 
-  it("round-trips simple names", () => {
-    const name = "Conference Alpha";
-    expect(eventSlugToName(eventNameToSlug(name))).toBe(name);
-  });
+describe("votesApiUrl", () => {
+  it("builds the votes query for plain values", () =>
+    expect(votesApiUrl("guest1", "My-Event")).toBe(
+      "/api/votes?user=guest1&event=My-Event"
+    ));
 
-  it("documents lossy behavior: hyphen in original name becomes space", () => {
-    // "My-Event" as a name slugifies to "My-Event", which reads back as "My Event"
-    expect(eventSlugToName(eventNameToSlug("My-Event"))).toBe("My Event");
+  it("encodes reserved URL characters so the slug survives query parsing", () => {
+    // "Food & Drinks" slugifies to "Food-&-Drinks"; unencoded, the server
+    // would parse event as "Food-" and drop "-Drinks" into a bogus param.
+    const url = votesApiUrl("guest1", "Food-&-Drinks");
+    const params = new URL(url, "http://test").searchParams;
+    expect(params.get("event")).toBe("Food-&-Drinks");
+    expect(params.get("user")).toBe("guest1");
   });
 });
 

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -56,6 +56,21 @@ describe("eventNameToSlug", () => {
 
   it("keeps hyphens already in the name", () =>
     expect(eventNameToSlug("My-Event 2026")).toBe("My-Event-2026"));
+
+  it("replaces path separators so the slug stays a single URL segment", () =>
+    expect(eventNameToSlug("A/B Workshop")).toBe("A-B-Workshop"));
+
+  it("strips reserved URL characters", () =>
+    expect(eventNameToSlug("Foo?#Bar&Baz")).toBe("Foo-Bar-Baz"));
+
+  it("collapses runs of unsafe characters and trims edge hyphens", () =>
+    expect(eventNameToSlug(" /Foo -- Bar/ ")).toBe("Foo-Bar"));
+
+  it("keeps non-ASCII letters", () =>
+    expect(eventNameToSlug("Café Sessions")).toBe("Café-Sessions"));
+
+  it("returns an empty slug when nothing safe remains", () =>
+    expect(eventNameToSlug("///")).toBe(""));
 });
 
 // ── votesApiUrl ──────────────────────────────────────────────────────────────
@@ -67,8 +82,9 @@ describe("votesApiUrl", () => {
     ));
 
   it("encodes reserved URL characters so the slug survives query parsing", () => {
-    // "Food & Drinks" slugifies to "Food-&-Drinks"; unencoded, the server
-    // would parse event as "Food-" and drop "-Drinks" into a bogus param.
+    // Legacy slugs stored before sanitization can contain "&"; unencoded,
+    // the server would parse event as "Food-" and drop "-Drinks" into a
+    // bogus param.
     const url = votesApiUrl("guest1", "Food-&-Drinks");
     const params = new URL(url, "http://test").searchParams;
     expect(params.get("event")).toBe("Food-&-Drinks");

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -29,18 +29,27 @@ export const dateOnDay = (date: Date, day: Day) => {
 };
 
 /**
- * Slugification is lossy ("My-Event" and "My Event" share a slug), so it
- * cannot be reversed. To resolve a slug back to an event, use
- * `EventsRepository.findBySlug`, which matches by slugifying each name.
+ * Derives the URL slug for a new event from its name. Only used at event
+ * creation: the slug is stored on the event and stays stable across renames,
+ * so for anything else read `event.slug` / `EventsRepository.findBySlug`
+ * instead of re-deriving it (slugification is lossy and cannot be reversed).
+ *
+ * The slug must be safe as a single URL path segment (`/[eventSlug]`), so
+ * anything other than letters, numbers, and hyphens is replaced with a
+ * hyphen; runs are collapsed and edge hyphens trimmed. Can return "" when
+ * the name has no safe characters — callers must reject that.
  */
 export function eventNameToSlug(name: string): string {
-  return name.replace(/ /g, "-");
+  return name
+    .replace(/[^\p{L}\p{N}-]+/gu, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 /**
- * URL for fetching a guest's votes. Encodes both values: event slugs keep
- * every non-space character of the event name (see eventNameToSlug), so
- * reserved URL characters like "&" would otherwise corrupt the query string.
+ * URL for fetching a guest's votes. Encodes both values so reserved URL
+ * characters (e.g. in legacy slugs stored before sanitization, like "&")
+ * cannot corrupt the query string.
  */
 export function votesApiUrl(user: string, eventSlug: string): string {
   const params = new URLSearchParams({ user, event: eventSlug });

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -28,12 +28,23 @@ export const dateOnDay = (date: Date, day: Day) => {
   );
 };
 
+/**
+ * Slugification is lossy ("My-Event" and "My Event" share a slug), so it
+ * cannot be reversed. To resolve a slug back to an event, use
+ * `EventsRepository.findBySlug`, which matches by slugifying each name.
+ */
 export function eventNameToSlug(name: string): string {
   return name.replace(/ /g, "-");
 }
 
-export function eventSlugToName(slug: string): string {
-  return slug.replace(/-/g, " ");
+/**
+ * URL for fetching a guest's votes. Encodes both values: event slugs keep
+ * every non-space character of the event name (see eventNameToSlug), so
+ * reserved URL characters like "&" would otherwise corrupt the query string.
+ */
+export function votesApiUrl(user: string, eventSlug: string): string {
+  const params = new URLSearchParams({ user, event: eventSlug });
+  return `/api/votes?${params.toString()}`;
 }
 
 /**


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [3252ff7](https://github.com/LWCW-Europe/schellingboard/pull/523/commits/3252ff731fcbcc2ec1cabaddbe7840f68efdd0a2).

PRs:
* #524
* ➡️ #523 (this PR, depends on the ones below ⬇️)
* #522

---

## Description

Deriving the slug from the name on every lookup meant renames broke
shared URLs, and colliding names ("My Event" / "My-Event") silently
resolved to the same page. Store the slug at creation, keep it stable
across renames, enforce uniqueness in the DB, and reject colliding
names with a friendly error when creating events.

Also: disambiguate pre-existing slug collisions during migration
instead of failing CREATE UNIQUE INDEX, sanitize slugs to be
URL-segment-safe and reject reserved route names, and translate a
concurrent-create unique-constraint violation into the same friendly
error instead of a 500.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=3252ff731fcbcc2ec1cabaddbe7840f68efdd0a2 -->