### PR TITLE
Adjusting CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@
 
 ### Prerequisites
 
-- Node.js / Bun
+- **Bun** (package manager and script runner)
+- **Node.js 22** (or higher), installed and on your `PATH`. Although Bun runs
+  the app, the tooling shells out to a real `node` — `bun x tsx` for
+  migrations/scripts, and Vitest's test workers — so `node` must be directly on
+  your `PATH`. Check with `node -v`.
 
 ### Setup
 
@@ -203,7 +207,7 @@ Each E2E run starts from a clean database with 3 events (Alpha/Beta/Gamma) in di
 
 - Use conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, etc.)
 - Subject line ≤ 72 chars; explain WHY in the body if not obvious
-- Before committing, run `bun lint`, `bun format`, and `bun typecheck`
+- Before committing, run `make precommit`
 - When working on a GitHub issue, add a footer: `issue #123` (partial work) or `fixes #123` (fully resolves it)
 
 ## Pull Requests


### PR DESCRIPTION
- Without having the specific version of node@24 installed, starting up the server with `make dev` fails.

- There are no `bun lint / test / typecheck`, those commands exist for `make` however.