### PR TITLE
feat(admin): move event locations to paginated sub-route with bulk assign

### DIFF
--- a/app/admin/data-table.tsx
+++ b/app/admin/data-table.tsx
@@ -50,6 +50,62 @@ export function useTableParams() {
   return { searchParams, setParams };
 }
 
+/**
+ * Assign/remove/clear bar for a table selection. Rendered even while nothing
+ * is selected — hidden but keeping its space — so starting a selection doesn't
+ * shift the table under the user's pointer.
+ */
+export function BulkActionsBar({
+  selectedCount,
+  isPending,
+  onAssign,
+  onRemove,
+  onClear,
+}: {
+  selectedCount: number;
+  isPending: boolean;
+  onAssign: () => void;
+  onRemove: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className={`flex flex-wrap items-center gap-3 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm ${
+        selectedCount === 0 ? "invisible" : ""
+      }`}
+    >
+      <span className="font-medium text-gray-700">
+        {selectedCount} selected
+      </span>
+      <button
+        type="button"
+        onClick={onAssign}
+        disabled={isPending}
+        className="px-3 py-1 rounded-md border border-gray-900 bg-gray-900 text-white disabled:opacity-50 hover:bg-gray-700"
+      >
+        Assign selected
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={isPending}
+        className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-50 hover:bg-gray-50"
+      >
+        Remove selected
+      </button>
+      <button
+        type="button"
+        onClick={onClear}
+        className="px-3 py-1 rounded-md text-gray-600 hover:text-gray-900"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+
 export function DataTable<T>({
   rows,
   columns,

--- a/app/admin/events/[id]/event-guests-manager.tsx
+++ b/app/admin/events/[id]/event-guests-manager.tsx
@@ -7,6 +7,7 @@ import {
   removeGuestsFromEventAction,
 } from "@/app/actions/admin-guest-events";
 import {
+  BulkActionsBar,
   DataTable,
   useTableParams,
   type Column,
@@ -104,41 +105,15 @@ export function EventGuestsManager({
     rowLabel: (g) => g.name,
   };
 
-  const bulkBar =
-    selectedIds.size === 0 ? null : (
-      <div
-        role="region"
-        aria-label="Bulk actions"
-        className="flex flex-wrap items-center gap-3 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm"
-      >
-        <span className="font-medium text-gray-700">
-          {selectedIds.size} selected
-        </span>
-        <button
-          type="button"
-          onClick={() => handleBulk(true)}
-          disabled={isPending}
-          className="px-3 py-1 rounded-md border border-gray-900 bg-gray-900 text-white disabled:opacity-50 hover:bg-gray-700"
-        >
-          Assign selected
-        </button>
-        <button
-          type="button"
-          onClick={() => handleBulk(false)}
-          disabled={isPending}
-          className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-50 hover:bg-gray-50"
-        >
-          Remove selected
-        </button>
-        <button
-          type="button"
-          onClick={() => setSelectedIds(new Set())}
-          className="px-3 py-1 rounded-md text-gray-600 hover:text-gray-900"
-        >
-          Clear
-        </button>
-      </div>
-    );
+  const bulkBar = (
+    <BulkActionsBar
+      selectedCount={selectedIds.size}
+      isPending={isPending}
+      onAssign={() => handleBulk(true)}
+      onRemove={() => handleBulk(false)}
+      onClear={() => setSelectedIds(new Set())}
+    />
+  );
 
   const handleToggle = (guestId: string, currentlyAssigned: boolean) => {
     setPendingIds((prev) => new Set([...prev, guestId]));

--- a/app/admin/events/[id]/event-locations-manager.tsx
+++ b/app/admin/events/[id]/event-locations-manager.tsx
@@ -6,6 +6,13 @@ import {
   assignLocationsToEventAction,
   removeLocationsFromEventAction,
 } from "@/app/actions/admin-location-events";
+import {
+  BulkActionsBar,
+  DataTable,
+  useTableParams,
+  type Column,
+  type Selection,
+} from "../../data-table";
 
 export type LocationRow = {
   id: string;
@@ -14,27 +21,99 @@ export type LocationRow = {
   assigned: boolean;
 };
 
-type Filter = "all" | "assigned" | "not-assigned";
+export type LocationFilter = "all" | "assigned" | "not-assigned";
 
-const FILTER_LABEL: Record<Filter, string> = {
-  all: "All",
-  assigned: "Assigned",
-  "not-assigned": "Not assigned",
-};
+const FILTERS: { value: LocationFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "assigned", label: "Assigned" },
+  { value: "not-assigned", label: "Not assigned" },
+];
 
 export function EventLocationsManager({
   locations,
   eventId,
+  total,
+  page,
+  pageSize,
+  query,
+  filter,
 }: {
   locations: LocationRow[];
   eventId: string;
+  total: number;
+  page: number;
+  pageSize: number;
+  query: string;
+  filter: LocationFilter;
 }) {
   const router = useRouter();
-  const [filter, setFilter] = useState<Filter>("all");
+  const { setParams } = useTableParams();
   // Tracks which location IDs have a pending toggle so we can disable the box.
   const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  // Rows selected for bulk assign/remove (persists across pages until applied).
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
+
+  const toggleRow = (locationId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(locationId)) next.delete(locationId);
+      else next.add(locationId);
+      return next;
+    });
+  };
+
+  const toggleAllOnPage = (pageKeys: string[], shouldSelectAll: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const key of pageKeys) {
+        if (shouldSelectAll) next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
+  };
+
+  const handleBulk = (assign: boolean) => {
+    const locationIds = [...selectedIds];
+    if (locationIds.length === 0) return;
+    setError(null);
+
+    startTransition(async () => {
+      const action = assign
+        ? assignLocationsToEventAction
+        : removeLocationsFromEventAction;
+      try {
+        const result = await action({ eventId, locationIds });
+        if (!result.ok) {
+          setError(result.error);
+        } else {
+          setSelectedIds(new Set());
+          router.refresh();
+        }
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  const selection: Selection<LocationRow> = {
+    selectedKeys: selectedIds,
+    onToggleRow: toggleRow,
+    onToggleAllOnPage: toggleAllOnPage,
+    rowLabel: (l) => l.name,
+  };
+
+  const bulkBar = (
+    <BulkActionsBar
+      selectedCount={selectedIds.size}
+      isPending={isPending}
+      onAssign={() => handleBulk(true)}
+      onRemove={() => handleBulk(false)}
+      onClear={() => setSelectedIds(new Set())}
+    />
+  );
 
   const handleToggle = (locationId: string, currentlyAssigned: boolean) => {
     setPendingIds((prev) => new Set([...prev, locationId]));
@@ -63,64 +142,79 @@ export function EventLocationsManager({
     });
   };
 
-  const visible = locations.filter((l) => {
-    if (filter === "assigned") return l.assigned;
-    if (filter === "not-assigned") return !l.assigned;
-    return true;
-  });
+  const assignedCheckbox = (l: LocationRow) => (
+    <input
+      type="checkbox"
+      checked={l.assigned}
+      disabled={pendingIds.has(l.id)}
+      aria-label={`Assign ${l.name}`}
+      onChange={() => handleToggle(l.id, l.assigned)}
+      className="h-4 w-4 cursor-pointer"
+    />
+  );
+
+  const columns: Column<LocationRow>[] = [
+    { header: "Name", cell: (l) => l.name },
+    {
+      header: "Capacity",
+      cell: (l) => l.capacity,
+      cellClassName: "text-gray-500",
+    },
+    { header: "Assigned", cell: assignedCheckbox },
+  ];
+
+  const toolbar = (
+    <div className="flex gap-2">
+      {FILTERS.map((f) => (
+        <button
+          key={f.value}
+          type="button"
+          onClick={() =>
+            setParams({
+              filter: f.value === "all" ? null : f.value,
+              page: null,
+            })
+          }
+          className={`px-3 py-1 text-sm rounded-md border ${
+            filter === f.value
+              ? "bg-gray-900 text-white border-gray-900"
+              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+          }`}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  );
 
   return (
     <section aria-label="Locations" className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Locations</h2>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
-      <div className="flex gap-2">
-        {(["all", "assigned", "not-assigned"] as Filter[]).map((f) => (
-          <button
-            key={f}
-            onClick={() => setFilter(f)}
-            className={`px-3 py-1 text-sm rounded-md border ${
-              filter === f
-                ? "bg-gray-900 text-white border-gray-900"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-            }`}
-          >
-            {FILTER_LABEL[f]}
-          </button>
-        ))}
-      </div>
-
-      {locations.length === 0 ? (
-        <p className="text-sm text-gray-500">No locations yet.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-gray-200 text-left text-gray-600">
-              <th className="py-2 pr-4 font-medium">Name</th>
-              <th className="py-2 pr-4 font-medium">Capacity</th>
-              <th className="py-2 font-medium">Assigned</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visible.map((l) => (
-              <tr key={l.id} className="border-b border-gray-100">
-                <td className="py-2 pr-4">{l.name}</td>
-                <td className="py-2 pr-4 text-gray-500">{l.capacity}</td>
-                <td className="py-2">
-                  <input
-                    type="checkbox"
-                    checked={l.assigned}
-                    disabled={pendingIds.has(l.id)}
-                    aria-label={`Assign ${l.name}`}
-                    onChange={() => handleToggle(l.id, l.assigned)}
-                    className="h-4 w-4 cursor-pointer"
-                  />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <DataTable
+        rows={locations}
+        columns={columns}
+        rowKey={(l) => l.id}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        searchQuery={query}
+        searchPlaceholder="Search name…"
+        toolbar={toolbar}
+        bulkBar={bulkBar}
+        selection={selection}
+        emptyMessage="No locations match."
+        mobileCard={(l) => (
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="font-medium text-gray-900">{l.name}</p>
+              <p className="text-gray-500">Capacity: {l.capacity}</p>
+            </div>
+            {assignedCheckbox(l)}
+          </div>
+        )}
+      />
     </section>
   );
 }

--- a/app/admin/events/[id]/event-tabs.tsx
+++ b/app/admin/events/[id]/event-tabs.tsx
@@ -10,6 +10,7 @@ export function EventTabs({ eventId }: { eventId: string }) {
   const tabs: { href: string; label: string }[] = [
     { href: base, label: "Config" },
     { href: `${base}/guests`, label: "Guests" },
+    { href: `${base}/locations`, label: "Locations" },
     { href: `${base}/proposals`, label: "Proposals" },
     { href: `${base}/sessions`, label: "Sessions" },
   ];

--- a/app/admin/events/[id]/locations/page.tsx
+++ b/app/admin/events/[id]/locations/page.tsx
@@ -1,0 +1,81 @@
+import { notFound, redirect } from "next/navigation";
+import { getRepositories } from "@/db/container";
+import { outOfRangePageRedirect } from "@/utils/pagination";
+import { requireAdminPage } from "../../../require-admin";
+import {
+  EventLocationsManager,
+  type LocationFilter,
+  type LocationRow,
+} from "../event-locations-manager";
+
+const PAGE_SIZE = 25;
+
+function parseFilter(value: string | undefined): LocationFilter {
+  return value === "assigned" || value === "not-assigned" ? value : "all";
+}
+
+function parsePage(value: string | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
+
+export default async function AdminEventLocationsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ q?: string; page?: string; filter?: string }>;
+}) {
+  await requireAdminPage();
+
+  const { id } = await params;
+  const { q, page: pageParam, filter: filterParam } = await searchParams;
+  const repos = getRepositories();
+  const event = await repos.events.findById(id);
+  if (!event) notFound();
+
+  const filter = parseFilter(filterParam);
+  const page = parsePage(pageParam);
+  const query = q?.trim() ?? "";
+  const assigned =
+    filter === "assigned"
+      ? true
+      : filter === "not-assigned"
+        ? false
+        : undefined;
+
+  const { rows, total } = await repos.locations.searchForEventAssignment(id, {
+    query: query || undefined,
+    assigned,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+
+  const redirectTarget = outOfRangePageRedirect({
+    basePath: `/admin/events/${id}/locations`,
+    page,
+    total,
+    pageSize: PAGE_SIZE,
+    params: { q: query, filter: filter === "all" ? "" : filter },
+  });
+  if (redirectTarget) redirect(redirectTarget);
+
+  const locationRows: LocationRow[] = rows.map((l) => ({
+    id: l.id,
+    name: l.name,
+    capacity: l.capacity,
+    assigned: l.assigned,
+  }));
+
+  return (
+    <EventLocationsManager
+      locations={locationRows}
+      eventId={id}
+      total={total}
+      page={page}
+      pageSize={PAGE_SIZE}
+      query={query}
+      filter={filter}
+    />
+  );
+}

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -5,10 +5,6 @@ import { requireAdminPage } from "../../require-admin";
 import { EventDetailForm } from "./event-detail-form";
 import { EventPhasesForm } from "./event-phases-form";
 import { EventDaysManager, type SerializedDay } from "./event-days-manager";
-import {
-  EventLocationsManager,
-  type LocationRow,
-} from "./event-locations-manager";
 
 export default async function AdminEventConfigPage({
   params,
@@ -21,17 +17,6 @@ export default async function AdminEventConfigPage({
   const repos = getRepositories();
   const event = await repos.events.findById(id);
   if (!event) notFound();
-
-  const allLocations = await repos.locations.list();
-  const assignedLocationIds = new Set(
-    await repos.locations.listLocationIdsByEvent(id)
-  );
-  const locationRows: LocationRow[] = allLocations.map((l) => ({
-    id: l.id,
-    name: l.name,
-    capacity: l.capacity,
-    assigned: assignedLocationIds.has(l.id),
-  }));
 
   const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
   const days: SerializedDay[] = (await repos.days.listByEvent(id)).map((d) => ({
@@ -58,8 +43,6 @@ export default async function AdminEventConfigPage({
       </div>
       <hr className="border-gray-200" />
       <EventDaysManager days={days} eventId={id} />
-      <hr className="border-gray-200" />
-      <EventLocationsManager locations={locationRows} eventId={id} />
     </div>
   );
 }

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -160,9 +160,37 @@ export type Location = {
   areaDescription?: string;
 };
 
+/** A location paired with whether it is assigned to a given event. */
+export type EventLocationRow = {
+  id: string;
+  name: string;
+  capacity: number;
+  assigned: boolean;
+};
+
+/** A page of locations plus the total count of rows matching the same filter. */
+export type EventLocationPage = {
+  rows: EventLocationRow[];
+  total: number;
+};
+
 export interface LocationsRepository {
   /** All locations (including hidden), ordered by sortIndex. */
   list(): Promise<Location[]>;
+  /**
+   * Server-side paginated + searchable location list scoped to an event's
+   * assignment. `assigned` filters by membership (undefined = all); `query`
+   * matches the name (case-insensitive substring). Ordered by name.
+   */
+  searchForEventAssignment(
+    eventId: string,
+    opts: {
+      query?: string;
+      assigned?: boolean;
+      limit: number;
+      offset: number;
+    }
+  ): Promise<EventLocationPage>;
   listVisible(): Promise<Location[]>;
   listBookable(): Promise<Location[]>;
   findById(id: string): Promise<Location | undefined>;

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -1,10 +1,20 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
-import type { Location, LocationsRepository } from "../interfaces";
+import type {
+  EventLocationPage,
+  Location,
+  LocationsRepository,
+} from "../interfaces";
 
 type DB = BetterSQLite3Database<typeof schema>;
+
+// Escape LIKE meta-characters so user input is matched literally. Pairs with an
+// explicit `ESCAPE '\'` clause in the query below.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 function rowToLocation(row: typeof schema.locations.$inferSelect): Location {
   return {
@@ -31,6 +41,68 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .orderBy(schema.locations.sortIndex, schema.locations.id)
       .all()
       .map(rowToLocation);
+  }
+
+  async searchForEventAssignment(
+    eventId: string,
+    opts: {
+      query?: string;
+      assigned?: boolean;
+      limit: number;
+      offset: number;
+    }
+  ): Promise<EventLocationPage> {
+    // A location is "assigned" when the event-scoped left join matches a row.
+    const joinCondition = and(
+      eq(schema.locations.id, schema.eventLocations.locationId),
+      eq(schema.eventLocations.eventId, eventId)
+    );
+
+    const conditions = [];
+    if (opts.assigned === true) {
+      conditions.push(isNotNull(schema.eventLocations.locationId));
+    } else if (opts.assigned === false) {
+      conditions.push(isNull(schema.eventLocations.locationId));
+    }
+    if (opts.query) {
+      const pattern = `%${escapeLike(opts.query)}%`;
+      conditions.push(
+        sql`${schema.locations.name} like ${pattern} escape '\\'`
+      );
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const totalRow = this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.locations)
+      .leftJoin(schema.eventLocations, joinCondition)
+      .where(where)
+      .get();
+
+    const rows = this.db
+      .select({
+        id: schema.locations.id,
+        name: schema.locations.name,
+        capacity: schema.locations.capacity,
+        assigned: sql<number>`(${schema.eventLocations.locationId} is not null)`,
+      })
+      .from(schema.locations)
+      .leftJoin(schema.eventLocations, joinCondition)
+      .where(where)
+      // id as tiebreaker: name is not unique, and without a deterministic
+      // order LIMIT/OFFSET pagination can duplicate or skip rows.
+      .orderBy(schema.locations.name, schema.locations.id)
+      .limit(opts.limit)
+      .offset(opts.offset)
+      .all()
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        capacity: r.capacity,
+        assigned: Boolean(r.assigned),
+      }));
+
+    return { rows, total: totalRow?.count ?? 0 };
   }
 
   async listVisible(): Promise<Location[]> {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -33,11 +33,12 @@ async function gotoLocations(page: Page) {
   await expect(page.getByRole("heading", { name: "Locations" })).toBeVisible();
 }
 
-// Event detail is split into tab sub-routes (Config · Guests · Proposals ·
-// Sessions). Call this after clicking an event's "Manage" link to open a tab.
+// Event detail is split into tab sub-routes (Config · Guests · Locations ·
+// Proposals · Sessions). Call this after clicking an event's "Manage" link to
+// open a tab.
 async function openEventTab(
   page: Page,
-  tab: "Config" | "Guests" | "Proposals" | "Sessions"
+  tab: "Config" | "Guests" | "Locations" | "Proposals" | "Sessions"
 ) {
   const link = page
     .getByRole("navigation", { name: "Event sections" })
@@ -250,6 +251,10 @@ test.describe("Admin UI events", () => {
     await openEventTab(page, "Guests");
     await expect(page).toHaveURL(/\/guests$/);
     await expect(page.getByRole("region", { name: "Guests" })).toBeVisible();
+
+    await openEventTab(page, "Locations");
+    await expect(page).toHaveURL(/\/locations$/);
+    await expect(page.getByRole("region", { name: "Locations" })).toBeVisible();
 
     await openEventTab(page, "Proposals");
     await expect(page).toHaveURL(/\/proposals$/);
@@ -770,6 +775,7 @@ test.describe("Admin UI locations", () => {
         .filter({ hasText: eventName })
         .getByRole("link", { name: "Manage" })
         .click();
+      await openEventTab(page, "Locations");
 
       const locations = page.getByRole("region", { name: "Locations" });
       await expect(locations).toBeVisible();
@@ -780,11 +786,15 @@ test.describe("Admin UI locations", () => {
       const mainHallRow = locations
         .getByRole("row")
         .filter({ hasText: "Main Hall" });
-      await expect(mainHallRow.getByRole("checkbox")).not.toBeChecked();
+      // Each row has a "Select" checkbox (bulk) and an "Assign" checkbox (state).
+      const mainHallAssign = mainHallRow.getByRole("checkbox", {
+        name: /^Assign /,
+      });
+      await expect(mainHallAssign).not.toBeChecked();
 
-      // Assign Main Hall
-      await mainHallRow.getByRole("checkbox").click();
-      await expect(mainHallRow.getByRole("checkbox")).toBeChecked();
+      // Assign Main Hall — click and wait for server-driven update
+      await mainHallAssign.click();
+      await expect(mainHallAssign).toBeChecked();
 
       // Navigate away and back — assignment must persist. Soft navigation via
       // the back link avoids aborting the assignment action's revalidation
@@ -796,6 +806,7 @@ test.describe("Admin UI locations", () => {
         .filter({ hasText: eventName })
         .getByRole("link", { name: "Manage" })
         .click();
+      await openEventTab(page, "Locations");
       await expect(
         page
           .getByRole("region", { name: "Locations" })
@@ -808,7 +819,7 @@ test.describe("Admin UI locations", () => {
       const l2 = page.getByRole("region", { name: "Locations" });
       await l2.getByRole("button", { name: "Assigned", exact: true }).click();
       await expect(
-        l2.getByRole("row").filter({ has: page.getByRole("checkbox") })
+        l2.getByRole("row").filter({ hasNot: page.getByRole("columnheader") })
       ).toHaveCount(1);
       await expect(
         l2.getByRole("row").filter({ hasText: "Main Hall" })
@@ -826,10 +837,37 @@ test.describe("Admin UI locations", () => {
 
       // Switch back to All and remove the assignment
       await l2.getByRole("button", { name: "All", exact: true }).click();
-      await l2.getByRole("checkbox", { checked: true }).click();
-      await expect(l2.getByRole("checkbox", { checked: true })).toHaveCount(0);
+      await l2
+        .getByRole("checkbox", { name: /^Assign /, checked: true })
+        .click();
+      await expect(
+        l2.getByRole("checkbox", { name: /^Assign /, checked: true })
+      ).toHaveCount(0);
 
-      // Clean up
+      // Bulk: select all rows on the page, assign, then remove. Assert on fixed
+      // seeded locations, not row counts (parallel tests create/delete rows).
+      // Starting a selection must not shift the table (the bulk bar reserves
+      // its space), or the checkbox moves away from under the pointer.
+      const selectAll = l2.getByRole("checkbox", { name: "Select all" });
+      const boxBeforeSelect = await selectAll.boundingBox();
+      await selectAll.check();
+      expect(await selectAll.boundingBox()).toEqual(boxBeforeSelect);
+      await l2.getByRole("button", { name: "Assign selected" }).click();
+      await expect(
+        l2.getByRole("checkbox", { name: "Assign Main Hall" })
+      ).toBeChecked();
+      await expect(
+        l2.getByRole("checkbox", { name: "Assign Workshop Room" })
+      ).toBeChecked();
+
+      await l2.getByRole("checkbox", { name: "Select all" }).check();
+      await l2.getByRole("button", { name: "Remove selected" }).click();
+      await expect(
+        l2.getByRole("checkbox", { name: /^Assign /, checked: true })
+      ).toHaveCount(0);
+
+      // Clean up — the delete control lives on the Config tab
+      await openEventTab(page, "Config");
       await page.getByRole("button", { name: "Delete event" }).click();
       await page.getByLabel("Type the event name to confirm").fill(eventName);
       await page.getByRole("button", { name: "Confirm delete" }).click();

--- a/tests/integration/admin-location-search.test.ts
+++ b/tests/integration/admin-location-search.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createLocation } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("locations.searchForEventAssignment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns all locations with an assigned flag for the event", async () => {
+    const event = await createEvent();
+    const a = await createLocation({ name: "Auditorium", capacity: 100 });
+    await createLocation({ name: "Boardroom", capacity: 10 });
+    const repos = getRepositories();
+    await repos.locations.assignToEvent(event.id, [a.id]);
+
+    const { rows, total } = await repos.locations.searchForEventAssignment(
+      event.id,
+      { limit: 50, offset: 0 }
+    );
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => [r.name, r.capacity, r.assigned])).toEqual([
+      ["Auditorium", 100, true],
+      ["Boardroom", 10, false],
+    ]);
+  });
+
+  it("filters by assignment membership", async () => {
+    const event = await createEvent();
+    const a = await createLocation({ name: "Auditorium" });
+    await createLocation({ name: "Boardroom" });
+    const repos = getRepositories();
+    await repos.locations.assignToEvent(event.id, [a.id]);
+
+    const assigned = await repos.locations.searchForEventAssignment(event.id, {
+      assigned: true,
+      limit: 50,
+      offset: 0,
+    });
+    expect(assigned.total).toBe(1);
+    expect(assigned.rows.map((r) => r.name)).toEqual(["Auditorium"]);
+
+    const notAssigned = await repos.locations.searchForEventAssignment(
+      event.id,
+      { assigned: false, limit: 50, offset: 0 }
+    );
+    expect(notAssigned.total).toBe(1);
+    expect(notAssigned.rows.map((r) => r.name)).toEqual(["Boardroom"]);
+  });
+
+  it("searches name case-insensitively by substring", async () => {
+    const event = await createEvent();
+    await createLocation({ name: "Main Hall" });
+    await createLocation({ name: "Workshop Room" });
+    const repos = getRepositories();
+
+    const { rows } = await repos.locations.searchForEventAssignment(event.id, {
+      query: "hall",
+      limit: 50,
+      offset: 0,
+    });
+    expect(rows.map((r) => r.name)).toEqual(["Main Hall"]);
+  });
+
+  it("treats % and _ in the query as literal characters, not wildcards", async () => {
+    const event = await createEvent();
+    await createLocation({ name: "50% Off Room" });
+    await createLocation({ name: "500 Off Room" });
+    await createLocation({ name: "Room A_1" });
+    await createLocation({ name: "Room AX1" });
+    const repos = getRepositories();
+
+    const percent = await repos.locations.searchForEventAssignment(event.id, {
+      query: "50%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(percent.rows.map((r) => r.name)).toEqual(["50% Off Room"]);
+    expect(percent.total).toBe(1);
+
+    const underscore = await repos.locations.searchForEventAssignment(
+      event.id,
+      { query: "A_1", limit: 50, offset: 0 }
+    );
+    expect(underscore.rows.map((r) => r.name)).toEqual(["Room A_1"]);
+    expect(underscore.total).toBe(1);
+  });
+
+  it("paginates via limit/offset while reporting the full total", async () => {
+    const event = await createEvent();
+    for (const name of ["A", "B", "C", "D", "E"]) {
+      await createLocation({ name });
+    }
+    const repos = getRepositories();
+
+    const firstPage = await repos.locations.searchForEventAssignment(event.id, {
+      limit: 2,
+      offset: 0,
+    });
+    expect(firstPage.total).toBe(5);
+    expect(firstPage.rows.map((r) => r.name)).toEqual(["A", "B"]);
+
+    const secondPage = await repos.locations.searchForEventAssignment(
+      event.id,
+      { limit: 2, offset: 2 }
+    );
+    expect(secondPage.total).toBe(5);
+    expect(secondPage.rows.map((r) => r.name)).toEqual(["C", "D"]);
+  });
+
+  it("orders duplicate names by id so pagination is stable", async () => {
+    const event = await createEvent();
+    const repos = getRepositories();
+
+    // Create locations sharing a name until insertion order differs from id
+    // order, so a name tie cannot accidentally come back id-sorted without
+    // an explicit tiebreaker.
+    const ids: string[] = [];
+    do {
+      ids.push((await createLocation({ name: "Dup" })).id);
+    } while (
+      ids.length < 2 ||
+      ids.every((id, i) => i === 0 || ids[i - 1] < id)
+    );
+
+    const pagedIds: string[] = [];
+    for (let offset = 0; offset < ids.length; offset++) {
+      const { rows } = await repos.locations.searchForEventAssignment(
+        event.id,
+        { limit: 1, offset }
+      );
+      pagedIds.push(rows[0].id);
+    }
+
+    expect(pagedIds).toEqual([...ids].sort());
+  });
+});


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [2b62efd](https://github.com/LWCW-Europe/schellingboard/pull/525/commits/2b62efde7b9bae54bd07198965a7b112f320e9c6).

PRs:
* #546
* #545
* #540
* #539
* #538
* #527
* #526
* ➡️ #525 (this PR, base of the stack — can be merged first)

---

## Description

The bulk actions bar (extracted into data-table, shared with guests)
always reserves its space so starting a selection does not shift the
table under the pointer.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=2b62efde7b9bae54bd07198965a7b112f320e9c6 -->