### PR TITLE
Make .env.foo.local override .env.foo, not fully replace.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,7 @@
+# Values in this file will be overridden from .env.test.local, if it exists.
+# (Note: no way for that file to *unset* values in this file; it can only set
+# them to the empty string.)
+
 SITE_PASSWORD=testtest
 ADMIN_PASSWORD=admintest
 AUTH_SECRET=test-only-do-not-use-in-production-7f4c8e2a1b9d6f3e

--- a/set-env.ts
+++ b/set-env.ts
@@ -14,22 +14,23 @@ if (!mode || command.length === 0) {
   process.exit(1);
 }
 
-const envFileLocal = path.resolve(__dirname, `.env.${mode}.local`);
-const envFileShared = path.resolve(__dirname, `.env.${mode}`);
-const envFile = fs.existsSync(envFileLocal)
-  ? envFileLocal
-  : fs.existsSync(envFileShared)
-    ? envFileShared
-    : null;
+// The .local file is an overlay: dotenv never overwrites variables that are
+// already set, so loading the .local file first makes its values win, with
+// the shared file filling in the rest. Variables already present in the
+// actual environment beat both.
+const envFiles = [
+  path.resolve(__dirname, `.env.${mode}.local`),
+  path.resolve(__dirname, `.env.${mode}`),
+].filter((file) => fs.existsSync(file));
 
-if (!envFile) {
+if (envFiles.length === 0) {
   console.warn(
     `Warning: no env file found for mode "${mode}" — proceeding with empty env`
   );
 } else {
-  const dotenvResult = dotenv.config({ path: envFile });
+  const dotenvResult = dotenv.config({ path: envFiles });
   if (dotenvResult.error) {
-    console.error(`Failed to load ${envFile}`);
+    console.error(`Failed to load ${envFiles.join(", ")}`);
     console.error(dotenvResult.error);
     process.exit(1);
   }


### PR DESCRIPTION
That is, if a value is present in both, the value in .env.foo.local wins. But if it's only in .env.foo, the value there is used. (And if it's in your environment, that beats both.)

This is how I expected it to work, and I think it's more convenient. If an engineer wants to override just one value, copying the whole file is annoying, and risks it getting out of date when the defaults are updated. With #519, I expect most engineers to want to set `MAILPIT_API_URL=''` in .env.test.local (but I explicitly don't want that to be the default), and that would be annoying without this.

A thing that's mildly awkward is that there's no way to have .env.foo.local unset a value, only set it to the empty string. I think that's mostly fine, it looks like empty string and unset are usually treated the same anyway? (e.g. `auth.ts` uses `!process.env.SITE_PASSWORD` to see if passwords are disabled.)