### PR TITLE
fix(admin): escape LIKE wildcards in event guest search

### DIFF
--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -1,13 +1,4 @@
-import {
-  and,
-  eq,
-  inArray,
-  isNotNull,
-  isNull,
-  like,
-  or,
-  sql,
-} from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -20,6 +11,12 @@ import type {
 import { sanitizeGuest } from "@/utils/guests";
 
 type DB = BetterSQLite3Database<typeof schema>;
+
+// Escape LIKE meta-characters so user input is matched literally. Pairs with an
+// explicit `ESCAPE '\'` clause in the query below.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
   return {
@@ -83,12 +80,9 @@ export class SqliteGuestsRepository implements GuestsRepository {
       conditions.push(isNull(schema.eventGuests.guestId));
     }
     if (opts.query) {
-      const pattern = `%${opts.query}%`;
+      const pattern = `%${escapeLike(opts.query)}%`;
       conditions.push(
-        or(
-          like(schema.guests.name, pattern),
-          like(schema.guests.email, pattern)
-        )
+        sql`((${schema.guests.name} like ${pattern} escape '\\') or (${schema.guests.email} like ${pattern} escape '\\'))`
       );
     }
     const where = conditions.length > 0 ? and(...conditions) : undefined;

--- a/tests/integration/admin-guest-search.test.ts
+++ b/tests/integration/admin-guest-search.test.ts
@@ -72,6 +72,34 @@ describe("guests.searchForEventAssignment", () => {
     expect(byEmail.rows.map((r) => r.name)).toEqual(["Bob Jones"]);
   });
 
+  it("treats % and _ in the query as literal characters, not wildcards", async () => {
+    const event = await createEvent();
+    await createGuest({ name: "50% Discount", email: "fifty@test.example" });
+    await createGuest({
+      name: "500 Discount",
+      email: "fivehundred@test.example",
+    });
+    await createGuest({ name: "Underscore", email: "a_1@test.example" });
+    await createGuest({ name: "No Underscore", email: "ax1@test.example" });
+    const repos = getRepositories();
+
+    const percent = await repos.guests.searchForEventAssignment(event.id, {
+      query: "50%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(percent.rows.map((r) => r.name)).toEqual(["50% Discount"]);
+    expect(percent.total).toBe(1);
+
+    const underscore = await repos.guests.searchForEventAssignment(event.id, {
+      query: "a_1",
+      limit: 50,
+      offset: 0,
+    });
+    expect(underscore.rows.map((r) => r.name)).toEqual(["Underscore"]);
+    expect(underscore.total).toBe(1);
+  });
+
   it("paginates via limit/offset while reporting the full total", async () => {
     const event = await createEvent();
     for (const name of ["A", "B", "C", "D", "E"]) {


### PR DESCRIPTION
Queries containing % or _ leaked into the LIKE pattern, so they acted as
wildcards instead of matching literally. Same fix as locations search.

<!-- jip:pushed-commit=b220c57b7a93627ba44892800f2bb56fc18392d7 -->