### PR TITLE
fix(admin): fetch session RSVPs in one query on admin sessions page

### DIFF
--- a/app/admin/events/[id]/sessions/page.tsx
+++ b/app/admin/events/[id]/sessions/page.tsx
@@ -36,26 +36,32 @@ export default async function AdminEventSessionsPage({
     .filter((l) => assignedLocationIds.has(l.id))
     .map((l) => ({ id: l.id, name: l.name }));
 
-  const sessionRows: SessionRow[] = await Promise.all(
-    (await repos.sessions.listByEvent(id)).map(async (s) => ({
-      id: s.id,
-      title: s.title,
-      description: s.description,
-      startTime: s.startTime ? s.startTime.toISOString() : null,
-      endTime: s.endTime ? s.endTime.toISOString() : null,
-      capacity: s.capacity,
-      attendeeScheduled: s.attendeeScheduled,
-      blocker: s.blocker,
-      closed: s.closed,
-      hosts: s.hosts.map((h) => ({ id: h.id, name: h.name })),
-      locations: s.locations.map((l) => ({ id: l.id, name: l.name })),
-      numRsvps: s.numRsvps,
-      rsvps: (await repos.rsvps.listBySession(s.id)).map((r) => ({
-        guestId: r.guestId,
-        name: guestNameById.get(r.guestId) ?? "Unknown guest",
-      })),
-    }))
-  );
+  const sessions = await repos.sessions.listByEvent(id);
+  const rsvpsBySession = new Map<string, { guestId: string; name: string }[]>();
+  for (const r of await repos.rsvps.listBySessions(sessions.map((s) => s.id))) {
+    let list = rsvpsBySession.get(r.sessionId);
+    if (!list) rsvpsBySession.set(r.sessionId, (list = []));
+    list.push({
+      guestId: r.guestId,
+      name: guestNameById.get(r.guestId) ?? "Unknown guest",
+    });
+  }
+
+  const sessionRows: SessionRow[] = sessions.map((s) => ({
+    id: s.id,
+    title: s.title,
+    description: s.description,
+    startTime: s.startTime ? s.startTime.toISOString() : null,
+    endTime: s.endTime ? s.endTime.toISOString() : null,
+    capacity: s.capacity,
+    attendeeScheduled: s.attendeeScheduled,
+    blocker: s.blocker,
+    closed: s.closed,
+    hosts: s.hosts.map((h) => ({ id: h.id, name: h.name })),
+    locations: s.locations.map((l) => ({ id: l.id, name: l.name })),
+    numRsvps: s.numRsvps,
+    rsvps: rsvpsBySession.get(s.id) ?? [],
+  }));
 
   return (
     <EventSessionsManager

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -248,6 +248,7 @@ export type Rsvp = {
 export interface RsvpsRepository {
   listByGuest(guestId: string): Promise<Rsvp[]>;
   listBySession(sessionId: string): Promise<Rsvp[]>;
+  listBySessions(sessionIds: string[]): Promise<Rsvp[]>;
   create(data: { sessionId: string; guestId: string }): Promise<Rsvp>;
   deleteBySessionAndGuest(sessionId: string, guestId: string): Promise<void>;
   deleteBySessionAndGuests(

--- a/db/repositories/sqlite/rsvps.ts
+++ b/db/repositories/sqlite/rsvps.ts
@@ -31,6 +31,16 @@ export class SqliteRsvpsRepository implements RsvpsRepository {
       .map(rowToRsvp);
   }
 
+  async listBySessions(sessionIds: string[]): Promise<Rsvp[]> {
+    if (sessionIds.length === 0) return [];
+    return this.db
+      .select()
+      .from(schema.rsvps)
+      .where(inArray(schema.rsvps.sessionId, sessionIds))
+      .all()
+      .map(rowToRsvp);
+  }
+
   async create(data: { sessionId: string; guestId: string }): Promise<Rsvp> {
     const id = nanoid();
     this.db

--- a/tests/integration/admin-rsvps.test.ts
+++ b/tests/integration/admin-rsvps.test.ts
@@ -94,3 +94,40 @@ describe("adminRemoveRsvpAction", () => {
     expect(!result.ok && result.error).toBe("Session not found");
   });
 });
+
+describe("rsvps.listBySessions", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+  });
+
+  it("returns RSVPs for all given sessions in one call", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const g1 = await createGuest({ name: "Attendee One" });
+    const g2 = await createGuest({ name: "Attendee Two" });
+    const s1 = await createSession(event.id);
+    const s2 = await createSession(event.id);
+    const other = await createSession(event.id);
+    await repos.rsvps.create({ sessionId: s1.id, guestId: g1.id });
+    await repos.rsvps.create({ sessionId: s2.id, guestId: g1.id });
+    await repos.rsvps.create({ sessionId: s2.id, guestId: g2.id });
+    await repos.rsvps.create({ sessionId: other.id, guestId: g2.id });
+
+    const rsvps = await repos.rsvps.listBySessions([s1.id, s2.id]);
+
+    expect(rsvps.map((r) => [r.sessionId, r.guestId]).sort()).toEqual(
+      [
+        [s1.id, g1.id],
+        [s2.id, g1.id],
+        [s2.id, g2.id],
+      ].sort()
+    );
+  });
+
+  it("returns an empty list for no session ids", async () => {
+    const repos = getRepositories();
+    expect(await repos.rsvps.listBySessions([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Avoid an N+1 pattern that scaled DB round-trips with session count.

<!-- jip:pushed-commit=34c751e2b5d9d1e41d19c242f03863f0fcfa2174 -->