### PR TITLE
feat(admin): create sessions from the admin UI

### DIFF
--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -41,10 +41,59 @@ function parseTimeRange(
   return { start, end };
 }
 
-function revalidateEventPaths(eventId: string) {
+// The attendee-facing schedule fetches the session list in the shared
+// [eventSlug] layout (see app/(site)/[eventSlug]/session-actions.ts), so the
+// public layout must be revalidated alongside the admin pages.
+async function revalidateEventPaths(eventId: string) {
   revalidatePath("/admin");
   revalidatePath("/admin/events");
   revalidatePath(`/admin/events/${eventId}`);
+  const event = await getRepositories().events.findById(eventId);
+  if (event) revalidatePath(`/${event.slug}`, "layout");
+}
+
+export type AdminSessionCreateInput = Omit<AdminSessionInput, "id"> & {
+  eventId: string;
+};
+
+export async function adminCreateSessionAction(
+  input: AdminSessionCreateInput
+): Promise<AdminActionResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const title = input.title.trim();
+  if (!title) return { ok: false, error: "Title is required" };
+
+  const range = parseTimeRange(input.startTime, input.endTime);
+  if ("error" in range) return { ok: false, error: range.error };
+
+  if (!Number.isInteger(input.capacity) || input.capacity < 0)
+    return { ok: false, error: "Capacity must be a non-negative whole number" };
+
+  const { sessions, events } = getRepositories();
+  const event = await events.findById(input.eventId);
+  if (!event) return { ok: false, error: "Event not found" };
+
+  try {
+    await sessions.create({
+      title,
+      description: input.description.trim(),
+      startTime: range.start,
+      endTime: range.end,
+      capacity: input.capacity,
+      adminManaged: input.adminManaged,
+      blocker: input.blocker,
+      closed: input.closed,
+      eventId: input.eventId,
+      hostIds: input.hostIds,
+      locationIds: input.locationIds,
+    });
+  } catch {
+    return { ok: false, error: "Failed to create session" };
+  }
+
+  await revalidateEventPaths(input.eventId);
+  return { ok: true };
 }
 
 export async function adminUpdateSessionAction(
@@ -82,7 +131,7 @@ export async function adminUpdateSessionAction(
     return { ok: false, error: "Failed to update session" };
   }
 
-  revalidateEventPaths(session.eventId);
+  await revalidateEventPaths(session.eventId);
   return { ok: true };
 }
 
@@ -101,6 +150,6 @@ export async function adminDeleteSessionAction(input: {
     return { ok: false, error: "Failed to delete session" };
   }
 
-  revalidateEventPaths(session.eventId);
+  await revalidateEventPaths(session.eventId);
   return { ok: true };
 }

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Input } from "@/app/input";
 import {
+  adminCreateSessionAction,
   adminUpdateSessionAction,
   adminDeleteSessionAction,
 } from "@/app/actions/admin-sessions";
@@ -60,6 +61,35 @@ function flagLabels(session: SessionRow): string[] {
 function toIsoOrNull(value: string, timezone: string): string | null {
   const utc = zonedInputToUtc(value, timezone);
   return utc === "" ? null : `${utc}Z`;
+}
+
+type SessionFormValues = {
+  title: string;
+  description: string;
+  startTime: string;
+  endTime: string;
+  capacity: string;
+  adminManaged: boolean;
+  blocker: boolean;
+  closed: boolean;
+  hostIds: string[];
+  locationIds: string[];
+};
+
+// Shared shape of the create/update action payloads (everything but the ids).
+function toActionInput(values: SessionFormValues, timezone: string) {
+  return {
+    title: values.title,
+    description: values.description,
+    startTime: toIsoOrNull(values.startTime, timezone),
+    endTime: toIsoOrNull(values.endTime, timezone),
+    capacity: Number(values.capacity) || 0,
+    adminManaged: values.adminManaged,
+    blocker: values.blocker,
+    closed: values.closed,
+    hostIds: values.hostIds,
+    locationIds: values.locationIds,
+  };
 }
 
 function SessionRsvps({
@@ -147,6 +177,229 @@ function SessionRsvps({
   );
 }
 
+function SessionForm({
+  initial,
+  idPrefix,
+  timezone,
+  hostCandidates,
+  locationCandidates,
+  submitLabel,
+  pendingLabel,
+  isPending,
+  onSubmit,
+  onCancel,
+}: {
+  initial: SessionFormValues;
+  idPrefix: string;
+  timezone: string;
+  hostCandidates: EventGuest[];
+  locationCandidates: EventLocation[];
+  submitLabel: string;
+  pendingLabel: string;
+  isPending: boolean;
+  onSubmit: (values: SessionFormValues) => void;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState(initial.title);
+  const [description, setDescription] = useState(initial.description);
+  const [startTime, setStartTime] = useState(initial.startTime);
+  const [endTime, setEndTime] = useState(initial.endTime);
+  const [capacity, setCapacity] = useState(initial.capacity);
+  const [adminManaged, setAdminManaged] = useState(initial.adminManaged);
+  const [blocker, setBlocker] = useState(initial.blocker);
+  const [closed, setClosed] = useState(initial.closed);
+  const [hostIds, setHostIds] = useState<string[]>(initial.hostIds);
+  const [locationIds, setLocationIds] = useState<string[]>(initial.locationIds);
+
+  const toggle = (
+    set: React.Dispatch<React.SetStateAction<string[]>>,
+    id: string
+  ) =>
+    set((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      title,
+      description,
+      startTime,
+      endTime,
+      capacity,
+      adminManaged,
+      blocker,
+      closed,
+      hostIds,
+      locationIds,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label htmlFor={`${idPrefix}-title`} className="text-sm text-gray-600">
+          Title *
+        </label>
+        <Input
+          id={`${idPrefix}-title`}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="w-full h-10"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor={`${idPrefix}-desc`} className="text-sm text-gray-600">
+          Description
+        </label>
+        <textarea
+          id={`${idPrefix}-desc`}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor={`${idPrefix}-start`}
+            className="text-sm text-gray-600"
+          >
+            Start ({timezone}) — leave empty if not scheduled
+          </label>
+          <Input
+            id={`${idPrefix}-start`}
+            type="datetime-local"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="w-full h-10"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label htmlFor={`${idPrefix}-end`} className="text-sm text-gray-600">
+            End ({timezone})
+          </label>
+          <Input
+            id={`${idPrefix}-end`}
+            type="datetime-local"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+            className="w-full h-10"
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`${idPrefix}-capacity`}
+          className="text-sm text-gray-600"
+        >
+          Capacity
+        </label>
+        <Input
+          id={`${idPrefix}-capacity`}
+          type="number"
+          min="0"
+          value={capacity}
+          onChange={(e) => setCapacity(e.target.value)}
+          className="w-full h-10"
+        />
+      </div>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Flags</legend>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={blocker}
+            onChange={(e) => setBlocker(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Blocker
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={closed}
+            onChange={(e) => setClosed(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Closed
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={adminManaged}
+            onChange={(e) => setAdminManaged(e.target.checked)}
+            className="h-4 w-4 cursor-pointer"
+          />
+          Admin-managed
+        </label>
+      </fieldset>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Hosts</legend>
+        {hostCandidates.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No guests assigned to this event yet.
+          </p>
+        ) : (
+          hostCandidates.map((g) => (
+            <label
+              key={g.id}
+              className="flex items-center gap-2 text-sm text-gray-700"
+            >
+              <input
+                type="checkbox"
+                checked={hostIds.includes(g.id)}
+                onChange={() => toggle(setHostIds, g.id)}
+                aria-label={`Host ${g.name}`}
+                className="h-4 w-4 cursor-pointer"
+              />
+              {g.name}
+            </label>
+          ))
+        )}
+      </fieldset>
+      <fieldset className="flex flex-col gap-1">
+        <legend className="text-sm text-gray-600">Locations</legend>
+        {locationCandidates.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No locations assigned to this event yet.
+          </p>
+        ) : (
+          locationCandidates.map((l) => (
+            <label
+              key={l.id}
+              className="flex items-center gap-2 text-sm text-gray-700"
+            >
+              <input
+                type="checkbox"
+                checked={locationIds.includes(l.id)}
+                onChange={() => toggle(setLocationIds, l.id)}
+                aria-label={`Location ${l.name}`}
+                className="h-4 w-4 cursor-pointer"
+              />
+              {l.name}
+            </label>
+          ))
+        )}
+      </fieldset>
+      <div className="flex gap-2">
+        <button type="submit" disabled={isPending} className={PRIMARY_BUTTON}>
+          {isPending ? pendingLabel : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className={SECONDARY_BUTTON}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
 function SessionItem({
   session,
   eventGuests,
@@ -162,24 +415,6 @@ function SessionItem({
 }) {
   const router = useRouter();
   const [editMode, setEditMode] = useState(false);
-  const [title, setTitle] = useState(session.title);
-  const [description, setDescription] = useState(session.description);
-  const [startTime, setStartTime] = useState(
-    utcToZonedInput(session.startTime, timezone)
-  );
-  const [endTime, setEndTime] = useState(
-    utcToZonedInput(session.endTime, timezone)
-  );
-  const [capacity, setCapacity] = useState(String(session.capacity));
-  const [adminManaged, setAdminManaged] = useState(session.adminManaged);
-  const [blocker, setBlocker] = useState(session.blocker);
-  const [closed, setClosed] = useState(session.closed);
-  const [hostIds, setHostIds] = useState<string[]>(
-    session.hosts.map((h) => h.id)
-  );
-  const [locationIds, setLocationIds] = useState<string[]>(
-    session.locations.map((l) => l.id)
-  );
   const [isSaving, startSave] = useTransition();
   const [deleteMode, setDeleteMode] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
@@ -198,42 +433,11 @@ function SessionItem({
     ),
   ];
 
-  const reset = () => {
-    setTitle(session.title);
-    setDescription(session.description);
-    setStartTime(utcToZonedInput(session.startTime, timezone));
-    setEndTime(utcToZonedInput(session.endTime, timezone));
-    setCapacity(String(session.capacity));
-    setAdminManaged(session.adminManaged);
-    setBlocker(session.blocker);
-    setClosed(session.closed);
-    setHostIds(session.hosts.map((h) => h.id));
-    setLocationIds(session.locations.map((l) => l.id));
-  };
-
-  const toggle = (
-    set: React.Dispatch<React.SetStateAction<string[]>>,
-    id: string
-  ) =>
-    set((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    );
-
-  const handleSave = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSave = (values: SessionFormValues) => {
     startSave(async () => {
       const result = await adminUpdateSessionAction({
         id: session.id,
-        title,
-        description,
-        startTime: toIsoOrNull(startTime, timezone),
-        endTime: toIsoOrNull(endTime, timezone),
-        capacity: Number(capacity) || 0,
-        adminManaged,
-        blocker,
-        closed,
-        hostIds,
-        locationIds,
+        ...toActionInput(values, timezone),
       });
       if (!result.ok) {
         onError(result.error);
@@ -344,184 +548,115 @@ function SessionItem({
   }
 
   return (
-    <form onSubmit={handleSave} className="space-y-3">
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor={`sess-title-${session.id}`}
-          className="text-sm text-gray-600"
-        >
-          Title *
-        </label>
-        <Input
-          id={`sess-title-${session.id}`}
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          required
-          className="w-full h-10"
-        />
-      </div>
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor={`sess-desc-${session.id}`}
-          className="text-sm text-gray-600"
-        >
-          Description
-        </label>
-        <textarea
-          id={`sess-desc-${session.id}`}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
-        />
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`sess-start-${session.id}`}
-            className="text-sm text-gray-600"
-          >
-            Start ({timezone}) — leave empty if not scheduled
-          </label>
-          <Input
-            id={`sess-start-${session.id}`}
-            type="datetime-local"
-            value={startTime}
-            onChange={(e) => setStartTime(e.target.value)}
-            className="w-full h-10"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label
-            htmlFor={`sess-end-${session.id}`}
-            className="text-sm text-gray-600"
-          >
-            End ({timezone})
-          </label>
-          <Input
-            id={`sess-end-${session.id}`}
-            type="datetime-local"
-            value={endTime}
-            onChange={(e) => setEndTime(e.target.value)}
-            className="w-full h-10"
-          />
-        </div>
-      </div>
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor={`sess-capacity-${session.id}`}
-          className="text-sm text-gray-600"
-        >
-          Capacity
-        </label>
-        <Input
-          id={`sess-capacity-${session.id}`}
-          type="number"
-          min="0"
-          value={capacity}
-          onChange={(e) => setCapacity(e.target.value)}
-          className="w-full h-10"
-        />
-      </div>
-      <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Flags</legend>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={blocker}
-            onChange={(e) => setBlocker(e.target.checked)}
-            className="h-4 w-4 cursor-pointer"
-          />
-          Blocker
-        </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={closed}
-            onChange={(e) => setClosed(e.target.checked)}
-            className="h-4 w-4 cursor-pointer"
-          />
-          Closed
-        </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={adminManaged}
-            onChange={(e) => setAdminManaged(e.target.checked)}
-            className="h-4 w-4 cursor-pointer"
-          />
-          Admin-managed
-        </label>
-      </fieldset>
-      <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Hosts</legend>
-        {hostCandidates.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            No guests assigned to this event yet.
-          </p>
-        ) : (
-          hostCandidates.map((g) => (
-            <label
-              key={g.id}
-              className="flex items-center gap-2 text-sm text-gray-700"
-            >
-              <input
-                type="checkbox"
-                checked={hostIds.includes(g.id)}
-                onChange={() => toggle(setHostIds, g.id)}
-                aria-label={`Host ${g.name}`}
-                className="h-4 w-4 cursor-pointer"
-              />
-              {g.name}
-            </label>
-          ))
-        )}
-      </fieldset>
-      <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Locations</legend>
-        {locationCandidates.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            No locations assigned to this event yet.
-          </p>
-        ) : (
-          locationCandidates.map((l) => (
-            <label
-              key={l.id}
-              className="flex items-center gap-2 text-sm text-gray-700"
-            >
-              <input
-                type="checkbox"
-                checked={locationIds.includes(l.id)}
-                onChange={() => toggle(setLocationIds, l.id)}
-                aria-label={`Location ${l.name}`}
-                className="h-4 w-4 cursor-pointer"
-              />
-              {l.name}
-            </label>
-          ))
-        )}
-      </fieldset>
-      <div className="flex gap-2">
-        <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
-          {isSaving ? "Saving..." : "Save"}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            reset();
-            setEditMode(false);
-            onError(null);
-          }}
-          disabled={isSaving}
-          className={SECONDARY_BUTTON}
-        >
-          Cancel
-        </button>
-      </div>
-    </form>
+    <SessionForm
+      initial={{
+        title: session.title,
+        description: session.description,
+        startTime: utcToZonedInput(session.startTime, timezone),
+        endTime: utcToZonedInput(session.endTime, timezone),
+        capacity: String(session.capacity),
+        adminManaged: session.adminManaged,
+        blocker: session.blocker,
+        closed: session.closed,
+        hostIds: session.hosts.map((h) => h.id),
+        locationIds: session.locations.map((l) => l.id),
+      }}
+      idPrefix={`sess-${session.id}`}
+      timezone={timezone}
+      hostCandidates={hostCandidates}
+      locationCandidates={locationCandidates}
+      submitLabel="Save"
+      pendingLabel="Saving..."
+      isPending={isSaving}
+      onSubmit={handleSave}
+      onCancel={() => {
+        setEditMode(false);
+        onError(null);
+      }}
+    />
+  );
+}
+
+// Sessions created by an admin are admin-managed by default: they stay under
+// admin control instead of being editable by their hosts.
+const EMPTY_SESSION: SessionFormValues = {
+  title: "",
+  description: "",
+  startTime: "",
+  endTime: "",
+  capacity: "0",
+  adminManaged: true,
+  blocker: false,
+  closed: false,
+  hostIds: [],
+  locationIds: [],
+};
+
+function AddSession({
+  eventId,
+  eventGuests,
+  eventLocations,
+  timezone,
+  onError,
+}: {
+  eventId: string;
+  eventGuests: EventGuest[];
+  eventLocations: EventLocation[];
+  timezone: string;
+  onError: (e: string | null) => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isCreating, startCreate] = useTransition();
+
+  const handleCreate = (values: SessionFormValues) => {
+    startCreate(async () => {
+      const result = await adminCreateSessionAction({
+        eventId,
+        ...toActionInput(values, timezone),
+      });
+      if (!result.ok) {
+        onError(result.error);
+      } else {
+        onError(null);
+        setOpen(false);
+        router.refresh();
+      }
+    });
+  };
+
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)} className={PRIMARY_BUTTON}>
+        Add session
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-3 border border-gray-200 rounded-md p-4">
+      <h3 className="font-medium text-gray-900">New session</h3>
+      <SessionForm
+        initial={EMPTY_SESSION}
+        idPrefix="sess-new"
+        timezone={timezone}
+        hostCandidates={eventGuests}
+        locationCandidates={eventLocations}
+        submitLabel="Create"
+        pendingLabel="Creating..."
+        isPending={isCreating}
+        onSubmit={handleCreate}
+        onCancel={() => {
+          setOpen(false);
+          onError(null);
+        }}
+      />
+    </div>
   );
 }
 
 export function EventSessionsManager({
+  eventId,
   sessions,
   eventGuests,
   eventLocations,
@@ -531,6 +666,7 @@ export function EventSessionsManager({
   pageSize,
   query,
 }: {
+  eventId: string;
   sessions: SessionRow[];
   eventGuests: EventGuest[];
   eventLocations: EventLocation[];
@@ -549,6 +685,14 @@ export function EventSessionsManager({
         All times are in the event timezone ({timezone}).
       </p>
       {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <AddSession
+        eventId={eventId}
+        eventGuests={eventGuests}
+        eventLocations={eventLocations}
+        timezone={timezone}
+        onError={setError}
+      />
 
       <DataTable
         rows={sessions}

--- a/app/admin/events/[id]/sessions/page.tsx
+++ b/app/admin/events/[id]/sessions/page.tsx
@@ -89,6 +89,7 @@ export default async function AdminEventSessionsPage({
 
   return (
     <EventSessionsManager
+      eventId={id}
       sessions={sessionRows}
       eventGuests={eventGuests}
       eventLocations={eventLocations}

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1288,6 +1288,39 @@ test.describe("Admin UI sessions", () => {
     ).toBeVisible();
   });
 
+  test("creates a session and deletes it again", async ({ page }) => {
+    await adminLogin(page);
+    await page.goto("/admin/events");
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Conference Alpha" })
+      .getByRole("link", { name: "Manage" })
+      .click();
+    await openEventTab(page, "Sessions");
+
+    const sessions = page.getByRole("region", { name: "Sessions" });
+    const title = `Lunch Blocker ${Date.now()}`;
+
+    await sessions.getByRole("button", { name: "Add session" }).click();
+    await sessions.getByLabel("Title *").fill(title);
+    await sessions.getByLabel("Blocker").check();
+    await sessions.getByRole("button", { name: "Create", exact: true }).click();
+
+    // Search for the unique title so pagination cannot hide the new row.
+    await sessions.getByRole("searchbox", { name: "Search" }).fill(title);
+    await sessions.getByRole("button", { name: "Search" }).click();
+    const row = sessions.getByRole("listitem").filter({ hasText: title });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("blocker");
+    await expect(row).toContainText("admin-managed");
+
+    // Clean up so the shared seed stays stable for other tests.
+    await row.getByRole("button", { name: /^Delete/ }).click();
+    await sessions.getByLabel("Type the session title to confirm").fill(title);
+    await sessions.getByRole("button", { name: "Confirm delete" }).click();
+    await expect(row).toHaveCount(0);
+  });
+
   test("deletes a session via named confirm", async ({ page }) => {
     await adminLogin(page);
     await page.goto("/admin/events");

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -24,6 +24,7 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+import { revalidatePath } from "next/cache";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -34,6 +35,7 @@ import {
 import { getRepositories } from "@/db/container";
 import { createAdminAuthCookie } from "@/utils/auth";
 import {
+  adminCreateSessionAction,
   adminUpdateSessionAction,
   adminDeleteSessionAction,
 } from "@/app/actions/admin-sessions";
@@ -44,6 +46,243 @@ async function loginAsAdmin() {
   const c = await createAdminAuthCookie();
   cookieJar.set(c.name, c.value);
 }
+
+describe("adminCreateSessionAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("creates a session with all fields, hosts and locations", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host One" });
+    const loc = await createLocation({ name: "Room A" });
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Lunch",
+      description: "Meal time",
+      startTime: "2030-01-01T12:30:00.000Z",
+      endTime: "2030-01-01T14:00:00.000Z",
+      capacity: 0,
+      adminManaged: true,
+      blocker: true,
+      closed: false,
+      hostIds: [host.id],
+      locationIds: [loc.id],
+    });
+    expect(result.ok).toBe(true);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(1);
+    const created = sessions[0];
+    expect(created.title).toBe("Lunch");
+    expect(created.description).toBe("Meal time");
+    expect(created.capacity).toBe(0);
+    expect(created.adminManaged).toBe(true);
+    expect(created.blocker).toBe(true);
+    expect(created.closed).toBe(false);
+    expect(created.startTime?.toISOString()).toBe("2030-01-01T12:30:00.000Z");
+    expect(created.endTime?.toISOString()).toBe("2030-01-01T14:00:00.000Z");
+    expect(created.hosts.map((h) => h.id)).toEqual([host.id]);
+    expect(created.locations.map((l) => l.id)).toEqual([loc.id]);
+  });
+
+  it("creates an unscheduled session without hosts or locations", async () => {
+    const event = await createEvent();
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Untimed",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 10,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].startTime).toBeUndefined();
+    expect(sessions[0].endTime).toBeUndefined();
+    expect(sessions[0].hosts).toHaveLength(0);
+    expect(sessions[0].locations).toHaveLength(0);
+  });
+
+  it("rejects an empty title", async () => {
+    const event = await createEvent();
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "   ",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(!result.ok && result.error).toBe("Title is required");
+  });
+
+  it("rejects when only one of startTime/endTime is set or the range is invalid", async () => {
+    const event = await createEvent();
+    const base = {
+      eventId: event.id,
+      title: "Title",
+      description: "",
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    };
+
+    const startOnly = await adminCreateSessionAction({
+      ...base,
+      startTime: "2030-01-01T10:00:00.000Z",
+      endTime: null,
+    });
+    expect(!startOnly.ok && startOnly.error).toBe(
+      "Start and end time must both be set or both empty"
+    );
+
+    const reversed = await adminCreateSessionAction({
+      ...base,
+      startTime: "2030-01-01T11:00:00.000Z",
+      endTime: "2030-01-01T10:00:00.000Z",
+    });
+    expect(!reversed.ok && reversed.error).toBe(
+      "End time must be after start time"
+    );
+
+    expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("rejects a capacity that is not a non-negative whole number", async () => {
+    const event = await createEvent();
+
+    for (const capacity of [-1, 2.5, Number.NaN]) {
+      const result = await adminCreateSessionAction({
+        eventId: event.id,
+        title: "Title",
+        description: "",
+        startTime: null,
+        endTime: null,
+        capacity,
+        adminManaged: true,
+        blocker: false,
+        closed: false,
+        hostIds: [],
+        locationIds: [],
+      });
+      expect(!result.ok && result.error).toBe(
+        "Capacity must be a non-negative whole number"
+      );
+    }
+  });
+
+  it("errors for an unknown event", async () => {
+    const result = await adminCreateSessionAction({
+      eventId: "no-such-event",
+      title: "Title",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+  });
+
+  it("returns an error instead of throwing when a host or location does not exist", async () => {
+    const event = await createEvent();
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Title",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: ["no-such-guest"],
+      locationIds: [],
+    });
+    expect(!result.ok && result.error).toBe("Failed to create session");
+
+    // the transaction rolled back, nothing was created
+    expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
+      0
+    );
+  });
+
+  it("revalidates the public event layout so attendees see the new session", async () => {
+    const event = await createEvent();
+    vi.mocked(revalidatePath).mockClear();
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Title",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+
+    expect(revalidatePath).toHaveBeenCalledWith(`/${event.slug}`, "layout");
+  });
+
+  it("rejects when not authenticated", async () => {
+    const event = await createEvent();
+    cookieJar.clear();
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Title",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 0,
+      adminManaged: true,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+});
 
 describe("adminUpdateSessionAction", () => {
   beforeAll(() => setupTestDb());
@@ -305,6 +544,29 @@ describe("adminUpdateSessionAction", () => {
     expect(updated?.title).toBe("Old title");
   });
 
+  it("revalidates the public event layout so attendees see the change", async () => {
+    const event = await createEvent();
+    const session = await createSession(event.id);
+    vi.mocked(revalidatePath).mockClear();
+
+    const result = await adminUpdateSessionAction({
+      id: session.id,
+      title: "New title",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 30,
+      adminManaged: false,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+
+    expect(revalidatePath).toHaveBeenCalledWith(`/${event.slug}`, "layout");
+  });
+
   it("rejects when not authenticated", async () => {
     const event = await createEvent();
     const session = await createSession(event.id);
@@ -377,6 +639,17 @@ describe("adminDeleteSessionAction", () => {
     // host and location are global records, untouched
     expect(await repos.guests.findById(host.id)).toBeDefined();
     expect(await repos.locations.findById(loc.id)).toBeDefined();
+  });
+
+  it("revalidates the public event layout so attendees see the removal", async () => {
+    const event = await createEvent();
+    const session = await createSession(event.id);
+    vi.mocked(revalidatePath).mockClear();
+
+    const result = await adminDeleteSessionAction({ id: session.id });
+    expect(result.ok).toBe(true);
+
+    expect(revalidatePath).toHaveBeenCalledWith(`/${event.slug}`, "layout");
   });
 
   it("rejects when not authenticated", async () => {


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [d01fef3](https://github.com/LWCW-Europe/schellingboard/pull/550/commits/d01fef3cdf6e1941c867878313ef6b881a192bf4).

PRs:
* #551
* ➡️ #550 (this PR, base of the stack — can be merged first)

---

## Description

Admins need to add sessions directly (e.g. lunch blockers) without going
through the proposal flow. New sessions default to admin-managed so hosts
cannot edit them. Extracts the shared SessionForm from the edit UI.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=d01fef3cdf6e1941c867878313ef6b881a192bf4 -->