### PR TITLE
feat(admin): visual icon picker for event icon

### DIFF
--- a/app/(site)/nav-bar.tsx
+++ b/app/(site)/nav-bar.tsx
@@ -1,36 +1,8 @@
 "use client";
 import { Disclosure } from "@headlessui/react";
 import {
-  AcademicCapIcon,
   Bars3Icon,
-  BeakerIcon,
-  BoltIcon,
-  BookOpenIcon,
-  BriefcaseIcon,
-  BuildingOfficeIcon,
-  CakeIcon,
-  CalendarIcon,
-  ChatBubbleLeftIcon,
-  CloudIcon,
-  CodeBracketIcon,
-  CogIcon,
-  CommandLineIcon,
-  ComputerDesktopIcon,
-  CpuChipIcon,
-  FireIcon,
-  GlobeAltIcon,
-  HeartIcon,
-  HomeIcon,
-  MicrophoneIcon,
-  MusicalNoteIcon,
-  PaintBrushIcon,
-  RocketLaunchIcon,
-  SparklesIcon,
-  StarIcon,
-  SunIcon,
-  TrophyIcon,
   UserGroupIcon,
-  WrenchIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import clsx from "clsx";
@@ -38,46 +10,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { MapModal } from "./modals";
 import { LogoutButton } from "./logout-button";
-import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
-
-type HeroIcon = ForwardRefExoticComponent<
-  Omit<SVGProps<SVGSVGElement>, "ref"> & {
-    title?: string;
-    titleId?: string;
-  } & RefAttributes<SVGSVGElement>
->;
-
-const ICON_MAP: Record<string, HeroIcon> = {
-  AcademicCapIcon,
-  BeakerIcon,
-  BoltIcon,
-  BookOpenIcon,
-  BriefcaseIcon,
-  BuildingOfficeIcon,
-  CakeIcon,
-  CalendarIcon,
-  ChatBubbleLeftIcon,
-  CloudIcon,
-  CodeBracketIcon,
-  CogIcon,
-  CommandLineIcon,
-  ComputerDesktopIcon,
-  CpuChipIcon,
-  FireIcon,
-  GlobeAltIcon,
-  HeartIcon,
-  HomeIcon,
-  MicrophoneIcon,
-  MusicalNoteIcon,
-  PaintBrushIcon,
-  RocketLaunchIcon,
-  SparklesIcon,
-  StarIcon,
-  SunIcon,
-  TrophyIcon,
-  UserGroupIcon,
-  WrenchIcon,
-};
+import { EVENT_ICONS } from "@/app/event-icons";
 
 export type NavItem = {
   name: string;
@@ -162,7 +95,7 @@ export default function NavBar({
 function NavBarItem(props: { item: NavItem }) {
   const { item } = props;
   const isCurrentPage = usePathname().includes(item.href) && item.href != null;
-  const Icon = item.icon ? ICON_MAP[item.icon] : null;
+  const Icon = item.icon ? EVENT_ICONS[item.icon] : null;
   return (
     <Link
       key={item.name}
@@ -183,7 +116,7 @@ function NavBarItem(props: { item: NavItem }) {
 function SmallNavBarItem(props: { item: NavItem }) {
   const { item } = props;
   const isCurrentPage = usePathname().includes(item.href) && item.href != null;
-  const Icon = item.icon ? ICON_MAP[item.icon] : null;
+  const Icon = item.icon ? EVENT_ICONS[item.icon] : null;
   return (
     <Disclosure.Button
       key={item.name}

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -7,6 +7,7 @@ import { eventNameToSlug } from "@/utils/utils";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import type { Event } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
+import { isEventIconName } from "@/app/event-icons";
 
 async function isAdminRequest(): Promise<boolean> {
   const cookieStore = await cookies();
@@ -71,6 +72,11 @@ function parseEventInput(input: EventInput): ParseResult {
     return { error: "Break must be zero or a positive number" };
   }
 
+  const icon = input.icon?.trim() || undefined;
+  if (icon && !isEventIconName(icon)) {
+    return { error: "Unknown icon" };
+  }
+
   return {
     data: {
       name,
@@ -81,7 +87,7 @@ function parseEventInput(input: EventInput): ParseResult {
       timezone,
       maxSessionDuration,
       breakMinutes,
-      icon: input.icon?.trim() || undefined,
+      icon,
     },
   };
 }

--- a/app/admin/events/[id]/event-days-manager.tsx
+++ b/app/admin/events/[id]/event-days-manager.tsx
@@ -14,6 +14,7 @@ import {
   SECONDARY_BUTTON,
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
+import { utcToZonedInput, zonedInputToUtc } from "@/utils/admin-datetime";
 
 // Dates are pre-serialized to ISO strings in the server component to avoid
 // any RSC Date serialization ambiguity (Day.start is Date on server, but
@@ -37,11 +38,27 @@ const EMPTY_FORM: Omit<DayInput, "eventId"> = {
   endBookings: "",
 };
 
+// Converts every field of a day form from the event timezone to the UTC wire
+// format the day actions expect.
+function toUtcForm(
+  form: Omit<DayInput, "eventId">,
+  timezone: string
+): Omit<DayInput, "eventId"> {
+  return {
+    start: zonedInputToUtc(form.start, timezone),
+    end: zonedInputToUtc(form.end, timezone),
+    startBookings: zonedInputToUtc(form.startBookings, timezone),
+    endBookings: zonedInputToUtc(form.endBookings, timezone),
+  };
+}
+
 function AddDayForm({
   eventId,
+  timezone,
   onError,
 }: {
   eventId: string;
+  timezone: string;
   onError: (e: string | null) => void;
 }) {
   const router = useRouter();
@@ -56,7 +73,10 @@ function AddDayForm({
     e.preventDefault();
     startTransition(async () => {
       try {
-        const result = await createDayAction({ eventId, ...form });
+        const result = await createDayAction({
+          eventId,
+          ...toUtcForm(form, timezone),
+        });
         if (!result.ok) {
           onError(result.error);
         } else {
@@ -162,20 +182,22 @@ function AddDayForm({
 function DayRow({
   day,
   eventId,
+  timezone,
   onError,
 }: {
   day: SerializedDay;
   eventId: string;
+  timezone: string;
   onError: (e: string | null) => void;
 }) {
   const router = useRouter();
   const [editMode, setEditMode] = useState(false);
   const [deleteMode, setDeleteMode] = useState(false);
   const [form, setFormState] = useState<Omit<DayInput, "eventId">>({
-    start: day.start.slice(0, 16),
-    end: day.end.slice(0, 16),
-    startBookings: day.startBookings.slice(0, 16),
-    endBookings: day.endBookings.slice(0, 16),
+    start: utcToZonedInput(day.start, timezone),
+    end: utcToZonedInput(day.end, timezone),
+    startBookings: utcToZonedInput(day.startBookings, timezone),
+    endBookings: utcToZonedInput(day.endBookings, timezone),
   });
   const [isSaving, startSave] = useTransition();
   const [isDeleting, startDelete] = useTransition();
@@ -187,7 +209,11 @@ function DayRow({
     e.preventDefault();
     startSave(async () => {
       try {
-        const result = await updateDayAction({ id: day.id, eventId, ...form });
+        const result = await updateDayAction({
+          id: day.id,
+          eventId,
+          ...toUtcForm(form, timezone),
+        });
         if (!result.ok) {
           onError(result.error);
         } else {
@@ -217,7 +243,10 @@ function DayRow({
     });
   };
 
-  const label = `${day.start.slice(0, 16)} – ${day.end.slice(0, 16)} UTC`;
+  const label = `${utcToZonedInput(day.start, timezone)} – ${utcToZonedInput(
+    day.end,
+    timezone
+  )} (${timezone})`;
 
   if (deleteMode) {
     const affected = day.affectedSessionTitles;
@@ -378,16 +407,20 @@ function DayRow({
 export function EventDaysManager({
   days,
   eventId,
+  timezone,
 }: {
   days: SerializedDay[];
   eventId: string;
+  timezone: string;
 }) {
   const [error, setError] = useState<string | null>(null);
 
   return (
     <section aria-label="Days" className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Days</h2>
-      <p className="text-sm text-gray-500">All times are UTC.</p>
+      <p className="text-sm text-gray-500">
+        All times are in the event timezone ({timezone}).
+      </p>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
       {days.length > 0 && (
@@ -397,13 +430,14 @@ export function EventDaysManager({
               key={day.id}
               day={day}
               eventId={eventId}
+              timezone={timezone}
               onError={setError}
             />
           ))}
         </ul>
       )}
 
-      <AddDayForm eventId={eventId} onError={setError} />
+      <AddDayForm eventId={eventId} timezone={timezone} onError={setError} />
     </section>
   );
 }

--- a/app/admin/events/[id]/event-detail-form.tsx
+++ b/app/admin/events/[id]/event-detail-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useSyncExternalStore } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/app/input";
 import type { Event } from "@/db/repositories/interfaces";
@@ -14,25 +14,11 @@ import {
   SECONDARY_BUTTON,
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
+import { TimezoneSelect } from "@/app/admin/timezone-select";
 
 function toDateInputValue(date: Date): string {
   return date.toISOString().split("T")[0];
 }
-
-// useSyncExternalStore compares snapshots with Object.is, so each getter must
-// return a stable reference — otherwise it re-renders forever (React #185).
-const EMPTY_TIMEZONES: string[] = [];
-let cachedTimezones: string[] | null = null;
-function getClientTimezones(): string[] {
-  if (cachedTimezones === null) {
-    cachedTimezones = Intl.supportedValuesOf("timeZone");
-  }
-  return cachedTimezones;
-}
-function getServerTimezones(): string[] {
-  return EMPTY_TIMEZONES;
-}
-const subscribeTimezones = () => () => {};
 
 export function EventDetailForm({ event }: { event: Event }) {
   const router = useRouter();
@@ -54,11 +40,6 @@ export function EventDetailForm({ event }: { event: Event }) {
   const [deleteMode, setDeleteMode] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
   const [isDeleting, startDelete] = useTransition();
-  const timezones = useSyncExternalStore(
-    subscribeTimezones,
-    getClientTimezones,
-    getServerTimezones
-  );
 
   const set = (key: keyof EventInput, value: string) => {
     setSaveSuccess(false);
@@ -161,19 +142,11 @@ export function EventDetailForm({ event }: { event: Event }) {
             <label htmlFor="ev-timezone" className="text-sm text-gray-600">
               Timezone *
             </label>
-            <Input
+            <TimezoneSelect
               id="ev-timezone"
-              list="timezones"
               value={form.timezone}
-              onChange={(e) => set("timezone", e.target.value)}
-              required
-              className="w-full h-10"
+              onChange={(v) => set("timezone", v)}
             />
-            <datalist id="timezones">
-              {timezones.map((tz) => (
-                <option key={tz} value={tz} />
-              ))}
-            </datalist>
           </div>
           <div className="flex flex-col gap-1">
             <label htmlFor="ev-duration" className="text-sm text-gray-600">

--- a/app/admin/events/[id]/event-detail-form.tsx
+++ b/app/admin/events/[id]/event-detail-form.tsx
@@ -15,6 +15,8 @@ import {
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
 import { TimezoneSelect } from "@/app/admin/timezone-select";
+import { IconPicker } from "@/app/admin/icon-picker";
+import { normalizeEventIconName } from "@/app/event-icons";
 
 function toDateInputValue(date: Date): string {
   return date.toISOString().split("T")[0];
@@ -31,7 +33,7 @@ export function EventDetailForm({ event }: { event: Event }) {
     timezone: event.timezone,
     maxSessionDuration: String(event.maxSessionDuration),
     breakMinutes: String(event.breakMinutes),
-    icon: event.icon ?? "",
+    icon: normalizeEventIconName(event.icon),
   });
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -178,15 +180,11 @@ export function EventDetailForm({ event }: { event: Event }) {
           </div>
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-icon" className="text-sm text-gray-600">
-            Icon
-          </label>
-          <Input
-            id="ev-icon"
+          <span className="text-sm text-gray-600">Icon</span>
+          <IconPicker
+            label="Icon"
             value={form.icon ?? ""}
-            onChange={(e) => set("icon", e.target.value)}
-            placeholder="e.g. AcademicCapIcon"
-            className="w-full h-10"
+            onChange={(v) => set("icon", v)}
           />
         </div>
         <div className="flex items-center gap-3">

--- a/app/admin/events/[id]/event-phases-form.tsx
+++ b/app/admin/events/[id]/event-phases-form.tsx
@@ -8,22 +8,20 @@ import {
   type EventPhasesInput,
 } from "@/app/actions/admin-events";
 import { PRIMARY_BUTTON } from "@/app/admin/buttons";
-
-function toDateTimeInputValue(date: Date | undefined): string {
-  if (!date) return "";
-  return date.toISOString().slice(0, 16);
-}
+import { utcToZonedInput, zonedInputToUtc } from "@/utils/admin-datetime";
 
 type PhasesForm = Omit<EventPhasesInput, "id">;
 
 export function EventPhasesForm({ event }: { event: Event }) {
+  const toInput = (date: Date | undefined) =>
+    utcToZonedInput(date?.toISOString(), event.timezone);
   const [form, setForm] = useState<PhasesForm>({
-    proposalPhaseStart: toDateTimeInputValue(event.proposalPhaseStart),
-    proposalPhaseEnd: toDateTimeInputValue(event.proposalPhaseEnd),
-    votingPhaseStart: toDateTimeInputValue(event.votingPhaseStart),
-    votingPhaseEnd: toDateTimeInputValue(event.votingPhaseEnd),
-    schedulingPhaseStart: toDateTimeInputValue(event.schedulingPhaseStart),
-    schedulingPhaseEnd: toDateTimeInputValue(event.schedulingPhaseEnd),
+    proposalPhaseStart: toInput(event.proposalPhaseStart),
+    proposalPhaseEnd: toInput(event.proposalPhaseEnd),
+    votingPhaseStart: toInput(event.votingPhaseStart),
+    votingPhaseEnd: toInput(event.votingPhaseEnd),
+    schedulingPhaseStart: toInput(event.schedulingPhaseStart),
+    schedulingPhaseEnd: toInput(event.schedulingPhaseEnd),
   });
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -38,7 +36,17 @@ export function EventPhasesForm({ event }: { event: Event }) {
     e.preventDefault();
     setSaveError(null);
     startSave(async () => {
-      const result = await updateEventPhasesAction({ id: event.id, ...form });
+      // Form values are in the event timezone; the action expects UTC.
+      const utcForm = Object.fromEntries(
+        Object.entries(form).map(([key, value]) => [
+          key,
+          zonedInputToUtc(value ?? "", event.timezone),
+        ])
+      ) as PhasesForm;
+      const result = await updateEventPhasesAction({
+        id: event.id,
+        ...utcForm,
+      });
       if (!result.ok) {
         setSaveError(result.error);
       } else {
@@ -51,9 +59,9 @@ export function EventPhasesForm({ event }: { event: Event }) {
     <form onSubmit={handleSave} className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Phases</h2>
       <p className="text-sm text-gray-500">
-        All times are UTC. Leave fields empty to unset a phase. A phase with no
-        end runs until the next phase starts; set an end earlier than the next
-        start to leave an inactive gap.
+        All times are in the event timezone ({event.timezone}). Leave fields
+        empty to unset a phase. A phase with no end runs until the next phase
+        starts; set an end earlier than the next start to leave an inactive gap.
       </p>
       {saveError && <p className="text-sm text-red-600">{saveError}</p>}
 

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -14,6 +14,7 @@ import {
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
 import { DataTable } from "../../data-table";
+import { utcToZonedInput, zonedInputToUtc } from "@/utils/admin-datetime";
 
 export type SessionRow = {
   id: string;
@@ -38,9 +39,12 @@ function joinNames(items: { name: string }[]): string {
   return items.length > 0 ? items.map((i) => i.name).join(", ") : "—";
 }
 
-function timeLabel(session: SessionRow): string {
+function timeLabel(session: SessionRow, timezone: string): string {
   if (!session.startTime || !session.endTime) return "Not scheduled";
-  return `${session.startTime.slice(0, 16)} – ${session.endTime.slice(0, 16)} UTC`;
+  return `${utcToZonedInput(session.startTime, timezone)} – ${utcToZonedInput(
+    session.endTime,
+    timezone
+  )} (${timezone})`;
 }
 
 function flagLabels(session: SessionRow): string[] {
@@ -51,10 +55,11 @@ function flagLabels(session: SessionRow): string[] {
   return flags;
 }
 
-// datetime-local strings are 16 chars (no timezone). Times are treated as UTC,
-// so append "Z" before sending to the server; empty means "not scheduled".
-function toIsoOrNull(value: string): string | null {
-  return value.trim() === "" ? null : `${value}Z`;
+// datetime-local values are edited in the event timezone; the server expects
+// UTC ISO. Empty means "not scheduled".
+function toIsoOrNull(value: string, timezone: string): string | null {
+  const utc = zonedInputToUtc(value, timezone);
+  return utc === "" ? null : `${utc}Z`;
 }
 
 function SessionRsvps({
@@ -146,11 +151,13 @@ function SessionItem({
   session,
   eventGuests,
   eventLocations,
+  timezone,
   onError,
 }: {
   session: SessionRow;
   eventGuests: EventGuest[];
   eventLocations: EventLocation[];
+  timezone: string;
   onError: (e: string | null) => void;
 }) {
   const router = useRouter();
@@ -158,9 +165,11 @@ function SessionItem({
   const [title, setTitle] = useState(session.title);
   const [description, setDescription] = useState(session.description);
   const [startTime, setStartTime] = useState(
-    session.startTime?.slice(0, 16) ?? ""
+    utcToZonedInput(session.startTime, timezone)
   );
-  const [endTime, setEndTime] = useState(session.endTime?.slice(0, 16) ?? "");
+  const [endTime, setEndTime] = useState(
+    utcToZonedInput(session.endTime, timezone)
+  );
   const [capacity, setCapacity] = useState(String(session.capacity));
   const [attendeeScheduled, setAttendeeScheduled] = useState(
     session.attendeeScheduled
@@ -194,8 +203,8 @@ function SessionItem({
   const reset = () => {
     setTitle(session.title);
     setDescription(session.description);
-    setStartTime(session.startTime?.slice(0, 16) ?? "");
-    setEndTime(session.endTime?.slice(0, 16) ?? "");
+    setStartTime(utcToZonedInput(session.startTime, timezone));
+    setEndTime(utcToZonedInput(session.endTime, timezone));
     setCapacity(String(session.capacity));
     setAttendeeScheduled(session.attendeeScheduled);
     setBlocker(session.blocker);
@@ -219,8 +228,8 @@ function SessionItem({
         id: session.id,
         title,
         description,
-        startTime: toIsoOrNull(startTime),
-        endTime: toIsoOrNull(endTime),
+        startTime: toIsoOrNull(startTime, timezone),
+        endTime: toIsoOrNull(endTime, timezone),
         capacity: Number(capacity) || 0,
         attendeeScheduled,
         blocker,
@@ -305,7 +314,7 @@ function SessionItem({
           <div className="space-y-1">
             <p className="font-medium text-gray-900">{session.title}</p>
             <p className="text-sm text-gray-500">
-              {timeLabel(session)} · {joinNames(session.locations)}
+              {timeLabel(session, timezone)} · {joinNames(session.locations)}
             </p>
             <p className="text-sm text-gray-500">
               Hosts: {joinNames(session.hosts)} · {session.numRsvps} RSVPs
@@ -373,7 +382,7 @@ function SessionItem({
             htmlFor={`sess-start-${session.id}`}
             className="text-sm text-gray-600"
           >
-            Start (UTC) — leave empty if not scheduled
+            Start ({timezone}) — leave empty if not scheduled
           </label>
           <Input
             id={`sess-start-${session.id}`}
@@ -388,7 +397,7 @@ function SessionItem({
             htmlFor={`sess-end-${session.id}`}
             className="text-sm text-gray-600"
           >
-            End (UTC)
+            End ({timezone})
           </label>
           <Input
             id={`sess-end-${session.id}`}
@@ -518,6 +527,7 @@ export function EventSessionsManager({
   sessions,
   eventGuests,
   eventLocations,
+  timezone,
   total,
   page,
   pageSize,
@@ -526,6 +536,7 @@ export function EventSessionsManager({
   sessions: SessionRow[];
   eventGuests: EventGuest[];
   eventLocations: EventLocation[];
+  timezone: string;
   total: number;
   page: number;
   pageSize: number;
@@ -536,7 +547,9 @@ export function EventSessionsManager({
   return (
     <section aria-label="Sessions" className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-900">Sessions</h2>
-      <p className="text-sm text-gray-500">All times are UTC.</p>
+      <p className="text-sm text-gray-500">
+        All times are in the event timezone ({timezone}).
+      </p>
       {error && <p className="text-sm text-red-600">{error}</p>}
 
       <DataTable
@@ -553,6 +566,7 @@ export function EventSessionsManager({
             session={s}
             eventGuests={eventGuests}
             eventLocations={eventLocations}
+            timezone={timezone}
             onError={setError}
           />
         )}

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function AdminEventConfigPage({
         <EventPhasesForm event={event} />
       </div>
       <hr className="border-gray-200" />
-      <EventDaysManager days={days} eventId={id} />
+      <EventDaysManager days={days} eventId={id} timezone={event.timezone} />
     </div>
   );
 }

--- a/app/admin/events/[id]/sessions/page.tsx
+++ b/app/admin/events/[id]/sessions/page.tsx
@@ -92,6 +92,7 @@ export default async function AdminEventSessionsPage({
       sessions={sessionRows}
       eventGuests={eventGuests}
       eventLocations={eventLocations}
+      timezone={event.timezone}
       total={total}
       page={page}
       pageSize={PAGE_SIZE}

--- a/app/admin/events/events-manager.tsx
+++ b/app/admin/events/events-manager.tsx
@@ -6,12 +6,13 @@ import { Input } from "@/app/input";
 import type { Event } from "@/db/repositories/interfaces";
 import { createEventAction, type EventInput } from "@/app/actions/admin-events";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/admin/buttons";
-import dynamic from "next/dynamic";
+import { TimezoneSelect } from "@/app/admin/timezone-select";
 
-const ClientTimestamp = dynamic(
-  () => import("@/app/client-only/ClientTimestamp"),
-  { ssr: false }
-);
+// Event start/end are date-only values stored as UTC midnight; format them in
+// UTC so browsers west of Greenwich don't show the previous day.
+function formatEventDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
 
 const DEFAULT_FORM: EventInput = {
   name: "",
@@ -131,12 +132,10 @@ function AddEventForm({
           <label htmlFor="ev-timezone" className="text-sm text-gray-600">
             Timezone *
           </label>
-          <Input
+          <TimezoneSelect
             id="ev-timezone"
             value={form.timezone}
-            onChange={(e) => set("timezone", e.target.value)}
-            required
-            className="w-full h-10"
+            onChange={(v) => set("timezone", v)}
           />
         </div>
         <div className="flex flex-col gap-1">
@@ -201,8 +200,7 @@ export function EventsManager({ events }: { events: Event[] }) {
                   {event.name}
                 </p>
                 <p className="text-sm text-gray-500">
-                  <ClientTimestamp timestamp={event.start} /> –{" "}
-                  <ClientTimestamp timestamp={event.end} />
+                  {formatEventDate(event.start)} – {formatEventDate(event.end)}
                   {" · "}
                   {event.timezone}
                 </p>

--- a/app/admin/icon-picker.tsx
+++ b/app/admin/icon-picker.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import clsx from "clsx";
+import { NoSymbolIcon } from "@heroicons/react/24/outline";
+import { EVENT_ICONS, eventIconLabel } from "@/app/event-icons";
+
+export function IconPicker({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className="flex flex-wrap gap-1.5"
+    >
+      <IconOption
+        name="No icon"
+        selected={value === ""}
+        onSelect={() => onChange("")}
+      >
+        <NoSymbolIcon className="h-5 w-5 text-gray-300" />
+      </IconOption>
+      {Object.entries(EVENT_ICONS).map(([name, Icon]) => (
+        <IconOption
+          key={name}
+          name={eventIconLabel(name)}
+          selected={value === name}
+          onSelect={() => onChange(name)}
+        >
+          <Icon className="h-5 w-5" />
+        </IconOption>
+      ))}
+    </div>
+  );
+}
+
+function IconOption({
+  name,
+  selected,
+  onSelect,
+  children,
+}: {
+  name: string;
+  selected: boolean;
+  onSelect: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      aria-label={name}
+      title={name}
+      onClick={onSelect}
+      className={clsx(
+        selected
+          ? "border-rose-400 bg-rose-50 text-rose-500"
+          : "border-gray-300 text-gray-500 hover:bg-gray-100",
+        "flex h-10 w-10 items-center justify-center rounded-md border"
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/app/admin/timezone-select.tsx
+++ b/app/admin/timezone-select.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+// useSyncExternalStore compares snapshots with Object.is, so each getter must
+// return a stable reference — otherwise it re-renders forever (React #185).
+const EMPTY_TIMEZONES: string[] = [];
+let cachedTimezones: string[] | null = null;
+function getClientTimezones(): string[] {
+  if (cachedTimezones === null) {
+    // Older runtimes lack supportedValuesOf; the options below still offer
+    // UTC and the current value, so the select stays usable.
+    cachedTimezones =
+      typeof Intl.supportedValuesOf === "function"
+        ? Intl.supportedValuesOf("timeZone")
+        : EMPTY_TIMEZONES;
+  }
+  return cachedTimezones;
+}
+function getServerTimezones(): string[] {
+  return EMPTY_TIMEZONES;
+}
+const subscribeTimezones = () => () => {};
+
+export function TimezoneSelect({
+  id,
+  value,
+  onChange,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const timezones = useSyncExternalStore(
+    subscribeTimezones,
+    getClientTimezones,
+    getServerTimezones
+  );
+  // Always offer UTC and the current value (which may be an alias or a zone
+  // missing from this browser's list) so the select never shows a blank —
+  // including on the server render, where the Intl list is empty.
+  const options = Array.from(new Set(["UTC", value, ...timezones])).filter(
+    Boolean
+  );
+
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      required
+      className="w-full h-10 rounded-md border border-gray-300 bg-white px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-rose-400"
+    >
+      {options.map((tz) => (
+        <option key={tz} value={tz}>
+          {tz}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/client-only/ClientTimestamp.tsx
+++ b/app/client-only/ClientTimestamp.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-export default function ClientTimestamp({ timestamp }: { timestamp: Date }) {
-  return (
-    <time dateTime={timestamp.toISOString()}>
-      {timestamp.toLocaleDateString()}
-    </time>
-  );
-}

--- a/app/event-icons.ts
+++ b/app/event-icons.ts
@@ -1,0 +1,94 @@
+import {
+  AcademicCapIcon,
+  BeakerIcon,
+  BoltIcon,
+  BookOpenIcon,
+  BriefcaseIcon,
+  BuildingOfficeIcon,
+  CakeIcon,
+  CalendarIcon,
+  ChatBubbleLeftIcon,
+  CloudIcon,
+  CodeBracketIcon,
+  CogIcon,
+  CommandLineIcon,
+  ComputerDesktopIcon,
+  CpuChipIcon,
+  FireIcon,
+  GlobeAltIcon,
+  HeartIcon,
+  HomeIcon,
+  MicrophoneIcon,
+  MusicalNoteIcon,
+  PaintBrushIcon,
+  RocketLaunchIcon,
+  SparklesIcon,
+  StarIcon,
+  SunIcon,
+  TrophyIcon,
+  UserGroupIcon,
+  WrenchIcon,
+} from "@heroicons/react/24/outline";
+import { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+
+export type HeroIcon = ForwardRefExoticComponent<
+  Omit<SVGProps<SVGSVGElement>, "ref"> & {
+    title?: string;
+    titleId?: string;
+  } & RefAttributes<SVGSVGElement>
+>;
+
+export const EVENT_ICONS: Record<string, HeroIcon> = {
+  AcademicCapIcon,
+  BeakerIcon,
+  BoltIcon,
+  BookOpenIcon,
+  BriefcaseIcon,
+  BuildingOfficeIcon,
+  CakeIcon,
+  CalendarIcon,
+  ChatBubbleLeftIcon,
+  CloudIcon,
+  CodeBracketIcon,
+  CogIcon,
+  CommandLineIcon,
+  ComputerDesktopIcon,
+  CpuChipIcon,
+  FireIcon,
+  GlobeAltIcon,
+  HeartIcon,
+  HomeIcon,
+  MicrophoneIcon,
+  MusicalNoteIcon,
+  PaintBrushIcon,
+  RocketLaunchIcon,
+  SparklesIcon,
+  StarIcon,
+  SunIcon,
+  TrophyIcon,
+  UserGroupIcon,
+  WrenchIcon,
+};
+
+export function isEventIconName(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(EVENT_ICONS, name);
+}
+
+/**
+ * Icons used to be stored as free text, so the DB may hold values outside
+ * EVENT_ICONS. Those never rendered anywhere; treat them as "no icon" so
+ * forms don't re-submit them and trip the server-side validation.
+ */
+export function normalizeEventIconName(
+  name: string | null | undefined
+): string {
+  return name && isEventIconName(name) ? name : "";
+}
+
+/** "AcademicCapIcon" -> "Academic Cap" */
+export function eventIconLabel(name: string): string {
+  return name
+    .replace(/Icon$/, "")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1 $2");
+}

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -386,6 +386,34 @@ describe("event actions", () => {
       });
       expect(!result.ok && result.error).toMatch(/letter or number/i);
     });
+
+    it("persists a known icon", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        icon: "RocketLaunchIcon",
+      });
+      expect(result.ok).toBe(true);
+      const event = await getRepositories().events.findByName("Test Event");
+      expect(event?.icon).toBe("RocketLaunchIcon");
+    });
+
+    it("allows no icon", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        icon: "",
+      });
+      expect(result.ok).toBe(true);
+      const event = await getRepositories().events.findByName("Test Event");
+      expect(event?.icon).toBeUndefined();
+    });
+
+    it("rejects an unknown icon", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        icon: "NoSuchIcon",
+      });
+      expect(!result.ok && result.error).toMatch(/icon/i);
+    });
   });
 
   describe("updateEventAction", () => {

--- a/tests/unit/admin-datetime.test.ts
+++ b/tests/unit/admin-datetime.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { utcToZonedInput, zonedInputToUtc } from "@/utils/admin-datetime";
+
+// ── utcToZonedInput ──────────────────────────────────────────────────────────
+
+describe("utcToZonedInput", () => {
+  it("converts a full UTC ISO string into the zone's datetime-local value", () =>
+    expect(utcToZonedInput("2026-10-01T09:00:00.000Z", "Europe/Berlin")).toBe(
+      "2026-10-01T11:00"
+    ));
+
+  it("keeps UTC values unchanged for the UTC zone", () =>
+    expect(utcToZonedInput("2026-10-01T09:00:00.000Z", "UTC")).toBe(
+      "2026-10-01T09:00"
+    ));
+
+  it("handles negative offsets crossing a date boundary", () =>
+    expect(
+      utcToZonedInput("2026-10-01T02:00:00.000Z", "America/New_York")
+    ).toBe("2026-09-30T22:00"));
+
+  it("applies DST-aware offsets (Berlin winter = +1)", () =>
+    expect(utcToZonedInput("2026-01-15T09:00:00.000Z", "Europe/Berlin")).toBe(
+      "2026-01-15T10:00"
+    ));
+
+  it("returns empty string for null/empty input", () => {
+    expect(utcToZonedInput(null, "Europe/Berlin")).toBe("");
+    expect(utcToZonedInput("", "Europe/Berlin")).toBe("");
+  });
+
+  it("falls back to UTC for an invalid timezone", () =>
+    expect(utcToZonedInput("2026-10-01T09:00:00.000Z", "Not/AZone")).toBe(
+      "2026-10-01T09:00"
+    ));
+});
+
+// ── zonedInputToUtc ──────────────────────────────────────────────────────────
+
+describe("zonedInputToUtc", () => {
+  it("converts a zoned datetime-local value to a UTC datetime-local value", () =>
+    expect(zonedInputToUtc("2026-10-01T11:00", "Europe/Berlin")).toBe(
+      "2026-10-01T09:00"
+    ));
+
+  it("keeps UTC values unchanged for the UTC zone", () =>
+    expect(zonedInputToUtc("2026-10-01T09:00", "UTC")).toBe(
+      "2026-10-01T09:00"
+    ));
+
+  it("handles negative offsets crossing a date boundary", () =>
+    expect(zonedInputToUtc("2026-09-30T22:00", "America/New_York")).toBe(
+      "2026-10-01T02:00"
+    ));
+
+  it("returns empty string for empty input", () =>
+    expect(zonedInputToUtc("", "Europe/Berlin")).toBe(""));
+
+  it("returns empty string for an unparseable value", () =>
+    expect(zonedInputToUtc("not-a-date", "Europe/Berlin")).toBe(""));
+
+  it("falls back to UTC for an invalid timezone (round-trips with utcToZonedInput)", () =>
+    expect(zonedInputToUtc("2026-10-01T09:00", "Not/AZone")).toBe(
+      "2026-10-01T09:00"
+    ));
+
+  it("round-trips through utcToZonedInput across DST boundaries", () => {
+    const utcIso = "2026-03-29T05:30:00.000Z";
+    const zoned = utcToZonedInput(utcIso, "Europe/Berlin");
+    expect(zonedInputToUtc(zoned, "Europe/Berlin")).toBe("2026-03-29T05:30");
+  });
+});

--- a/tests/unit/event-icons.test.ts
+++ b/tests/unit/event-icons.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { normalizeEventIconName } from "@/app/event-icons";
+
+describe("normalizeEventIconName", () => {
+  it("keeps a known icon name", () => {
+    expect(normalizeEventIconName("RocketLaunchIcon")).toBe("RocketLaunchIcon");
+  });
+
+  it("maps a legacy free-text value to no icon", () => {
+    expect(normalizeEventIconName("rocket emoji 🚀")).toBe("");
+  });
+
+  it("maps null to no icon", () => {
+    expect(normalizeEventIconName(null)).toBe("");
+  });
+});

--- a/utils/admin-datetime.ts
+++ b/utils/admin-datetime.ts
@@ -1,0 +1,36 @@
+import { DateTime } from "luxon";
+
+// Admin forms edit times in the event's timezone, but the server actions and
+// the database speak UTC. These helpers convert between the two at the client
+// boundary. An unrecognized timezone falls back to UTC in BOTH directions so
+// values always round-trip without shifting.
+
+const INPUT_FORMAT = "yyyy-MM-dd'T'HH:mm";
+
+/**
+ * UTC ISO string → `datetime-local` input value ("yyyy-MM-ddTHH:mm") in the
+ * given IANA timezone. Returns "" for null/empty/unparseable input.
+ */
+export function utcToZonedInput(
+  utcIso: string | null | undefined,
+  timezone: string
+): string {
+  if (!utcIso) return "";
+  const dt = DateTime.fromISO(utcIso, { zone: "utc" });
+  if (!dt.isValid) return "";
+  const zoned = dt.setZone(timezone);
+  return (zoned.isValid ? zoned : dt).toFormat(INPUT_FORMAT);
+}
+
+/**
+ * `datetime-local` input value in the given IANA timezone → UTC
+ * "yyyy-MM-ddTHH:mm" (the wire format the admin actions expect). Returns ""
+ * for empty/unparseable input.
+ */
+export function zonedInputToUtc(value: string, timezone: string): string {
+  if (!value.trim()) return "";
+  let dt = DateTime.fromISO(value, { zone: timezone });
+  if (!dt.isValid) dt = DateTime.fromISO(value, { zone: "utc" });
+  if (!dt.isValid) return "";
+  return dt.toUTC().toFormat(INPUT_FORMAT);
+}


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [39ad995](https://github.com/LWCW-Europe/schellingboard/pull/548/commits/39ad995ec1ad4d7950a7f89c118dfc2ebd0ac2cd).

PRs:
* #549
* ➡️ #548 (this PR, depends on the ones below ⬇️)
* #547

---

## Description

Replace the free-text Heroicon-name input with a grid picker so admins
don't need to know valid icon names. Extract the icon map into a shared
module and reject unknown icon names server-side.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=39ad995ec1ad4d7950a7f89c118dfc2ebd0ac2cd -->