### PR TITLE
fix(admin): escape LIKE wildcards in session/proposal search

### DIFF
--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -5,7 +5,6 @@ import {
   exists,
   inArray,
   isNotNull,
-  like,
   or,
   sql,
 } from "drizzle-orm";
@@ -23,6 +22,12 @@ import type {
 
 type DB = BetterSQLite3Database<typeof schema>;
 type ProposalRow = typeof schema.sessionProposals.$inferSelect;
+
+// Escape LIKE meta-characters so user input is matched literally. Pairs with an
+// explicit `ESCAPE '\'` clause in the query below.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 export class SqliteSessionProposalsRepository implements SessionProposalsRepository {
   constructor(private readonly db: DB) {}
@@ -149,7 +154,7 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
   ): Promise<SessionProposalPage> {
     const conditions = [eq(schema.sessionProposals.eventId, eventId)];
     if (opts.query) {
-      const pattern = `%${opts.query}%`;
+      const pattern = `%${escapeLike(opts.query)}%`;
       // Match the title or any host's name.
       const hostMatch = exists(
         this.db
@@ -162,12 +167,15 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
           .where(
             and(
               eq(schema.proposalHosts.proposalId, schema.sessionProposals.id),
-              like(schema.guests.name, pattern)
+              sql`${schema.guests.name} like ${pattern} escape '\\'`
             )
           )
       );
       conditions.push(
-        or(like(schema.sessionProposals.title, pattern), hostMatch)!
+        or(
+          sql`${schema.sessionProposals.title} like ${pattern} escape '\\'`,
+          hostMatch
+        )!
       );
     }
     const where = and(...conditions);

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -5,7 +5,6 @@ import {
   exists,
   inArray,
   isNotNull,
-  like,
   or,
   sql,
 } from "drizzle-orm";
@@ -24,6 +23,12 @@ import type {
 
 type DB = BetterSQLite3Database<typeof schema>;
 type SessionRow = typeof schema.sessions.$inferSelect;
+
+// Escape LIKE meta-characters so user input is matched literally. Pairs with an
+// explicit `ESCAPE '\'` clause in the query below.
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
 
 function buildSessions(
   rows: SessionRow[],
@@ -194,7 +199,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
   ): Promise<SessionPage> {
     const conditions = [eq(schema.sessions.eventId, eventId)];
     if (opts.query) {
-      const pattern = `%${opts.query}%`;
+      const pattern = `%${escapeLike(opts.query)}%`;
       // Match the title or any host's name.
       const hostMatch = exists(
         this.db
@@ -207,11 +212,16 @@ export class SqliteSessionsRepository implements SessionsRepository {
           .where(
             and(
               eq(schema.sessionHosts.sessionId, schema.sessions.id),
-              like(schema.guests.name, pattern)
+              sql`${schema.guests.name} like ${pattern} escape '\\'`
             )
           )
       );
-      conditions.push(or(like(schema.sessions.title, pattern), hostMatch)!);
+      conditions.push(
+        or(
+          sql`${schema.sessions.title} like ${pattern} escape '\\'`,
+          hostMatch
+        )!
+      );
     }
     const where = and(...conditions);
 

--- a/tests/integration/admin-proposal-search.test.ts
+++ b/tests/integration/admin-proposal-search.test.ts
@@ -60,6 +60,43 @@ describe("sessionProposals.searchByEvent", () => {
     expect(rows.map((r) => r.title)).toEqual(["First"]);
   });
 
+  it("treats % and _ in the query as literal characters, not wildcards", async () => {
+    const event = await createEvent();
+    await createProposal(event.id, [], { title: "50% Faster Builds" });
+    await createProposal(event.id, [], { title: "500 Faster Builds" });
+    await createProposal(event.id, [], { title: "Track A_1" });
+    await createProposal(event.id, [], { title: "Track AX1" });
+    const percentHost = await createGuest({ name: "Mr 10% Smith" });
+    const plainHost = await createGuest({ name: "Mr 100 Smith" });
+    await createProposal(event.id, [percentHost.id], { title: "Hosted A" });
+    await createProposal(event.id, [plainHost.id], { title: "Hosted B" });
+    const repos = getRepositories();
+
+    const percent = await repos.sessionProposals.searchByEvent(event.id, {
+      query: "50%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(percent.rows.map((r) => r.title)).toEqual(["50% Faster Builds"]);
+    expect(percent.total).toBe(1);
+
+    const underscore = await repos.sessionProposals.searchByEvent(event.id, {
+      query: "A_1",
+      limit: 50,
+      offset: 0,
+    });
+    expect(underscore.rows.map((r) => r.title)).toEqual(["Track A_1"]);
+    expect(underscore.total).toBe(1);
+
+    const hostMatch = await repos.sessionProposals.searchByEvent(event.id, {
+      query: "10%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(hostMatch.rows.map((r) => r.title)).toEqual(["Hosted A"]);
+    expect(hostMatch.total).toBe(1);
+  });
+
   it("paginates via limit/offset while reporting the full total", async () => {
     const event = await createEvent();
     for (const title of ["A", "B", "C", "D", "E"]) {

--- a/tests/integration/admin-session-search.test.ts
+++ b/tests/integration/admin-session-search.test.ts
@@ -127,6 +127,49 @@ describe("sessions.searchByEvent", () => {
     expect(rows.map((r) => r.title)).toEqual(["First"]);
   });
 
+  it("treats % and _ in the query as literal characters, not wildcards", async () => {
+    const event = await createEvent();
+    await createSession(event.id, { title: "50% Faster Builds" });
+    await createSession(event.id, { title: "500 Faster Builds" });
+    await createSession(event.id, { title: "Track A_1" });
+    await createSession(event.id, { title: "Track AX1" });
+    const percentHost = await createGuest({ name: "Mr 10% Smith" });
+    const plainHost = await createGuest({ name: "Mr 100 Smith" });
+    await createSession(event.id, {
+      title: "Hosted A",
+      hostIds: [percentHost.id],
+    });
+    await createSession(event.id, {
+      title: "Hosted B",
+      hostIds: [plainHost.id],
+    });
+    const repos = getRepositories();
+
+    const percent = await repos.sessions.searchByEvent(event.id, {
+      query: "50%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(percent.rows.map((r) => r.title)).toEqual(["50% Faster Builds"]);
+    expect(percent.total).toBe(1);
+
+    const underscore = await repos.sessions.searchByEvent(event.id, {
+      query: "A_1",
+      limit: 50,
+      offset: 0,
+    });
+    expect(underscore.rows.map((r) => r.title)).toEqual(["Track A_1"]);
+    expect(underscore.total).toBe(1);
+
+    const hostMatch = await repos.sessions.searchByEvent(event.id, {
+      query: "10%",
+      limit: 50,
+      offset: 0,
+    });
+    expect(hostMatch.rows.map((r) => r.title)).toEqual(["Hosted A"]);
+    expect(hostMatch.total).toBe(1);
+  });
+
   it("paginates via limit/offset while reporting the full total", async () => {
     const event = await createEvent();
     for (const title of ["A", "B", "C", "D", "E"]) {


### PR DESCRIPTION
query is documented as a literal substring match, but % and _ acted as
SQL wildcards in both the title and host-name clauses. Same fix as
locations search: escape the query and add ESCAPE to every LIKE.

<!-- jip:pushed-commit=bc928284da7d4fed413e161ffc1390acbe37152b -->