### PR TITLE
Set `silent: "passed-only"` in vitest config.

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     include: ["tests/unit/**/*.test.ts", "tests/integration/**/*.test.ts"],
     environment: "node",
     pool: "forks",
+    silent: "passed-only",
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],


### PR DESCRIPTION
That means stdout/stderr output from tests is only visible from tests that fail.