### PR TITLE
feat(admin): server-side search + pagination on /admin/users

### DIFF
--- a/app/admin/data-table.tsx
+++ b/app/admin/data-table.tsx
@@ -156,7 +156,10 @@ export function DataTable<T>({
   const onSearch = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const value = new FormData(event.currentTarget).get("q");
-    setParams({ q: typeof value === "string" ? value : null, page: null });
+    // Server pages trim the query, so a whitespace-only value means "no
+    // search" — keep it out of the URL to match what the server renders.
+    const query = typeof value === "string" ? value.trim() : "";
+    setParams({ q: query || null, page: null });
   };
 
   const pageKeys = rows.map(rowKey);

--- a/app/admin/data-table.tsx
+++ b/app/admin/data-table.tsx
@@ -106,6 +106,34 @@ export function BulkActionsBar({
   );
 }
 
+type TableProps<T> = {
+  rows: T[];
+  rowKey: (row: T) => string;
+  total: number;
+  page: number;
+  pageSize: number;
+  searchQuery: string;
+  searchPlaceholder?: string;
+  toolbar?: ReactNode;
+  bulkBar?: ReactNode;
+  emptyMessage?: string;
+} & (
+  | {
+      columns: Column<T>[];
+      selection?: Selection<T>;
+      mobileCard: (row: T) => ReactNode;
+      listItem?: undefined;
+    }
+  | {
+      // List mode: each row renders as a rich list item on every viewport
+      // (for rows that don't fit a column layout, e.g. inline edit forms).
+      columns?: undefined;
+      selection?: undefined;
+      mobileCard?: undefined;
+      listItem: (row: T) => ReactNode;
+    }
+);
+
 export function DataTable<T>({
   rows,
   columns,
@@ -119,22 +147,9 @@ export function DataTable<T>({
   bulkBar,
   selection,
   mobileCard,
+  listItem,
   emptyMessage = "Nothing to show.",
-}: {
-  rows: T[];
-  columns: Column<T>[];
-  rowKey: (row: T) => string;
-  total: number;
-  page: number;
-  pageSize: number;
-  searchQuery: string;
-  searchPlaceholder?: string;
-  toolbar?: ReactNode;
-  bulkBar?: ReactNode;
-  selection?: Selection<T>;
-  mobileCard: (row: T) => ReactNode;
-  emptyMessage?: string;
-}) {
+}: TableProps<T>) {
   const { setParams } = useTableParams();
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -186,6 +201,14 @@ export function DataTable<T>({
 
       {rows.length === 0 ? (
         <p className="text-sm text-gray-500">{emptyMessage}</p>
+      ) : listItem ? (
+        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+          {rows.map((row) => (
+            <li key={rowKey(row)} className="py-3">
+              {listItem(row)}
+            </li>
+          ))}
+        </ul>
       ) : (
         <>
           {/* Desktop: a table. */}

--- a/app/admin/data-table.tsx
+++ b/app/admin/data-table.tsx
@@ -50,6 +50,62 @@ export function useTableParams() {
   return { searchParams, setParams };
 }
 
+/**
+ * Assign/remove/clear bar for a table selection. Rendered even while nothing
+ * is selected — hidden but keeping its space — so starting a selection doesn't
+ * shift the table under the user's pointer.
+ */
+export function BulkActionsBar({
+  selectedCount,
+  isPending,
+  onAssign,
+  onRemove,
+  onClear,
+}: {
+  selectedCount: number;
+  isPending: boolean;
+  onAssign: () => void;
+  onRemove: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className={`flex flex-wrap items-center gap-3 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm ${
+        selectedCount === 0 ? "invisible" : ""
+      }`}
+    >
+      <span className="font-medium text-gray-700">
+        {selectedCount} selected
+      </span>
+      <button
+        type="button"
+        onClick={onAssign}
+        disabled={isPending}
+        className="px-3 py-1 rounded-md border border-gray-900 bg-gray-900 text-white disabled:opacity-50 hover:bg-gray-700"
+      >
+        Assign selected
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={isPending}
+        className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-50 hover:bg-gray-50"
+      >
+        Remove selected
+      </button>
+      <button
+        type="button"
+        onClick={onClear}
+        className="px-3 py-1 rounded-md text-gray-600 hover:text-gray-900"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+
 export function DataTable<T>({
   rows,
   columns,

--- a/app/admin/events/[id]/event-guests-manager.tsx
+++ b/app/admin/events/[id]/event-guests-manager.tsx
@@ -7,6 +7,7 @@ import {
   removeGuestsFromEventAction,
 } from "@/app/actions/admin-guest-events";
 import {
+  BulkActionsBar,
   DataTable,
   useTableParams,
   type Column,
@@ -104,41 +105,15 @@ export function EventGuestsManager({
     rowLabel: (g) => g.name,
   };
 
-  const bulkBar =
-    selectedIds.size === 0 ? null : (
-      <div
-        role="region"
-        aria-label="Bulk actions"
-        className="flex flex-wrap items-center gap-3 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm"
-      >
-        <span className="font-medium text-gray-700">
-          {selectedIds.size} selected
-        </span>
-        <button
-          type="button"
-          onClick={() => handleBulk(true)}
-          disabled={isPending}
-          className="px-3 py-1 rounded-md border border-gray-900 bg-gray-900 text-white disabled:opacity-50 hover:bg-gray-700"
-        >
-          Assign selected
-        </button>
-        <button
-          type="button"
-          onClick={() => handleBulk(false)}
-          disabled={isPending}
-          className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-50 hover:bg-gray-50"
-        >
-          Remove selected
-        </button>
-        <button
-          type="button"
-          onClick={() => setSelectedIds(new Set())}
-          className="px-3 py-1 rounded-md text-gray-600 hover:text-gray-900"
-        >
-          Clear
-        </button>
-      </div>
-    );
+  const bulkBar = (
+    <BulkActionsBar
+      selectedCount={selectedIds.size}
+      isPending={isPending}
+      onAssign={() => handleBulk(true)}
+      onRemove={() => handleBulk(false)}
+      onClear={() => setSelectedIds(new Set())}
+    />
+  );
 
   const handleToggle = (guestId: string, currentlyAssigned: boolean) => {
     setPendingIds((prev) => new Set([...prev, guestId]));

--- a/app/admin/events/[id]/event-locations-manager.tsx
+++ b/app/admin/events/[id]/event-locations-manager.tsx
@@ -6,6 +6,13 @@ import {
   assignLocationsToEventAction,
   removeLocationsFromEventAction,
 } from "@/app/actions/admin-location-events";
+import {
+  BulkActionsBar,
+  DataTable,
+  useTableParams,
+  type Column,
+  type Selection,
+} from "../../data-table";
 
 export type LocationRow = {
   id: string;
@@ -14,27 +21,99 @@ export type LocationRow = {
   assigned: boolean;
 };
 
-type Filter = "all" | "assigned" | "not-assigned";
+export type LocationFilter = "all" | "assigned" | "not-assigned";
 
-const FILTER_LABEL: Record<Filter, string> = {
-  all: "All",
-  assigned: "Assigned",
-  "not-assigned": "Not assigned",
-};
+const FILTERS: { value: LocationFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "assigned", label: "Assigned" },
+  { value: "not-assigned", label: "Not assigned" },
+];
 
 export function EventLocationsManager({
   locations,
   eventId,
+  total,
+  page,
+  pageSize,
+  query,
+  filter,
 }: {
   locations: LocationRow[];
   eventId: string;
+  total: number;
+  page: number;
+  pageSize: number;
+  query: string;
+  filter: LocationFilter;
 }) {
   const router = useRouter();
-  const [filter, setFilter] = useState<Filter>("all");
+  const { setParams } = useTableParams();
   // Tracks which location IDs have a pending toggle so we can disable the box.
   const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  // Rows selected for bulk assign/remove (persists across pages until applied).
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
+
+  const toggleRow = (locationId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(locationId)) next.delete(locationId);
+      else next.add(locationId);
+      return next;
+    });
+  };
+
+  const toggleAllOnPage = (pageKeys: string[], shouldSelectAll: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const key of pageKeys) {
+        if (shouldSelectAll) next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
+  };
+
+  const handleBulk = (assign: boolean) => {
+    const locationIds = [...selectedIds];
+    if (locationIds.length === 0) return;
+    setError(null);
+
+    startTransition(async () => {
+      const action = assign
+        ? assignLocationsToEventAction
+        : removeLocationsFromEventAction;
+      try {
+        const result = await action({ eventId, locationIds });
+        if (!result.ok) {
+          setError(result.error);
+        } else {
+          setSelectedIds(new Set());
+          router.refresh();
+        }
+      } catch {
+        setError("Request failed");
+      }
+    });
+  };
+
+  const selection: Selection<LocationRow> = {
+    selectedKeys: selectedIds,
+    onToggleRow: toggleRow,
+    onToggleAllOnPage: toggleAllOnPage,
+    rowLabel: (l) => l.name,
+  };
+
+  const bulkBar = (
+    <BulkActionsBar
+      selectedCount={selectedIds.size}
+      isPending={isPending}
+      onAssign={() => handleBulk(true)}
+      onRemove={() => handleBulk(false)}
+      onClear={() => setSelectedIds(new Set())}
+    />
+  );
 
   const handleToggle = (locationId: string, currentlyAssigned: boolean) => {
     setPendingIds((prev) => new Set([...prev, locationId]));
@@ -63,64 +142,79 @@ export function EventLocationsManager({
     });
   };
 
-  const visible = locations.filter((l) => {
-    if (filter === "assigned") return l.assigned;
-    if (filter === "not-assigned") return !l.assigned;
-    return true;
-  });
+  const assignedCheckbox = (l: LocationRow) => (
+    <input
+      type="checkbox"
+      checked={l.assigned}
+      disabled={pendingIds.has(l.id)}
+      aria-label={`Assign ${l.name}`}
+      onChange={() => handleToggle(l.id, l.assigned)}
+      className="h-4 w-4 cursor-pointer"
+    />
+  );
+
+  const columns: Column<LocationRow>[] = [
+    { header: "Name", cell: (l) => l.name },
+    {
+      header: "Capacity",
+      cell: (l) => l.capacity,
+      cellClassName: "text-gray-500",
+    },
+    { header: "Assigned", cell: assignedCheckbox },
+  ];
+
+  const toolbar = (
+    <div className="flex gap-2">
+      {FILTERS.map((f) => (
+        <button
+          key={f.value}
+          type="button"
+          onClick={() =>
+            setParams({
+              filter: f.value === "all" ? null : f.value,
+              page: null,
+            })
+          }
+          className={`px-3 py-1 text-sm rounded-md border ${
+            filter === f.value
+              ? "bg-gray-900 text-white border-gray-900"
+              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+          }`}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  );
 
   return (
     <section aria-label="Locations" className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Locations</h2>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
-      <div className="flex gap-2">
-        {(["all", "assigned", "not-assigned"] as Filter[]).map((f) => (
-          <button
-            key={f}
-            onClick={() => setFilter(f)}
-            className={`px-3 py-1 text-sm rounded-md border ${
-              filter === f
-                ? "bg-gray-900 text-white border-gray-900"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-            }`}
-          >
-            {FILTER_LABEL[f]}
-          </button>
-        ))}
-      </div>
-
-      {locations.length === 0 ? (
-        <p className="text-sm text-gray-500">No locations yet.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-gray-200 text-left text-gray-600">
-              <th className="py-2 pr-4 font-medium">Name</th>
-              <th className="py-2 pr-4 font-medium">Capacity</th>
-              <th className="py-2 font-medium">Assigned</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visible.map((l) => (
-              <tr key={l.id} className="border-b border-gray-100">
-                <td className="py-2 pr-4">{l.name}</td>
-                <td className="py-2 pr-4 text-gray-500">{l.capacity}</td>
-                <td className="py-2">
-                  <input
-                    type="checkbox"
-                    checked={l.assigned}
-                    disabled={pendingIds.has(l.id)}
-                    aria-label={`Assign ${l.name}`}
-                    onChange={() => handleToggle(l.id, l.assigned)}
-                    className="h-4 w-4 cursor-pointer"
-                  />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <DataTable
+        rows={locations}
+        columns={columns}
+        rowKey={(l) => l.id}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        searchQuery={query}
+        searchPlaceholder="Search name…"
+        toolbar={toolbar}
+        bulkBar={bulkBar}
+        selection={selection}
+        emptyMessage="No locations match."
+        mobileCard={(l) => (
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="font-medium text-gray-900">{l.name}</p>
+              <p className="text-gray-500">Capacity: {l.capacity}</p>
+            </div>
+            {assignedCheckbox(l)}
+          </div>
+        )}
+      />
     </section>
   );
 }

--- a/app/admin/events/[id]/event-proposals-manager.tsx
+++ b/app/admin/events/[id]/event-proposals-manager.tsx
@@ -12,6 +12,7 @@ import {
   SECONDARY_BUTTON,
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
+import { DataTable } from "../../data-table";
 
 export type ProposalRow = {
   id: string;
@@ -131,7 +132,7 @@ function ProposalItem({
           } will be kept (unlinked from this proposal).`
         : "";
     return (
-      <li className="py-3 space-y-2">
+      <div className="space-y-2">
         <p className="font-medium text-gray-900">{proposal.title}</p>
         <p className="text-sm text-red-700">
           This will permanently delete the proposal, its {proposal.votesCount}{" "}
@@ -175,13 +176,13 @@ function ProposalItem({
             Cancel
           </button>
         </div>
-      </li>
+      </div>
     );
   }
 
   if (!editMode) {
     return (
-      <li className="py-3 flex items-start justify-between gap-3">
+      <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
           <p className="font-medium text-gray-900">{proposal.title}</p>
           <p className="text-sm text-gray-500">
@@ -208,113 +209,119 @@ function ProposalItem({
             Delete
           </button>
         </div>
-      </li>
+      </div>
     );
   }
 
   return (
-    <li className="py-3">
-      <form onSubmit={handleSave} className="space-y-3">
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`prop-title-${proposal.id}`}
-            className="text-sm text-gray-600"
-          >
-            Title *
-          </label>
-          <Input
-            id={`prop-title-${proposal.id}`}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            required
-            className="w-full h-10"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`prop-desc-${proposal.id}`}
-            className="text-sm text-gray-600"
-          >
-            Description
-          </label>
-          <textarea
-            id={`prop-desc-${proposal.id}`}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`prop-duration-${proposal.id}`}
-            className="text-sm text-gray-600"
-          >
-            Duration (minutes) — leave empty for undecided
-          </label>
-          <Input
-            id={`prop-duration-${proposal.id}`}
-            type="number"
-            min="0"
-            step="5"
-            value={duration}
-            onChange={(e) => setDuration(e.target.value)}
-            className="w-full h-10"
-          />
-        </div>
-        <fieldset className="flex flex-col gap-1">
-          <legend className="text-sm text-gray-600">Hosts</legend>
-          {candidates.length === 0 ? (
-            <p className="text-sm text-gray-500">
-              No guests assigned to this event yet.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-1">
-              {candidates.map((g) => (
-                <label
-                  key={g.id}
-                  className="flex items-center gap-2 text-sm text-gray-700"
-                >
-                  <input
-                    type="checkbox"
-                    checked={hostIds.includes(g.id)}
-                    onChange={() => toggleHost(g.id)}
-                    aria-label={`Host ${g.name}`}
-                    className="h-4 w-4 cursor-pointer"
-                  />
-                  {g.name}
-                </label>
-              ))}
-            </div>
-          )}
-        </fieldset>
-        <div className="flex gap-2">
-          <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
-            {isSaving ? "Saving..." : "Save"}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              reset();
-              setEditMode(false);
-              onError(null);
-            }}
-            disabled={isSaving}
-            className={SECONDARY_BUTTON}
-          >
-            Cancel
-          </button>
-        </div>
-      </form>
-    </li>
+    <form onSubmit={handleSave} className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`prop-title-${proposal.id}`}
+          className="text-sm text-gray-600"
+        >
+          Title *
+        </label>
+        <Input
+          id={`prop-title-${proposal.id}`}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="w-full h-10"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`prop-desc-${proposal.id}`}
+          className="text-sm text-gray-600"
+        >
+          Description
+        </label>
+        <textarea
+          id={`prop-desc-${proposal.id}`}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`prop-duration-${proposal.id}`}
+          className="text-sm text-gray-600"
+        >
+          Duration (minutes) — leave empty for undecided
+        </label>
+        <Input
+          id={`prop-duration-${proposal.id}`}
+          type="number"
+          min="0"
+          step="5"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+          className="w-full h-10"
+        />
+      </div>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Hosts</legend>
+        {candidates.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No guests assigned to this event yet.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {candidates.map((g) => (
+              <label
+                key={g.id}
+                className="flex items-center gap-2 text-sm text-gray-700"
+              >
+                <input
+                  type="checkbox"
+                  checked={hostIds.includes(g.id)}
+                  onChange={() => toggleHost(g.id)}
+                  aria-label={`Host ${g.name}`}
+                  className="h-4 w-4 cursor-pointer"
+                />
+                {g.name}
+              </label>
+            ))}
+          </div>
+        )}
+      </fieldset>
+      <div className="flex gap-2">
+        <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
+          {isSaving ? "Saving..." : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setEditMode(false);
+            onError(null);
+          }}
+          disabled={isSaving}
+          className={SECONDARY_BUTTON}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }
 
 export function EventProposalsManager({
   proposals,
   eventGuests,
+  total,
+  page,
+  pageSize,
+  query,
 }: {
   proposals: ProposalRow[];
   eventGuests: EventGuest[];
+  total: number;
+  page: number;
+  pageSize: number;
+  query: string;
 }) {
   const [error, setError] = useState<string | null>(null);
 
@@ -323,20 +330,23 @@ export function EventProposalsManager({
       <h2 className="text-lg font-semibold text-gray-900">Proposals</h2>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
-      {proposals.length === 0 ? (
-        <p className="text-sm text-gray-500">No proposals yet.</p>
-      ) : (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
-          {proposals.map((p) => (
-            <ProposalItem
-              key={p.id}
-              proposal={p}
-              eventGuests={eventGuests}
-              onError={setError}
-            />
-          ))}
-        </ul>
-      )}
+      <DataTable
+        rows={proposals}
+        rowKey={(p) => p.id}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        searchQuery={query}
+        searchPlaceholder="Search title or host…"
+        emptyMessage="No proposals match."
+        listItem={(p) => (
+          <ProposalItem
+            proposal={p}
+            eventGuests={eventGuests}
+            onError={setError}
+          />
+        )}
+      />
     </section>
   );
 }

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -13,6 +13,7 @@ import {
   SECONDARY_BUTTON,
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
+import { DataTable } from "../../data-table";
 
 export type SessionRow = {
   id: string;
@@ -251,7 +252,7 @@ function SessionItem({
 
   if (deleteMode) {
     return (
-      <li className="py-3 space-y-2">
+      <div className="space-y-2">
         <p className="font-medium text-gray-900">{session.title}</p>
         <p className="text-sm text-red-700">
           This will permanently delete the session and its {session.numRsvps}{" "}
@@ -293,13 +294,13 @@ function SessionItem({
             Cancel
           </button>
         </div>
-      </li>
+      </div>
     );
   }
 
   if (!editMode) {
     return (
-      <li className="py-3 space-y-3">
+      <div className="space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
             <p className="font-medium text-gray-900">{session.title}</p>
@@ -331,187 +332,185 @@ function SessionItem({
           </div>
         </div>
         <SessionRsvps session={session} onError={onError} />
-      </li>
+      </div>
     );
   }
 
   return (
-    <li className="py-3">
-      <form onSubmit={handleSave} className="space-y-3">
+    <form onSubmit={handleSave} className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`sess-title-${session.id}`}
+          className="text-sm text-gray-600"
+        >
+          Title *
+        </label>
+        <Input
+          id={`sess-title-${session.id}`}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="w-full h-10"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`sess-desc-${session.id}`}
+          className="text-sm text-gray-600"
+        >
+          Description
+        </label>
+        <textarea
+          id={`sess-desc-${session.id}`}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1">
           <label
-            htmlFor={`sess-title-${session.id}`}
+            htmlFor={`sess-start-${session.id}`}
             className="text-sm text-gray-600"
           >
-            Title *
+            Start (UTC) — leave empty if not scheduled
           </label>
           <Input
-            id={`sess-title-${session.id}`}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            required
+            id={`sess-start-${session.id}`}
+            type="datetime-local"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
             className="w-full h-10"
           />
         </div>
         <div className="flex flex-col gap-1">
           <label
-            htmlFor={`sess-desc-${session.id}`}
+            htmlFor={`sess-end-${session.id}`}
             className="text-sm text-gray-600"
           >
-            Description
-          </label>
-          <textarea
-            id={`sess-desc-${session.id}`}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
-          />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor={`sess-start-${session.id}`}
-              className="text-sm text-gray-600"
-            >
-              Start (UTC) — leave empty if not scheduled
-            </label>
-            <Input
-              id={`sess-start-${session.id}`}
-              type="datetime-local"
-              value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              className="w-full h-10"
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor={`sess-end-${session.id}`}
-              className="text-sm text-gray-600"
-            >
-              End (UTC)
-            </label>
-            <Input
-              id={`sess-end-${session.id}`}
-              type="datetime-local"
-              value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
-              className="w-full h-10"
-            />
-          </div>
-        </div>
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`sess-capacity-${session.id}`}
-            className="text-sm text-gray-600"
-          >
-            Capacity
+            End (UTC)
           </label>
           <Input
-            id={`sess-capacity-${session.id}`}
-            type="number"
-            min="0"
-            value={capacity}
-            onChange={(e) => setCapacity(e.target.value)}
+            id={`sess-end-${session.id}`}
+            type="datetime-local"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
             className="w-full h-10"
           />
         </div>
-        <fieldset className="flex flex-col gap-1">
-          <legend className="text-sm text-gray-600">Flags</legend>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              checked={blocker}
-              onChange={(e) => setBlocker(e.target.checked)}
-              className="h-4 w-4 cursor-pointer"
-            />
-            Blocker
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              checked={closed}
-              onChange={(e) => setClosed(e.target.checked)}
-              className="h-4 w-4 cursor-pointer"
-            />
-            Closed
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              checked={attendeeScheduled}
-              onChange={(e) => setAttendeeScheduled(e.target.checked)}
-              className="h-4 w-4 cursor-pointer"
-            />
-            Attendee-scheduled
-          </label>
-        </fieldset>
-        <fieldset className="flex flex-col gap-1">
-          <legend className="text-sm text-gray-600">Hosts</legend>
-          {hostCandidates.length === 0 ? (
-            <p className="text-sm text-gray-500">
-              No guests assigned to this event yet.
-            </p>
-          ) : (
-            hostCandidates.map((g) => (
-              <label
-                key={g.id}
-                className="flex items-center gap-2 text-sm text-gray-700"
-              >
-                <input
-                  type="checkbox"
-                  checked={hostIds.includes(g.id)}
-                  onChange={() => toggle(setHostIds, g.id)}
-                  aria-label={`Host ${g.name}`}
-                  className="h-4 w-4 cursor-pointer"
-                />
-                {g.name}
-              </label>
-            ))
-          )}
-        </fieldset>
-        <fieldset className="flex flex-col gap-1">
-          <legend className="text-sm text-gray-600">Locations</legend>
-          {locationCandidates.length === 0 ? (
-            <p className="text-sm text-gray-500">
-              No locations assigned to this event yet.
-            </p>
-          ) : (
-            locationCandidates.map((l) => (
-              <label
-                key={l.id}
-                className="flex items-center gap-2 text-sm text-gray-700"
-              >
-                <input
-                  type="checkbox"
-                  checked={locationIds.includes(l.id)}
-                  onChange={() => toggle(setLocationIds, l.id)}
-                  aria-label={`Location ${l.name}`}
-                  className="h-4 w-4 cursor-pointer"
-                />
-                {l.name}
-              </label>
-            ))
-          )}
-        </fieldset>
-        <div className="flex gap-2">
-          <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
-            {isSaving ? "Saving..." : "Save"}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              reset();
-              setEditMode(false);
-              onError(null);
-            }}
-            disabled={isSaving}
-            className={SECONDARY_BUTTON}
-          >
-            Cancel
-          </button>
-        </div>
-      </form>
-    </li>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`sess-capacity-${session.id}`}
+          className="text-sm text-gray-600"
+        >
+          Capacity
+        </label>
+        <Input
+          id={`sess-capacity-${session.id}`}
+          type="number"
+          min="0"
+          value={capacity}
+          onChange={(e) => setCapacity(e.target.value)}
+          className="w-full h-10"
+        />
+      </div>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Flags</legend>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={blocker}
+            onChange={(e) => setBlocker(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Blocker
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={closed}
+            onChange={(e) => setClosed(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Closed
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={attendeeScheduled}
+            onChange={(e) => setAttendeeScheduled(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Attendee-scheduled
+        </label>
+      </fieldset>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Hosts</legend>
+        {hostCandidates.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No guests assigned to this event yet.
+          </p>
+        ) : (
+          hostCandidates.map((g) => (
+            <label
+              key={g.id}
+              className="flex items-center gap-2 text-sm text-gray-700"
+            >
+              <input
+                type="checkbox"
+                checked={hostIds.includes(g.id)}
+                onChange={() => toggle(setHostIds, g.id)}
+                aria-label={`Host ${g.name}`}
+                className="h-4 w-4 cursor-pointer"
+              />
+              {g.name}
+            </label>
+          ))
+        )}
+      </fieldset>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Locations</legend>
+        {locationCandidates.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No locations assigned to this event yet.
+          </p>
+        ) : (
+          locationCandidates.map((l) => (
+            <label
+              key={l.id}
+              className="flex items-center gap-2 text-sm text-gray-700"
+            >
+              <input
+                type="checkbox"
+                checked={locationIds.includes(l.id)}
+                onChange={() => toggle(setLocationIds, l.id)}
+                aria-label={`Location ${l.name}`}
+                className="h-4 w-4 cursor-pointer"
+              />
+              {l.name}
+            </label>
+          ))
+        )}
+      </fieldset>
+      <div className="flex gap-2">
+        <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
+          {isSaving ? "Saving..." : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            reset();
+            setEditMode(false);
+            onError(null);
+          }}
+          disabled={isSaving}
+          className={SECONDARY_BUTTON}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }
 
@@ -519,10 +518,18 @@ export function EventSessionsManager({
   sessions,
   eventGuests,
   eventLocations,
+  total,
+  page,
+  pageSize,
+  query,
 }: {
   sessions: SessionRow[];
   eventGuests: EventGuest[];
   eventLocations: EventLocation[];
+  total: number;
+  page: number;
+  pageSize: number;
+  query: string;
 }) {
   const [error, setError] = useState<string | null>(null);
 
@@ -532,21 +539,24 @@ export function EventSessionsManager({
       <p className="text-sm text-gray-500">All times are UTC.</p>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
-      {sessions.length === 0 ? (
-        <p className="text-sm text-gray-500">No sessions yet.</p>
-      ) : (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
-          {sessions.map((s) => (
-            <SessionItem
-              key={s.id}
-              session={s}
-              eventGuests={eventGuests}
-              eventLocations={eventLocations}
-              onError={setError}
-            />
-          ))}
-        </ul>
-      )}
+      <DataTable
+        rows={sessions}
+        rowKey={(s) => s.id}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        searchQuery={query}
+        searchPlaceholder="Search title or host…"
+        emptyMessage="No sessions match."
+        listItem={(s) => (
+          <SessionItem
+            session={s}
+            eventGuests={eventGuests}
+            eventLocations={eventLocations}
+            onError={setError}
+          />
+        )}
+      />
     </section>
   );
 }

--- a/app/admin/events/[id]/event-tabs.tsx
+++ b/app/admin/events/[id]/event-tabs.tsx
@@ -10,6 +10,7 @@ export function EventTabs({ eventId }: { eventId: string }) {
   const tabs: { href: string; label: string }[] = [
     { href: base, label: "Config" },
     { href: `${base}/guests`, label: "Guests" },
+    { href: `${base}/locations`, label: "Locations" },
     { href: `${base}/proposals`, label: "Proposals" },
     { href: `${base}/sessions`, label: "Sessions" },
   ];

--- a/app/admin/events/[id]/locations/page.tsx
+++ b/app/admin/events/[id]/locations/page.tsx
@@ -1,0 +1,81 @@
+import { notFound, redirect } from "next/navigation";
+import { getRepositories } from "@/db/container";
+import { outOfRangePageRedirect } from "@/utils/pagination";
+import { requireAdminPage } from "../../../require-admin";
+import {
+  EventLocationsManager,
+  type LocationFilter,
+  type LocationRow,
+} from "../event-locations-manager";
+
+const PAGE_SIZE = 25;
+
+function parseFilter(value: string | undefined): LocationFilter {
+  return value === "assigned" || value === "not-assigned" ? value : "all";
+}
+
+function parsePage(value: string | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
+
+export default async function AdminEventLocationsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ q?: string; page?: string; filter?: string }>;
+}) {
+  await requireAdminPage();
+
+  const { id } = await params;
+  const { q, page: pageParam, filter: filterParam } = await searchParams;
+  const repos = getRepositories();
+  const event = await repos.events.findById(id);
+  if (!event) notFound();
+
+  const filter = parseFilter(filterParam);
+  const page = parsePage(pageParam);
+  const query = q?.trim() ?? "";
+  const assigned =
+    filter === "assigned"
+      ? true
+      : filter === "not-assigned"
+        ? false
+        : undefined;
+
+  const { rows, total } = await repos.locations.searchForEventAssignment(id, {
+    query: query || undefined,
+    assigned,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+
+  const redirectTarget = outOfRangePageRedirect({
+    basePath: `/admin/events/${id}/locations`,
+    page,
+    total,
+    pageSize: PAGE_SIZE,
+    params: { q: query, filter: filter === "all" ? "" : filter },
+  });
+  if (redirectTarget) redirect(redirectTarget);
+
+  const locationRows: LocationRow[] = rows.map((l) => ({
+    id: l.id,
+    name: l.name,
+    capacity: l.capacity,
+    assigned: l.assigned,
+  }));
+
+  return (
+    <EventLocationsManager
+      locations={locationRows}
+      eventId={id}
+      total={total}
+      page={page}
+      pageSize={PAGE_SIZE}
+      query={query}
+      filter={filter}
+    />
+  );
+}

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -5,10 +5,6 @@ import { requireAdminPage } from "../../require-admin";
 import { EventDetailForm } from "./event-detail-form";
 import { EventPhasesForm } from "./event-phases-form";
 import { EventDaysManager, type SerializedDay } from "./event-days-manager";
-import {
-  EventLocationsManager,
-  type LocationRow,
-} from "./event-locations-manager";
 
 export default async function AdminEventConfigPage({
   params,
@@ -21,17 +17,6 @@ export default async function AdminEventConfigPage({
   const repos = getRepositories();
   const event = await repos.events.findById(id);
   if (!event) notFound();
-
-  const allLocations = await repos.locations.list();
-  const assignedLocationIds = new Set(
-    await repos.locations.listLocationIdsByEvent(id)
-  );
-  const locationRows: LocationRow[] = allLocations.map((l) => ({
-    id: l.id,
-    name: l.name,
-    capacity: l.capacity,
-    assigned: assignedLocationIds.has(l.id),
-  }));
 
   const scheduledSessions = await repos.sessions.listScheduledByEvent(id);
   const days: SerializedDay[] = (await repos.days.listByEvent(id)).map((d) => ({
@@ -58,8 +43,6 @@ export default async function AdminEventConfigPage({
       </div>
       <hr className="border-gray-200" />
       <EventDaysManager days={days} eventId={id} />
-      <hr className="border-gray-200" />
-      <EventLocationsManager locations={locationRows} eventId={id} />
     </div>
   );
 }

--- a/app/admin/events/[id]/proposals/page.tsx
+++ b/app/admin/events/[id]/proposals/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getRepositories } from "@/db/container";
+import { outOfRangePageRedirect } from "@/utils/pagination";
 import { requireAdminPage } from "../../../require-admin";
 import {
   EventProposalsManager,
@@ -7,25 +8,51 @@ import {
   type EventGuest,
 } from "../event-proposals-manager";
 
+const PAGE_SIZE = 25;
+
+function parsePage(value: string | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
+
 export default async function AdminEventProposalsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ q?: string; page?: string }>;
 }) {
   await requireAdminPage();
 
   const { id } = await params;
+  const { q, page: pageParam } = await searchParams;
   const repos = getRepositories();
   const event = await repos.events.findById(id);
   if (!event) notFound();
+
+  const page = parsePage(pageParam);
+  const query = q?.trim() ?? "";
 
   const eventGuests: EventGuest[] = (await repos.guests.listByEvent(id)).map(
     (g) => ({ id: g.id, name: g.name })
   );
 
-  const proposalRows: ProposalRow[] = (
-    await repos.sessionProposals.listByEvent(id)
-  ).map((p) => ({
+  const { rows, total } = await repos.sessionProposals.searchByEvent(id, {
+    query: query || undefined,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+
+  const redirectTarget = outOfRangePageRedirect({
+    basePath: `/admin/events/${id}/proposals`,
+    page,
+    total,
+    pageSize: PAGE_SIZE,
+    params: { q: query },
+  });
+  if (redirectTarget) redirect(redirectTarget);
+
+  const proposalRows: ProposalRow[] = rows.map((p) => ({
     id: p.id,
     title: p.title,
     description: p.description ?? "",
@@ -36,6 +63,13 @@ export default async function AdminEventProposalsPage({
   }));
 
   return (
-    <EventProposalsManager proposals={proposalRows} eventGuests={eventGuests} />
+    <EventProposalsManager
+      proposals={proposalRows}
+      eventGuests={eventGuests}
+      total={total}
+      page={page}
+      pageSize={PAGE_SIZE}
+      query={query}
+    />
   );
 }

--- a/app/admin/events/[id]/sessions/page.tsx
+++ b/app/admin/events/[id]/sessions/page.tsx
@@ -65,26 +65,27 @@ export default async function AdminEventSessionsPage({
   });
   if (redirectTarget) redirect(redirectTarget);
 
-  const sessionRows: SessionRow[] = await Promise.all(
-    rows.map(async (s) => ({
-      id: s.id,
-      title: s.title,
-      description: s.description,
-      startTime: s.startTime ? s.startTime.toISOString() : null,
-      endTime: s.endTime ? s.endTime.toISOString() : null,
-      capacity: s.capacity,
-      attendeeScheduled: s.attendeeScheduled,
-      blocker: s.blocker,
-      closed: s.closed,
-      hosts: s.hosts.map((h) => ({ id: h.id, name: h.name })),
-      locations: s.locations.map((l) => ({ id: l.id, name: l.name })),
-      numRsvps: s.numRsvps,
-      rsvps: (await repos.rsvps.listBySession(s.id)).map((r) => ({
-        guestId: r.guestId,
-        name: guestNameById.get(r.guestId) ?? "Unknown guest",
-      })),
-    }))
+  const rsvpsBySession = await repos.rsvps.listBySessions(
+    rows.map((s) => s.id)
   );
+  const sessionRows: SessionRow[] = rows.map((s) => ({
+    id: s.id,
+    title: s.title,
+    description: s.description,
+    startTime: s.startTime ? s.startTime.toISOString() : null,
+    endTime: s.endTime ? s.endTime.toISOString() : null,
+    capacity: s.capacity,
+    attendeeScheduled: s.attendeeScheduled,
+    blocker: s.blocker,
+    closed: s.closed,
+    hosts: s.hosts.map((h) => ({ id: h.id, name: h.name })),
+    locations: s.locations.map((l) => ({ id: l.id, name: l.name })),
+    numRsvps: s.numRsvps,
+    rsvps: (rsvpsBySession.get(s.id) ?? []).map((r) => ({
+      guestId: r.guestId,
+      name: guestNameById.get(r.guestId) ?? "Unknown guest",
+    })),
+  }));
 
   return (
     <EventSessionsManager

--- a/app/admin/events/[id]/sessions/page.tsx
+++ b/app/admin/events/[id]/sessions/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getRepositories } from "@/db/container";
+import { outOfRangePageRedirect } from "@/utils/pagination";
 import { requireAdminPage } from "../../../require-admin";
 import {
   EventSessionsManager,
@@ -8,17 +9,30 @@ import {
   type EventLocation,
 } from "../event-sessions-manager";
 
+const PAGE_SIZE = 25;
+
+function parsePage(value: string | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
+
 export default async function AdminEventSessionsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ q?: string; page?: string }>;
 }) {
   await requireAdminPage();
 
   const { id } = await params;
+  const { q, page: pageParam } = await searchParams;
   const repos = getRepositories();
   const event = await repos.events.findById(id);
   if (!event) notFound();
+
+  const page = parsePage(pageParam);
+  const query = q?.trim() ?? "";
 
   const eventGuests: EventGuest[] = (await repos.guests.listByEvent(id)).map(
     (g) => ({ id: g.id, name: g.name })
@@ -36,8 +50,23 @@ export default async function AdminEventSessionsPage({
     .filter((l) => assignedLocationIds.has(l.id))
     .map((l) => ({ id: l.id, name: l.name }));
 
+  const { rows, total } = await repos.sessions.searchByEvent(id, {
+    query: query || undefined,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+
+  const redirectTarget = outOfRangePageRedirect({
+    basePath: `/admin/events/${id}/sessions`,
+    page,
+    total,
+    pageSize: PAGE_SIZE,
+    params: { q: query },
+  });
+  if (redirectTarget) redirect(redirectTarget);
+
   const sessionRows: SessionRow[] = await Promise.all(
-    (await repos.sessions.listByEvent(id)).map(async (s) => ({
+    rows.map(async (s) => ({
       id: s.id,
       title: s.title,
       description: s.description,
@@ -62,6 +91,10 @@ export default async function AdminEventSessionsPage({
       sessions={sessionRows}
       eventGuests={eventGuests}
       eventLocations={eventLocations}
+      total={total}
+      page={page}
+      pageSize={PAGE_SIZE}
+      query={query}
     />
   );
 }

--- a/app/admin/guests-manager.tsx
+++ b/app/admin/guests-manager.tsx
@@ -11,6 +11,7 @@ import {
   sendTestEmailAction,
 } from "../actions/admin-guests";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON, DANGER_BUTTON } from "./buttons";
+import { DataTable } from "./data-table";
 
 function AddGuestForm({
   onError,
@@ -128,53 +129,47 @@ function GuestRow({
 
   if (mode === "edit") {
     return (
-      <li className="py-3">
-        <form
-          onSubmit={handleSave}
-          className="flex flex-col sm:flex-row gap-2 sm:items-center"
-        >
-          <Input
-            aria-label="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            className="flex-1 h-10"
-          />
-          <Input
-            aria-label="Email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="flex-1 h-10"
-          />
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              disabled={isPending}
-              className={PRIMARY_BUTTON}
-            >
-              {isPending ? "Saving..." : "Save"}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                onError(null);
-                setMode("view");
-              }}
-              disabled={isPending}
-              className={SECONDARY_BUTTON}
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      </li>
+      <form
+        onSubmit={handleSave}
+        className="flex flex-col sm:flex-row gap-2 sm:items-center"
+      >
+        <Input
+          aria-label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="flex-1 h-10"
+        />
+        <Input
+          aria-label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="flex-1 h-10"
+        />
+        <div className="flex gap-2">
+          <button type="submit" disabled={isPending} className={PRIMARY_BUTTON}>
+            {isPending ? "Saving..." : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onError(null);
+              setMode("view");
+            }}
+            disabled={isPending}
+            className={SECONDARY_BUTTON}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
     );
   }
 
   return (
-    <li className="py-3 flex flex-col sm:flex-row gap-2 sm:items-center">
+    <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
       <div className="flex-1 min-w-0">
         <p className="font-medium text-gray-900 truncate">{guest.name}</p>
         <p className="text-sm text-gray-500 truncate">{guest.info.email}</p>
@@ -227,11 +222,23 @@ function GuestRow({
           </button>
         </div>
       )}
-    </li>
+    </div>
   );
 }
 
-export function GuestsManager({ guests }: { guests: CompleteGuest[] }) {
+export function GuestsManager({
+  guests,
+  total,
+  page,
+  pageSize,
+  query,
+}: {
+  guests: CompleteGuest[];
+  total: number;
+  page: number;
+  pageSize: number;
+  query: string;
+}) {
   const [error, setError] = useState<string | null>(null);
 
   return (
@@ -244,15 +251,17 @@ export function GuestsManager({ guests }: { guests: CompleteGuest[] }) {
 
       <AddGuestForm onError={setError} />
 
-      {guests.length === 0 ? (
-        <p className="text-sm text-gray-500">No users yet.</p>
-      ) : (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
-          {guests.map((guest) => (
-            <GuestRow key={guest.id} guest={guest} onError={setError} />
-          ))}
-        </ul>
-      )}
+      <DataTable
+        rows={guests}
+        rowKey={(g) => g.id}
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        searchQuery={query}
+        searchPlaceholder="Search name or email…"
+        emptyMessage="No users match."
+        listItem={(guest) => <GuestRow guest={guest} onError={setError} />}
+      />
     </div>
   );
 }

--- a/app/admin/locations/page.tsx
+++ b/app/admin/locations/page.tsx
@@ -7,15 +7,17 @@ export default async function AdminLocationsPage() {
 
   const repositories = getRepositories();
   const events = await repositories.events.list();
-  const locations: AdminLocation[] = await Promise.all(
-    (await repositories.locations.list()).map(async (location) => ({
-      location,
-      eventIds: await repositories.locations.listEventIds(location.id),
-      sessionLinkCount: await repositories.locations.countSessionLinks(
-        location.id
-      ),
-    }))
-  );
+  const allLocations = await repositories.locations.list();
+  const locationIds = allLocations.map((l) => l.id);
+  const eventIdsByLocation =
+    await repositories.locations.listEventIdsByLocations(locationIds);
+  const sessionLinkCounts =
+    await repositories.locations.countSessionLinksByLocations(locationIds);
+  const locations: AdminLocation[] = allLocations.map((location) => ({
+    location,
+    eventIds: eventIdsByLocation.get(location.id) ?? [],
+    sessionLinkCount: sessionLinkCounts.get(location.id) ?? 0,
+  }));
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,18 +1,54 @@
+import { redirect } from "next/navigation";
 import { getRepositories } from "@/db/container";
+import { outOfRangePageRedirect } from "@/utils/pagination";
 import { requireAdminPage } from "../require-admin";
 import { GuestsManager } from "../guests-manager";
 
-export default async function AdminUsersPage() {
+const PAGE_SIZE = 25;
+
+function parsePage(value: string | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 1 ? n : 1;
+}
+
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; page?: string }>;
+}) {
   await requireAdminPage();
 
+  const { q, page: pageParam } = await searchParams;
+  const page = parsePage(pageParam);
+  const query = q?.trim() ?? "";
+
   const repositories = getRepositories();
-  const guests = await repositories.guests.listFull();
+  const { rows, total } = await repositories.guests.search({
+    query: query || undefined,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+
+  const redirectTarget = outOfRangePageRedirect({
+    basePath: "/admin/users",
+    page,
+    total,
+    pageSize: PAGE_SIZE,
+    params: { q: query },
+  });
+  if (redirectTarget) redirect(redirectTarget);
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
       <h1 className="text-2xl font-bold text-gray-900">Users</h1>
       <section aria-label="Users" className="space-y-4">
-        <GuestsManager guests={guests} />
+        <GuestsManager
+          guests={rows}
+          total={total}
+          page={page}
+          pageSize={PAGE_SIZE}
+          query={query}
+        />
       </section>
     </div>
   );

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -329,9 +329,24 @@ export type SessionProposalUpdateInput = {
   durationMinutes?: number | null;
 };
 
+/** A page of proposals plus the total count of rows matching the same filter. */
+export type SessionProposalPage = {
+  rows: SessionProposal[];
+  total: number;
+};
+
 export interface SessionProposalsRepository {
   listByEvent(eventId: string): Promise<SessionProposal[]>;
   listByHost(guestId: string): Promise<SessionProposal[]>;
+  /**
+   * Server-side paginated + searchable proposal list for an event. `query`
+   * matches the title or a host name (case-insensitive substring). Ordered by
+   * title.
+   */
+  searchByEvent(
+    eventId: string,
+    opts: { query?: string; limit: number; offset: number }
+  ): Promise<SessionProposalPage>;
   findById(id: string): Promise<SessionProposal | undefined>;
   create(data: SessionProposalCreateInput): Promise<SessionProposal>;
   update(

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -106,11 +106,27 @@ export type EventGuestPage = {
   total: number;
 };
 
+/** A page of complete guests plus the total count matching the same filter. */
+export type GuestPage = {
+  rows: CompleteGuest[];
+  total: number;
+};
+
 export interface GuestsRepository {
   list(): Promise<Guest[]>;
   /** Every user with their private info (email). For admin export/lookup. */
   listFull(): Promise<CompleteGuest[]>;
   listByEvent(eventId: string): Promise<Guest[]>;
+  /**
+   * Server-side paginated + searchable global user list. `query` matches name
+   * or email (case-insensitive substring, LIKE metacharacters matched
+   * literally). Ordered by name with id tiebreaker.
+   */
+  search(opts: {
+    query?: string;
+    limit: number;
+    offset: number;
+  }): Promise<GuestPage>;
   /**
    * Server-side paginated + searchable guest list scoped to an event's
    * assignment. `assigned` filters by membership (undefined = all); `query`

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -200,8 +200,18 @@ export interface LocationsRepository {
   delete(id: string): Promise<void>;
   /** Number of sessions linked to this location. */
   countSessionLinks(id: string): Promise<number>;
+  /**
+   * Session-link counts for many locations in one query. Every requested id
+   * is present in the result; locations without links map to 0.
+   */
+  countSessionLinksByLocations(ids: string[]): Promise<Map<string, number>>;
   /** IDs of events this location is assigned to. */
   listEventIds(id: string): Promise<string[]>;
+  /**
+   * Event IDs for many locations in one query. Every requested id is present
+   * in the result; locations without assignments map to [].
+   */
+  listEventIdsByLocations(ids: string[]): Promise<Map<string, string[]>>;
   /** IDs of locations assigned to the given event. */
   listLocationIdsByEvent(eventId: string): Promise<string[]>;
   /** Replaces the location's event assignments. */
@@ -303,6 +313,11 @@ export type Rsvp = {
 export interface RsvpsRepository {
   listByGuest(guestId: string): Promise<Rsvp[]>;
   listBySession(sessionId: string): Promise<Rsvp[]>;
+  /**
+   * RSVPs for many sessions in one query. Every requested id is present in
+   * the result; sessions without RSVPs map to [].
+   */
+  listBySessions(sessionIds: string[]): Promise<Map<string, Rsvp[]>>;
   create(data: { sessionId: string; guestId: string }): Promise<Rsvp>;
   deleteBySessionAndGuest(sessionId: string, guestId: string): Promise<void>;
   deleteBySessionAndGuests(

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -264,6 +264,12 @@ export type SessionUpdateInput = Partial<
   locationIds?: string[];
 };
 
+/** A page of sessions plus the total count of rows matching the same filter. */
+export type SessionPage = {
+  rows: Session[];
+  total: number;
+};
+
 export interface SessionsRepository {
   list(): Promise<Session[]>;
   listScheduled(): Promise<Session[]>;
@@ -271,6 +277,15 @@ export interface SessionsRepository {
   listScheduledByEvent(eventId: string): Promise<Session[]>;
   listHostedByGuest(guestId: string): Promise<Session[]>;
   listRsvpdByGuest(guestId: string): Promise<Session[]>;
+  /**
+   * Server-side paginated + searchable session list for an event. `query`
+   * matches the title or a host name (case-insensitive substring). Ordered by
+   * title.
+   */
+  searchByEvent(
+    eventId: string,
+    opts: { query?: string; limit: number; offset: number }
+  ): Promise<SessionPage>;
   findById(id: string): Promise<Session | undefined>;
   create(data: SessionCreateInput): Promise<Session>;
   update(id: string, patch: SessionUpdateInput): Promise<Session>;

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -160,9 +160,37 @@ export type Location = {
   areaDescription?: string;
 };
 
+/** A location paired with whether it is assigned to a given event. */
+export type EventLocationRow = {
+  id: string;
+  name: string;
+  capacity: number;
+  assigned: boolean;
+};
+
+/** A page of locations plus the total count of rows matching the same filter. */
+export type EventLocationPage = {
+  rows: EventLocationRow[];
+  total: number;
+};
+
 export interface LocationsRepository {
   /** All locations (including hidden), ordered by sortIndex. */
   list(): Promise<Location[]>;
+  /**
+   * Server-side paginated + searchable location list scoped to an event's
+   * assignment. `assigned` filters by membership (undefined = all); `query`
+   * matches the name (case-insensitive substring). Ordered by name.
+   */
+  searchForEventAssignment(
+    eventId: string,
+    opts: {
+      query?: string;
+      assigned?: boolean;
+      limit: number;
+      offset: number;
+    }
+  ): Promise<EventLocationPage>;
   listVisible(): Promise<Location[]>;
   listBookable(): Promise<Location[]>;
   findById(id: string): Promise<Location | undefined>;

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -6,6 +6,7 @@ import type {
   CompleteGuest,
   EventGuestPage,
   Guest,
+  GuestPage,
   GuestsRepository,
 } from "../interfaces";
 import { sanitizeGuest } from "@/utils/guests";
@@ -56,6 +57,41 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .all()
       .map((row) => row as Guest);
     return rows;
+  }
+
+  async search(opts: {
+    query?: string;
+    limit: number;
+    offset: number;
+  }): Promise<GuestPage> {
+    let where = undefined;
+    if (opts.query) {
+      const pattern = `%${escapeLike(opts.query)}%`;
+      where = or(
+        sql`${schema.guests.name} like ${pattern} escape '\\'`,
+        sql`${schema.guests.email} like ${pattern} escape '\\'`
+      );
+    }
+
+    const totalRow = this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.guests)
+      .where(where)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.guests)
+      .where(where)
+      // id as tiebreaker: name is not unique, and without a deterministic
+      // order LIMIT/OFFSET pagination can duplicate or skip rows.
+      .orderBy(schema.guests.name, schema.guests.id)
+      .limit(opts.limit)
+      .offset(opts.offset)
+      .all()
+      .map(rowToGuest);
+
+    return { rows, total: totalRow?.count ?? 0 };
   }
 
   async searchForEventAssignment(

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -1,10 +1,20 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
-import type { Location, LocationsRepository } from "../interfaces";
+import type {
+  EventLocationPage,
+  Location,
+  LocationsRepository,
+} from "../interfaces";
 
 type DB = BetterSQLite3Database<typeof schema>;
+
+// Escape LIKE meta-characters so user input is matched literally. Pairs with an
+// explicit `ESCAPE '\'` clause in the query below.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 function rowToLocation(row: typeof schema.locations.$inferSelect): Location {
   return {
@@ -31,6 +41,68 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .orderBy(schema.locations.sortIndex, schema.locations.id)
       .all()
       .map(rowToLocation);
+  }
+
+  async searchForEventAssignment(
+    eventId: string,
+    opts: {
+      query?: string;
+      assigned?: boolean;
+      limit: number;
+      offset: number;
+    }
+  ): Promise<EventLocationPage> {
+    // A location is "assigned" when the event-scoped left join matches a row.
+    const joinCondition = and(
+      eq(schema.locations.id, schema.eventLocations.locationId),
+      eq(schema.eventLocations.eventId, eventId)
+    );
+
+    const conditions = [];
+    if (opts.assigned === true) {
+      conditions.push(isNotNull(schema.eventLocations.locationId));
+    } else if (opts.assigned === false) {
+      conditions.push(isNull(schema.eventLocations.locationId));
+    }
+    if (opts.query) {
+      const pattern = `%${escapeLike(opts.query)}%`;
+      conditions.push(
+        sql`${schema.locations.name} like ${pattern} escape '\\'`
+      );
+    }
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const totalRow = this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.locations)
+      .leftJoin(schema.eventLocations, joinCondition)
+      .where(where)
+      .get();
+
+    const rows = this.db
+      .select({
+        id: schema.locations.id,
+        name: schema.locations.name,
+        capacity: schema.locations.capacity,
+        assigned: sql<number>`(${schema.eventLocations.locationId} is not null)`,
+      })
+      .from(schema.locations)
+      .leftJoin(schema.eventLocations, joinCondition)
+      .where(where)
+      // id as tiebreaker: name is not unique, and without a deterministic
+      // order LIMIT/OFFSET pagination can duplicate or skip rows.
+      .orderBy(schema.locations.name, schema.locations.id)
+      .limit(opts.limit)
+      .offset(opts.offset)
+      .all()
+      .map((r) => ({
+        id: r.id,
+        name: r.name,
+        capacity: r.capacity,
+        assigned: Boolean(r.assigned),
+      }));
+
+    return { rows, total: totalRow?.count ?? 0 };
   }
 
   async listVisible(): Promise<Location[]> {

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -186,6 +186,24 @@ export class SqliteLocationsRepository implements LocationsRepository {
     return row?.count ?? 0;
   }
 
+  async countSessionLinksByLocations(
+    ids: string[]
+  ): Promise<Map<string, number>> {
+    const result = new Map<string, number>(ids.map((id) => [id, 0]));
+    if (ids.length === 0) return result;
+    const rows = this.db
+      .select({
+        locationId: schema.sessionLocations.locationId,
+        count: sql<number>`count(*)`,
+      })
+      .from(schema.sessionLocations)
+      .where(inArray(schema.sessionLocations.locationId, ids))
+      .groupBy(schema.sessionLocations.locationId)
+      .all();
+    for (const row of rows) result.set(row.locationId, row.count);
+    return result;
+  }
+
   async listEventIds(id: string): Promise<string[]> {
     return this.db
       .select({ eventId: schema.eventLocations.eventId })
@@ -193,6 +211,21 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .where(eq(schema.eventLocations.locationId, id))
       .all()
       .map((r) => r.eventId);
+  }
+
+  async listEventIdsByLocations(ids: string[]): Promise<Map<string, string[]>> {
+    const result = new Map<string, string[]>(ids.map((id) => [id, []]));
+    if (ids.length === 0) return result;
+    const rows = this.db
+      .select({
+        locationId: schema.eventLocations.locationId,
+        eventId: schema.eventLocations.eventId,
+      })
+      .from(schema.eventLocations)
+      .where(inArray(schema.eventLocations.locationId, ids))
+      .all();
+    for (const row of rows) result.get(row.locationId)?.push(row.eventId);
+    return result;
   }
 
   async listLocationIdsByEvent(eventId: string): Promise<string[]> {

--- a/db/repositories/sqlite/rsvps.ts
+++ b/db/repositories/sqlite/rsvps.ts
@@ -31,6 +31,18 @@ export class SqliteRsvpsRepository implements RsvpsRepository {
       .map(rowToRsvp);
   }
 
+  async listBySessions(sessionIds: string[]): Promise<Map<string, Rsvp[]>> {
+    const result = new Map<string, Rsvp[]>(sessionIds.map((id) => [id, []]));
+    if (sessionIds.length === 0) return result;
+    const rows = this.db
+      .select()
+      .from(schema.rsvps)
+      .where(inArray(schema.rsvps.sessionId, sessionIds))
+      .all();
+    for (const row of rows) result.get(row.sessionId)?.push(rowToRsvp(row));
+    return result;
+  }
+
   async create(data: { sessionId: string; guestId: string }): Promise<Rsvp> {
     this.db
       .insert(schema.rsvps)

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -1,4 +1,14 @@
-import { and, count, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  exists,
+  inArray,
+  isNotNull,
+  like,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -6,6 +16,7 @@ import type {
   ProposalHost,
   SessionProposal,
   SessionProposalCreateInput,
+  SessionProposalPage,
   SessionProposalUpdateInput,
   SessionProposalsRepository,
 } from "../interfaces";
@@ -130,6 +141,55 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
       .all()
       .map((r) => r.proposal);
     return this.enrichProposals(rows);
+  }
+
+  async searchByEvent(
+    eventId: string,
+    opts: { query?: string; limit: number; offset: number }
+  ): Promise<SessionProposalPage> {
+    const conditions = [eq(schema.sessionProposals.eventId, eventId)];
+    if (opts.query) {
+      const pattern = `%${opts.query}%`;
+      // Match the title or any host's name.
+      const hostMatch = exists(
+        this.db
+          .select({ one: sql`1` })
+          .from(schema.proposalHosts)
+          .innerJoin(
+            schema.guests,
+            eq(schema.proposalHosts.guestId, schema.guests.id)
+          )
+          .where(
+            and(
+              eq(schema.proposalHosts.proposalId, schema.sessionProposals.id),
+              like(schema.guests.name, pattern)
+            )
+          )
+      );
+      conditions.push(
+        or(like(schema.sessionProposals.title, pattern), hostMatch)!
+      );
+    }
+    const where = and(...conditions);
+
+    const totalRow = this.db
+      .select({ count: count() })
+      .from(schema.sessionProposals)
+      .where(where)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.sessionProposals)
+      .where(where)
+      // id as tiebreaker: title is not unique, and without a deterministic
+      // order LIMIT/OFFSET pagination can duplicate or skip rows.
+      .orderBy(schema.sessionProposals.title, schema.sessionProposals.id)
+      .limit(opts.limit)
+      .offset(opts.offset)
+      .all();
+
+    return { rows: this.enrichProposals(rows), total: totalRow?.count ?? 0 };
   }
 
   async findById(id: string): Promise<SessionProposal | undefined> {

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -1,4 +1,14 @@
-import { and, count, eq, isNotNull } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  exists,
+  inArray,
+  isNotNull,
+  like,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
@@ -7,6 +17,7 @@ import type {
   SessionCreateInput,
   SessionHost,
   SessionLocation,
+  SessionPage,
   SessionsRepository,
   SessionUpdateInput,
 } from "../interfaces";
@@ -57,8 +68,8 @@ export class SqliteSessionsRepository implements SessionsRepository {
         schema.guests,
         eq(schema.sessionHosts.guestId, schema.guests.id)
       )
-      .all()
-      .filter((r) => ids.includes(r.sessionId));
+      .where(inArray(schema.sessionHosts.sessionId, ids))
+      .all();
 
     const locationRows = this.db
       .select({
@@ -72,15 +83,15 @@ export class SqliteSessionsRepository implements SessionsRepository {
         schema.locations,
         eq(schema.sessionLocations.locationId, schema.locations.id)
       )
-      .all()
-      .filter((r) => ids.includes(r.sessionId));
+      .where(inArray(schema.sessionLocations.sessionId, ids))
+      .all();
 
     const rsvpRows = this.db
       .select({ sessionId: schema.rsvps.sessionId, cnt: count() })
       .from(schema.rsvps)
+      .where(inArray(schema.rsvps.sessionId, ids))
       .groupBy(schema.rsvps.sessionId)
-      .all()
-      .filter((r) => ids.includes(r.sessionId));
+      .all();
 
     const hostsBySession = new Map<string, SessionHost[]>();
     for (const r of hostRows) {
@@ -175,6 +186,53 @@ export class SqliteSessionsRepository implements SessionsRepository {
       .all()
       .map((r) => r.session);
     return this.enrichSessions(rows);
+  }
+
+  async searchByEvent(
+    eventId: string,
+    opts: { query?: string; limit: number; offset: number }
+  ): Promise<SessionPage> {
+    const conditions = [eq(schema.sessions.eventId, eventId)];
+    if (opts.query) {
+      const pattern = `%${opts.query}%`;
+      // Match the title or any host's name.
+      const hostMatch = exists(
+        this.db
+          .select({ one: sql`1` })
+          .from(schema.sessionHosts)
+          .innerJoin(
+            schema.guests,
+            eq(schema.sessionHosts.guestId, schema.guests.id)
+          )
+          .where(
+            and(
+              eq(schema.sessionHosts.sessionId, schema.sessions.id),
+              like(schema.guests.name, pattern)
+            )
+          )
+      );
+      conditions.push(or(like(schema.sessions.title, pattern), hostMatch)!);
+    }
+    const where = and(...conditions);
+
+    const totalRow = this.db
+      .select({ count: count() })
+      .from(schema.sessions)
+      .where(where)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.sessions)
+      .where(where)
+      // id as tiebreaker: title is not unique, and without a deterministic
+      // order LIMIT/OFFSET pagination can duplicate or skip rows.
+      .orderBy(schema.sessions.title, schema.sessions.id)
+      .limit(opts.limit)
+      .offset(opts.offset)
+      .all();
+
+    return { rows: this.enrichSessions(rows), total: totalRow?.count ?? 0 };
   }
 
   async findById(id: string): Promise<Session | undefined> {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1065,6 +1065,49 @@ test.describe("Admin UI sessions", () => {
     await expect(row).toBeVisible();
     // Keynote is hosted by a seeded guest and placed in the first location
     await expect(row).toContainText("Test");
+
+    // Server-side search: a title substring narrows to one row and the URL
+    // carries the query.
+    await sessions
+      .getByRole("searchbox", { name: "Search" })
+      .fill("Opening Keynote");
+    await sessions.getByRole("button", { name: "Search" }).click();
+    await expect(page).toHaveURL(/[?&]q=/);
+    await expect(sessions.getByRole("listitem")).toHaveCount(1);
+    await expect(row).toBeVisible();
+
+    // Searching a host name matches their sessions and hides others.
+    await sessions
+      .getByRole("searchbox", { name: "Search" })
+      .fill("Charlie Test");
+    await sessions.getByRole("button", { name: "Search" }).click();
+    await expect(row).toBeVisible();
+    await expect(
+      sessions.getByRole("listitem").filter({ hasText: "Lunch Break" })
+    ).toHaveCount(0);
+  });
+
+  test("redirects to the last valid page when a stale page param is out of range", async ({
+    page,
+  }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Conference Gamma" })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    await openEventTab(page, "Sessions");
+
+    const sessions = page.getByRole("region", { name: "Sessions" });
+    await expect(sessions).toBeVisible();
+
+    // Simulate a stale bookmarked link pointing past the last page: the
+    // server should redirect back to a valid page instead of rendering an
+    // empty list.
+    await page.goto(`${page.url()}?page=999`);
+    await expect(page).not.toHaveURL(/[?&]page=999/);
+    await expect(sessions.getByRole("listitem").first()).toBeVisible();
   });
 
   test("can edit a session on the event detail page", async ({ page }) => {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -189,6 +189,44 @@ test.describe("Admin UI", () => {
       page.getByRole("listitem").filter({ hasText: email })
     ).toHaveCount(0);
   });
+
+  test("searches and paginates users", async ({ page }) => {
+    await adminLogin(page);
+    await gotoUsers(page);
+
+    const users = page.getByRole("region", { name: "Users" });
+    const userItem = (name: string) =>
+      users.getByRole("listitem").filter({ hasText: name });
+
+    // The 40 seeded guests span two pages of 25, ordered by name.
+    await expect(users.getByText(/Page 1 of \d+/)).toBeVisible();
+    await expect(userItem("Alice Test")).toBeVisible();
+    await users.getByRole("button", { name: "Next page" }).click();
+    await expect(users.getByText(/Page 2 of \d+/)).toBeVisible();
+    await expect(userItem("Alice Test")).toHaveCount(0);
+
+    // Server-side search by name narrows the list and resets to page 1; the
+    // URL carries the query.
+    await users.getByRole("searchbox", { name: "Search" }).fill("Alice");
+    await users.getByRole("button", { name: "Search" }).click();
+    await expect(page).toHaveURL(/[?&]q=Alice/);
+    await expect(userItem("Alice Test")).toBeVisible();
+    await expect(userItem("Bob Test")).toHaveCount(0);
+    await expect(users.getByText("Page 1 of 1")).toBeVisible();
+
+    // Search also matches emails.
+    await users.getByRole("searchbox", { name: "Search" }).fill("bob@test.com");
+    await users.getByRole("button", { name: "Search" }).click();
+    await expect(userItem("Bob Test")).toBeVisible();
+    await expect(userItem("Alice Test")).toHaveCount(0);
+
+    // A whitespace-only query means "no search": the URL must not keep a
+    // stale q param while the list renders unfiltered.
+    await users.getByRole("searchbox", { name: "Search" }).fill("   ");
+    await users.getByRole("button", { name: "Search" }).click();
+    await expect(userItem("Alice Test")).toBeVisible();
+    await expect(page).not.toHaveURL(/[?&]q=/);
+  });
 });
 
 test.describe("Admin UI events", () => {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -33,11 +33,12 @@ async function gotoLocations(page: Page) {
   await expect(page.getByRole("heading", { name: "Locations" })).toBeVisible();
 }
 
-// Event detail is split into tab sub-routes (Config · Guests · Proposals ·
-// Sessions). Call this after clicking an event's "Manage" link to open a tab.
+// Event detail is split into tab sub-routes (Config · Guests · Locations ·
+// Proposals · Sessions). Call this after clicking an event's "Manage" link to
+// open a tab.
 async function openEventTab(
   page: Page,
-  tab: "Config" | "Guests" | "Proposals" | "Sessions"
+  tab: "Config" | "Guests" | "Locations" | "Proposals" | "Sessions"
 ) {
   const link = page
     .getByRole("navigation", { name: "Event sections" })
@@ -250,6 +251,10 @@ test.describe("Admin UI events", () => {
     await openEventTab(page, "Guests");
     await expect(page).toHaveURL(/\/guests$/);
     await expect(page.getByRole("region", { name: "Guests" })).toBeVisible();
+
+    await openEventTab(page, "Locations");
+    await expect(page).toHaveURL(/\/locations$/);
+    await expect(page.getByRole("region", { name: "Locations" })).toBeVisible();
 
     await openEventTab(page, "Proposals");
     await expect(page).toHaveURL(/\/proposals$/);
@@ -770,6 +775,7 @@ test.describe("Admin UI locations", () => {
         .filter({ hasText: eventName })
         .getByRole("link", { name: "Manage" })
         .click();
+      await openEventTab(page, "Locations");
 
       const locations = page.getByRole("region", { name: "Locations" });
       await expect(locations).toBeVisible();
@@ -780,11 +786,15 @@ test.describe("Admin UI locations", () => {
       const mainHallRow = locations
         .getByRole("row")
         .filter({ hasText: "Main Hall" });
-      await expect(mainHallRow.getByRole("checkbox")).not.toBeChecked();
+      // Each row has a "Select" checkbox (bulk) and an "Assign" checkbox (state).
+      const mainHallAssign = mainHallRow.getByRole("checkbox", {
+        name: /^Assign /,
+      });
+      await expect(mainHallAssign).not.toBeChecked();
 
-      // Assign Main Hall
-      await mainHallRow.getByRole("checkbox").click();
-      await expect(mainHallRow.getByRole("checkbox")).toBeChecked();
+      // Assign Main Hall — click and wait for server-driven update
+      await mainHallAssign.click();
+      await expect(mainHallAssign).toBeChecked();
 
       // Navigate away and back — assignment must persist. Soft navigation via
       // the back link avoids aborting the assignment action's revalidation
@@ -796,6 +806,7 @@ test.describe("Admin UI locations", () => {
         .filter({ hasText: eventName })
         .getByRole("link", { name: "Manage" })
         .click();
+      await openEventTab(page, "Locations");
       await expect(
         page
           .getByRole("region", { name: "Locations" })
@@ -808,7 +819,7 @@ test.describe("Admin UI locations", () => {
       const l2 = page.getByRole("region", { name: "Locations" });
       await l2.getByRole("button", { name: "Assigned", exact: true }).click();
       await expect(
-        l2.getByRole("row").filter({ has: page.getByRole("checkbox") })
+        l2.getByRole("row").filter({ hasNot: page.getByRole("columnheader") })
       ).toHaveCount(1);
       await expect(
         l2.getByRole("row").filter({ hasText: "Main Hall" })
@@ -826,10 +837,37 @@ test.describe("Admin UI locations", () => {
 
       // Switch back to All and remove the assignment
       await l2.getByRole("button", { name: "All", exact: true }).click();
-      await l2.getByRole("checkbox", { checked: true }).click();
-      await expect(l2.getByRole("checkbox", { checked: true })).toHaveCount(0);
+      await l2
+        .getByRole("checkbox", { name: /^Assign /, checked: true })
+        .click();
+      await expect(
+        l2.getByRole("checkbox", { name: /^Assign /, checked: true })
+      ).toHaveCount(0);
 
-      // Clean up
+      // Bulk: select all rows on the page, assign, then remove. Assert on fixed
+      // seeded locations, not row counts (parallel tests create/delete rows).
+      // Starting a selection must not shift the table (the bulk bar reserves
+      // its space), or the checkbox moves away from under the pointer.
+      const selectAll = l2.getByRole("checkbox", { name: "Select all" });
+      const boxBeforeSelect = await selectAll.boundingBox();
+      await selectAll.check();
+      expect(await selectAll.boundingBox()).toEqual(boxBeforeSelect);
+      await l2.getByRole("button", { name: "Assign selected" }).click();
+      await expect(
+        l2.getByRole("checkbox", { name: "Assign Main Hall" })
+      ).toBeChecked();
+      await expect(
+        l2.getByRole("checkbox", { name: "Assign Workshop Room" })
+      ).toBeChecked();
+
+      await l2.getByRole("checkbox", { name: "Select all" }).check();
+      await l2.getByRole("button", { name: "Remove selected" }).click();
+      await expect(
+        l2.getByRole("checkbox", { name: /^Assign /, checked: true })
+      ).toHaveCount(0);
+
+      // Clean up — the delete control lives on the Config tab
+      await openEventTab(page, "Config");
       await page.getByRole("button", { name: "Delete event" }).click();
       await page.getByLabel("Type the event name to confirm").fill(eventName);
       await page.getByRole("button", { name: "Confirm delete" }).click();

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -900,6 +900,51 @@ test.describe("Admin UI proposals", () => {
     });
     await expect(row).toBeVisible();
     await expect(row).toContainText("Alice Test");
+
+    // Server-side search: a title substring narrows to one row and the URL
+    // carries the query.
+    await proposals
+      .getByRole("searchbox", { name: "Search" })
+      .fill("Community Showcase");
+    await proposals.getByRole("button", { name: "Search" }).click();
+    await expect(page).toHaveURL(/[?&]q=/);
+    await expect(proposals.getByRole("listitem")).toHaveCount(1);
+    await expect(row).toBeVisible();
+
+    // Searching a host name matches their proposals and hides others.
+    await proposals
+      .getByRole("searchbox", { name: "Search" })
+      .fill("Alice Test");
+    await proposals.getByRole("button", { name: "Search" }).click();
+    await expect(row).toBeVisible();
+    await expect(
+      proposals
+        .getByRole("listitem")
+        .filter({ hasText: "Networking & Coffee Chat" })
+    ).toHaveCount(0);
+  });
+
+  test("redirects to the last valid page when a stale page param is out of range", async ({
+    page,
+  }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Conference Alpha" })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    await openEventTab(page, "Proposals");
+
+    const proposals = page.getByRole("region", { name: "Proposals" });
+    await expect(proposals).toBeVisible();
+
+    // Simulate a stale bookmarked link pointing past the last page: the
+    // server should redirect back to a valid page instead of rendering an
+    // empty list.
+    await page.goto(`${page.url()}?page=999`);
+    await expect(page).not.toHaveURL(/[?&]page=999/);
+    await expect(proposals.getByRole("listitem").first()).toBeVisible();
   });
 
   test("can edit a proposal's title and hosts on the event detail page", async ({

--- a/tests/integration/admin-guest-search.test.ts
+++ b/tests/integration/admin-guest-search.test.ts
@@ -4,6 +4,61 @@ import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 
+describe("guests.search", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("searches name and email case-insensitively by substring", async () => {
+    await createGuest({ name: "Alice Smith", email: "alice@test.example" });
+    await createGuest({ name: "Bob Jones", email: "bob@corp.example" });
+    const repos = getRepositories();
+
+    const byName = await repos.guests.search({
+      query: "smith",
+      limit: 50,
+      offset: 0,
+    });
+    expect(byName.total).toBe(1);
+    expect(byName.rows.map((r) => r.name)).toEqual(["Alice Smith"]);
+
+    const byEmail = await repos.guests.search({
+      query: "CORP",
+      limit: 50,
+      offset: 0,
+    });
+    expect(byEmail.rows.map((r) => r.name)).toEqual(["Bob Jones"]);
+    expect(byEmail.rows[0].info.email).toBe("bob@corp.example");
+  });
+
+  it("matches LIKE metacharacters literally", async () => {
+    await createGuest({ name: "a_b", email: "underscore@test.example" });
+    await createGuest({ name: "axb", email: "plain@test.example" });
+    const repos = getRepositories();
+
+    const { rows } = await repos.guests.search({
+      query: "a_b",
+      limit: 50,
+      offset: 0,
+    });
+    expect(rows.map((r) => r.name)).toEqual(["a_b"]);
+  });
+
+  it("paginates by name via limit/offset while reporting the full total", async () => {
+    for (const name of ["E", "C", "A", "D", "B"]) {
+      await createGuest({ name, email: `${name}@test.example` });
+    }
+    const repos = getRepositories();
+
+    const firstPage = await repos.guests.search({ limit: 2, offset: 0 });
+    expect(firstPage.total).toBe(5);
+    expect(firstPage.rows.map((r) => r.name)).toEqual(["A", "B"]);
+
+    const secondPage = await repos.guests.search({ limit: 2, offset: 2 });
+    expect(secondPage.total).toBe(5);
+    expect(secondPage.rows.map((r) => r.name)).toEqual(["C", "D"]);
+  });
+});
+
 describe("guests.searchForEventAssignment", () => {
   beforeAll(() => setupTestDb());
   beforeEach(() => resetTestDb());

--- a/tests/integration/admin-location-search.test.ts
+++ b/tests/integration/admin-location-search.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createLocation } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("locations.searchForEventAssignment", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns all locations with an assigned flag for the event", async () => {
+    const event = await createEvent();
+    const a = await createLocation({ name: "Auditorium", capacity: 100 });
+    await createLocation({ name: "Boardroom", capacity: 10 });
+    const repos = getRepositories();
+    await repos.locations.assignToEvent(event.id, [a.id]);
+
+    const { rows, total } = await repos.locations.searchForEventAssignment(
+      event.id,
+      { limit: 50, offset: 0 }
+    );
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => [r.name, r.capacity, r.assigned])).toEqual([
+      ["Auditorium", 100, true],
+      ["Boardroom", 10, false],
+    ]);
+  });
+
+  it("filters by assignment membership", async () => {
+    const event = await createEvent();
+    const a = await createLocation({ name: "Auditorium" });
+    await createLocation({ name: "Boardroom" });
+    const repos = getRepositories();
+    await repos.locations.assignToEvent(event.id, [a.id]);
+
+    const assigned = await repos.locations.searchForEventAssignment(event.id, {
+      assigned: true,
+      limit: 50,
+      offset: 0,
+    });
+    expect(assigned.total).toBe(1);
+    expect(assigned.rows.map((r) => r.name)).toEqual(["Auditorium"]);
+
+    const notAssigned = await repos.locations.searchForEventAssignment(
+      event.id,
+      { assigned: false, limit: 50, offset: 0 }
+    );
+    expect(notAssigned.total).toBe(1);
+    expect(notAssigned.rows.map((r) => r.name)).toEqual(["Boardroom"]);
+  });
+
+  it("searches name case-insensitively by substring", async () => {
+    const event = await createEvent();
+    await createLocation({ name: "Main Hall" });
+    await createLocation({ name: "Workshop Room" });
+    const repos = getRepositories();
+
+    const { rows } = await repos.locations.searchForEventAssignment(event.id, {
+      query: "hall",
+      limit: 50,
+      offset: 0,
+    });
+    expect(rows.map((r) => r.name)).toEqual(["Main Hall"]);
+  });
+
+  it("treats % and _ in the query as literal characters, not wildcards", async () => {
+    const event = await createEvent();
+    await createLocation({ name: "50% Off Room" });
+    await createLocation({ name: "500 Off Room" });
+    await createLocation({ name: "Room A_1" });
+    await createLocation({ name: "Room AX1" });
+    const repos = getRepositories();
+
+    const percent = await repos.locations.searchForEventAssignment(event.id, {
+      query: "50%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(percent.rows.map((r) => r.name)).toEqual(["50% Off Room"]);
+    expect(percent.total).toBe(1);
+
+    const underscore = await repos.locations.searchForEventAssignment(
+      event.id,
+      { query: "A_1", limit: 50, offset: 0 }
+    );
+    expect(underscore.rows.map((r) => r.name)).toEqual(["Room A_1"]);
+    expect(underscore.total).toBe(1);
+  });
+
+  it("paginates via limit/offset while reporting the full total", async () => {
+    const event = await createEvent();
+    for (const name of ["A", "B", "C", "D", "E"]) {
+      await createLocation({ name });
+    }
+    const repos = getRepositories();
+
+    const firstPage = await repos.locations.searchForEventAssignment(event.id, {
+      limit: 2,
+      offset: 0,
+    });
+    expect(firstPage.total).toBe(5);
+    expect(firstPage.rows.map((r) => r.name)).toEqual(["A", "B"]);
+
+    const secondPage = await repos.locations.searchForEventAssignment(
+      event.id,
+      { limit: 2, offset: 2 }
+    );
+    expect(secondPage.total).toBe(5);
+    expect(secondPage.rows.map((r) => r.name)).toEqual(["C", "D"]);
+  });
+
+  it("orders duplicate names by id so pagination is stable", async () => {
+    const event = await createEvent();
+    const repos = getRepositories();
+
+    // Create locations sharing a name until insertion order differs from id
+    // order, so a name tie cannot accidentally come back id-sorted without
+    // an explicit tiebreaker.
+    const ids: string[] = [];
+    do {
+      ids.push((await createLocation({ name: "Dup" })).id);
+    } while (
+      ids.length < 2 ||
+      ids.every((id, i) => i === 0 || ids[i - 1] < id)
+    );
+
+    const pagedIds: string[] = [];
+    for (let offset = 0; offset < ids.length; offset++) {
+      const { rows } = await repos.locations.searchForEventAssignment(
+        event.id,
+        { limit: 1, offset }
+      );
+      pagedIds.push(rows[0].id);
+    }
+
+    expect(pagedIds).toEqual([...ids].sort());
+  });
+});

--- a/tests/integration/admin-proposal-search.test.ts
+++ b/tests/integration/admin-proposal-search.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createProposal } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("sessionProposals.searchByEvent", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns enriched proposals for the event only, ordered by title", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    const host = await createGuest({ name: "Alice" });
+    await createProposal(event.id, [host.id], { title: "Zebra Talk" });
+    await createProposal(event.id, [], { title: "Agile Workshop" });
+    await createProposal(other.id, [], { title: "Other Event Talk" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessionProposals.searchByEvent(
+      event.id,
+      { limit: 50, offset: 0 }
+    );
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => r.title)).toEqual(["Agile Workshop", "Zebra Talk"]);
+    expect(rows[1].hosts.map((h) => h.name)).toEqual(["Alice"]);
+  });
+
+  it("searches title case-insensitively by substring", async () => {
+    const event = await createEvent();
+    await createProposal(event.id, [], { title: "Intro to Rust" });
+    await createProposal(event.id, [], { title: "Advanced Python" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessionProposals.searchByEvent(
+      event.id,
+      { query: "rust", limit: 50, offset: 0 }
+    );
+
+    expect(total).toBe(1);
+    expect(rows.map((r) => r.title)).toEqual(["Intro to Rust"]);
+  });
+
+  it("matches proposals by host name", async () => {
+    const event = await createEvent();
+    const alice = await createGuest({ name: "Alice Smith" });
+    const bob = await createGuest({ name: "Bob Jones" });
+    await createProposal(event.id, [alice.id], { title: "First" });
+    await createProposal(event.id, [bob.id], { title: "Second" });
+    await createProposal(event.id, [], { title: "Hostless" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessionProposals.searchByEvent(
+      event.id,
+      { query: "smith", limit: 50, offset: 0 }
+    );
+
+    expect(total).toBe(1);
+    expect(rows.map((r) => r.title)).toEqual(["First"]);
+  });
+
+  it("paginates via limit/offset while reporting the full total", async () => {
+    const event = await createEvent();
+    for (const title of ["A", "B", "C", "D", "E"]) {
+      await createProposal(event.id, [], { title });
+    }
+    const repos = getRepositories();
+
+    const firstPage = await repos.sessionProposals.searchByEvent(event.id, {
+      limit: 2,
+      offset: 0,
+    });
+    expect(firstPage.total).toBe(5);
+    expect(firstPage.rows.map((r) => r.title)).toEqual(["A", "B"]);
+
+    const secondPage = await repos.sessionProposals.searchByEvent(event.id, {
+      limit: 2,
+      offset: 2,
+    });
+    expect(secondPage.total).toBe(5);
+    expect(secondPage.rows.map((r) => r.title)).toEqual(["C", "D"]);
+  });
+
+  it("orders duplicate titles by id so pagination is stable", async () => {
+    const event = await createEvent();
+    const repos = getRepositories();
+
+    // Create proposals sharing a title until insertion order differs from id
+    // order, so a title tie cannot accidentally come back id-sorted without
+    // an explicit tiebreaker.
+    const ids: string[] = [];
+    do {
+      ids.push((await createProposal(event.id, [], { title: "Dup" })).id);
+    } while (
+      ids.length < 2 ||
+      ids.every((id, i) => i === 0 || ids[i - 1] < id)
+    );
+
+    const pagedIds: string[] = [];
+    for (let offset = 0; offset < ids.length; offset++) {
+      const { rows } = await repos.sessionProposals.searchByEvent(event.id, {
+        limit: 1,
+        offset,
+      });
+      pagedIds.push(rows[0].id);
+    }
+
+    expect(pagedIds).toEqual([...ids].sort());
+  });
+});

--- a/tests/integration/admin-session-search.test.ts
+++ b/tests/integration/admin-session-search.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("sessions.searchByEvent", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns enriched sessions for the event only, ordered by title", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    const host = await createGuest({ name: "Alice" });
+    await createSession(event.id, { title: "Zebra Talk", hostIds: [host.id] });
+    await createSession(event.id, { title: "Agile Workshop" });
+    await createSession(other.id, { title: "Other Event Talk" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessions.searchByEvent(event.id, {
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => r.title)).toEqual(["Agile Workshop", "Zebra Talk"]);
+    expect(rows[1].hosts.map((h) => h.name)).toEqual(["Alice"]);
+  });
+
+  it("scopes hosts, locations and rsvp counts to each session without leaking across sessions or events", async () => {
+    const event = await createEvent();
+    const other = await createEvent();
+    const repos = getRepositories();
+
+    const alice = await createGuest({ name: "Alice" });
+    const bob = await createGuest({ name: "Bob" });
+    const roomA = await createLocation({ name: "Room A" });
+    const roomB = await createLocation({ name: "Room B" });
+
+    const first = await createSession(event.id, {
+      title: "First",
+      hostIds: [alice.id],
+      locationIds: [roomA.id],
+    });
+    const second = await createSession(event.id, {
+      title: "Second",
+      hostIds: [bob.id],
+      locationIds: [roomB.id],
+    });
+
+    // Another event's session carries its own hosts/locations/rsvps that must
+    // never bleed into this event's page.
+    const outsider = await createSession(other.id, {
+      title: "Outsider",
+      hostIds: [alice.id],
+      locationIds: [roomA.id],
+    });
+
+    // Distinct rsvp counts per session: 2 for First, 1 for Second, 3 elsewhere.
+    for (let i = 0; i < 2; i++) {
+      const g = await createGuest({ name: `first-rsvp-${i}` });
+      await repos.rsvps.create({ sessionId: first.id, guestId: g.id });
+    }
+    const g = await createGuest({ name: "second-rsvp" });
+    await repos.rsvps.create({ sessionId: second.id, guestId: g.id });
+    for (let i = 0; i < 3; i++) {
+      const og = await createGuest({ name: `outsider-rsvp-${i}` });
+      await repos.rsvps.create({ sessionId: outsider.id, guestId: og.id });
+    }
+
+    const { rows, total } = await repos.sessions.searchByEvent(event.id, {
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(total).toBe(2);
+    const byTitle = new Map(rows.map((r) => [r.title, r]));
+
+    const firstRow = byTitle.get("First")!;
+    expect(firstRow.hosts.map((h) => h.name)).toEqual(["Alice"]);
+    expect(firstRow.locations.map((l) => l.name)).toEqual(["Room A"]);
+    expect(firstRow.numRsvps).toBe(2);
+
+    const secondRow = byTitle.get("Second")!;
+    expect(secondRow.hosts.map((h) => h.name)).toEqual(["Bob"]);
+    expect(secondRow.locations.map((l) => l.name)).toEqual(["Room B"]);
+    expect(secondRow.numRsvps).toBe(1);
+  });
+
+  it("searches title case-insensitively by substring", async () => {
+    const event = await createEvent();
+    await createSession(event.id, { title: "Intro to Rust" });
+    await createSession(event.id, { title: "Advanced Python" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessions.searchByEvent(event.id, {
+      query: "rust",
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(total).toBe(1);
+    expect(rows.map((r) => r.title)).toEqual(["Intro to Rust"]);
+  });
+
+  it("matches sessions by host name", async () => {
+    const event = await createEvent();
+    const alice = await createGuest({ name: "Alice Smith" });
+    const bob = await createGuest({ name: "Bob Jones" });
+    await createSession(event.id, { title: "First", hostIds: [alice.id] });
+    await createSession(event.id, { title: "Second", hostIds: [bob.id] });
+    await createSession(event.id, { title: "Hostless" });
+    const repos = getRepositories();
+
+    const { rows, total } = await repos.sessions.searchByEvent(event.id, {
+      query: "smith",
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(total).toBe(1);
+    expect(rows.map((r) => r.title)).toEqual(["First"]);
+  });
+
+  it("paginates via limit/offset while reporting the full total", async () => {
+    const event = await createEvent();
+    for (const title of ["A", "B", "C", "D", "E"]) {
+      await createSession(event.id, { title });
+    }
+    const repos = getRepositories();
+
+    const firstPage = await repos.sessions.searchByEvent(event.id, {
+      limit: 2,
+      offset: 0,
+    });
+    expect(firstPage.total).toBe(5);
+    expect(firstPage.rows.map((r) => r.title)).toEqual(["A", "B"]);
+
+    const secondPage = await repos.sessions.searchByEvent(event.id, {
+      limit: 2,
+      offset: 2,
+    });
+    expect(secondPage.total).toBe(5);
+    expect(secondPage.rows.map((r) => r.title)).toEqual(["C", "D"]);
+  });
+
+  it("orders duplicate titles by id so pagination is stable", async () => {
+    const event = await createEvent();
+    const repos = getRepositories();
+
+    // Create sessions sharing a title until insertion order differs from id
+    // order, so a title tie cannot accidentally come back id-sorted without
+    // an explicit tiebreaker.
+    const ids: string[] = [];
+    do {
+      ids.push((await createSession(event.id, { title: "Dup" })).id);
+    } while (
+      ids.length < 2 ||
+      ids.every((id, i) => i === 0 || ids[i - 1] < id)
+    );
+
+    const pagedIds: string[] = [];
+    for (let offset = 0; offset < ids.length; offset++) {
+      const { rows } = await repos.sessions.searchByEvent(event.id, {
+        limit: 1,
+        offset,
+      });
+      pagedIds.push(rows[0].id);
+    }
+
+    expect(pagedIds).toEqual([...ids].sort());
+  });
+});

--- a/tests/integration/batch-links.test.ts
+++ b/tests/integration/batch-links.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("locations.listEventIdsByLocations", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns event ids grouped per location in one call", async () => {
+    const eventA = await createEvent();
+    const eventB = await createEvent();
+    const l1 = await createLocation();
+    const l2 = await createLocation();
+    const l3 = await createLocation();
+    const repos = getRepositories();
+    await repos.locations.setEventIds(l1.id, [eventA.id, eventB.id]);
+    await repos.locations.setEventIds(l2.id, [eventB.id]);
+
+    const result = await repos.locations.listEventIdsByLocations([
+      l1.id,
+      l2.id,
+      l3.id,
+    ]);
+
+    expect(result.get(l1.id)?.sort()).toEqual([eventA.id, eventB.id].sort());
+    expect(result.get(l2.id)).toEqual([eventB.id]);
+    expect(result.get(l3.id)).toEqual([]);
+  });
+
+  it("returns an empty map for no locations", async () => {
+    const result = await getRepositories().locations.listEventIdsByLocations(
+      []
+    );
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("locations.countSessionLinksByLocations", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns session-link counts per location in one call", async () => {
+    const event = await createEvent();
+    const l1 = await createLocation();
+    const l2 = await createLocation();
+    await createSession(event.id, { locationIds: [l1.id] });
+    await createSession(event.id, { locationIds: [l1.id] });
+
+    const repos = getRepositories();
+    const result = await repos.locations.countSessionLinksByLocations([
+      l1.id,
+      l2.id,
+    ]);
+
+    expect(result.get(l1.id)).toBe(2);
+    expect(result.get(l2.id)).toBe(0);
+  });
+
+  it("returns an empty map for no locations", async () => {
+    const result =
+      await getRepositories().locations.countSessionLinksByLocations([]);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("rsvps.listBySessions", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns RSVPs grouped per session in one call", async () => {
+    const event = await createEvent();
+    const g1 = await createGuest();
+    const g2 = await createGuest();
+    const s1 = await createSession(event.id);
+    const s2 = await createSession(event.id);
+    const s3 = await createSession(event.id);
+    const repos = getRepositories();
+    await repos.rsvps.create({ sessionId: s1.id, guestId: g1.id });
+    await repos.rsvps.create({ sessionId: s1.id, guestId: g2.id });
+    await repos.rsvps.create({ sessionId: s2.id, guestId: g1.id });
+
+    const result = await repos.rsvps.listBySessions([s1.id, s2.id, s3.id]);
+
+    expect(
+      result
+        .get(s1.id)
+        ?.map((r) => r.guestId)
+        .sort()
+    ).toEqual([g1.id, g2.id].sort());
+    expect(result.get(s2.id)?.map((r) => r.guestId)).toEqual([g1.id]);
+    expect(result.get(s3.id)).toEqual([]);
+  });
+
+  it("returns an empty map for no sessions", async () => {
+    const result = await getRepositories().rsvps.listBySessions([]);
+    expect(result.size).toBe(0);
+  });
+});


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [1d200e4](https://github.com/LWCW-Europe/schellingboard/pull/539/commits/1d200e44418b5a86f75920560933bbdc6705d0cd).

PRs:
* #546
* #545
* #540
* ➡️ #539 (this PR, depends on the ones below ⬇️)
* #538
* #527
* #526
* #525

---

## Description

The users page loaded every guest at once; with hundreds of users it
becomes unusable. Reuse DataTable's list-item mode backed by a new
paginated guests.search repo method (name/email substring, literal
LIKE matching). Drop listFull from the repo interface — no callers
left outside the sqlite impl.

Trim search input before writing it to the URL, so a whitespace-only
query doesn't leave a stale q= param while the list renders unfiltered.

issue #368

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=1d200e44418b5a86f75920560933bbdc6705d0cd -->