### PR TITLE
feat(admin): CSV user import with event assignment

### DIFF
--- a/app/actions/admin-guest-import.ts
+++ b/app/actions/admin-guest-import.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { parseUserImportCsv } from "@/utils/user-import";
+
+export type ImportGuestsResult =
+  | { ok: true; created: number; existing: number }
+  | { ok: false; error: string; lineErrors?: string[] };
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+/**
+ * Imports users from CSV (header: name,email) and assigns them to the given
+ * events. Users are matched by email (case-insensitive): existing users are
+ * left unchanged but still assigned, so re-running an import is idempotent.
+ */
+export async function importGuestsAction(input: {
+  csvText: string;
+  eventIds: string[];
+}): Promise<ImportGuestsResult> {
+  if (!(await isAdminRequest())) return { ok: false, error: "Unauthorized" };
+
+  const { events, guests } = getRepositories();
+  const eventIds = [...new Set(input.eventIds)];
+  for (const eventId of eventIds) {
+    if (!(await events.findById(eventId))) {
+      return { ok: false, error: "Event not found" };
+    }
+  }
+
+  const parsed = parseUserImportCsv(input.csvText);
+  if (!parsed.ok) {
+    return { ok: false, error: "Invalid CSV file", lineErrors: parsed.errors };
+  }
+
+  const { created } = await guests.importAndAssign(parsed.rows, eventIds);
+
+  revalidatePath("/admin/users");
+  revalidatePath("/admin");
+  revalidatePath("/admin/events");
+  for (const eventId of eventIds) {
+    revalidatePath(`/admin/events/${eventId}`);
+  }
+
+  return { ok: true, created, existing: parsed.rows.length - created };
+}

--- a/app/admin/users/import/page.tsx
+++ b/app/admin/users/import/page.tsx
@@ -1,0 +1,25 @@
+import { getRepositories } from "@/db/container";
+import { requireAdminPage } from "../../require-admin";
+import { UserImportForm } from "./user-import-form";
+
+export default async function AdminUserImportPage() {
+  await requireAdminPage();
+
+  const events = await getRepositories().events.list();
+
+  return (
+    <div className="w-full max-w-3xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Import users</h1>
+      <p className="text-sm text-gray-600">
+        Upload a CSV file with a header row containing <code>name</code> and{" "}
+        <code>email</code> columns (extra columns are ignored). Users are
+        matched by email: existing users are left unchanged, new ones are
+        created. Both are assigned to the selected events, so re-running an
+        import is safe.
+      </p>
+      <UserImportForm
+        events={events.map((e) => ({ id: e.id, name: e.name }))}
+      />
+    </div>
+  );
+}

--- a/app/admin/users/import/user-import-form.tsx
+++ b/app/admin/users/import/user-import-form.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { SelectHosts } from "@/app/select-hosts";
+import {
+  importGuestsAction,
+  type ImportGuestsResult,
+} from "@/app/actions/admin-guest-import";
+import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "../../buttons";
+
+type EventOption = { id: string; name: string };
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+export function UserImportForm({ events }: { events: EventOption[] }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [selectedEvents, setSelectedEvents] = useState<EventOption[]>([]);
+  const [result, setResult] = useState<ImportGuestsResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    startTransition(async () => {
+      const csvText = await file.text();
+      setResult(
+        await importGuestsAction({
+          csvText,
+          eventIds: selectedEvents.map((ev) => ev.id),
+        })
+      );
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="import-csv-file" className="text-sm text-gray-600">
+          CSV file
+        </label>
+        <input
+          id="import-csv-file"
+          type="file"
+          accept=".csv,text/csv"
+          required
+          onChange={(e) => {
+            setFile(e.target.files?.[0] ?? null);
+            setResult(null);
+          }}
+          className="text-sm text-gray-700 file:mr-3 file:px-3 file:py-2 file:text-sm file:font-medium file:rounded-md file:border-0 file:text-gray-700 file:bg-gray-100 hover:file:bg-gray-200 file:cursor-pointer"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="import-events" className="text-sm text-gray-600">
+          Assign to events
+        </label>
+        <SelectHosts
+          guests={events}
+          hosts={selectedEvents}
+          setHosts={setSelectedEvents}
+          id="import-events"
+          selectMany
+        />
+      </div>
+
+      {result && !result.ok && (
+        <div role="alert" className="text-sm text-red-600 space-y-1">
+          <p>{result.error}</p>
+          {result.lineErrors && (
+            <ul className="list-disc pl-5">
+              {result.lineErrors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      {result?.ok && (
+        <p role="status" className="text-sm text-green-700">
+          {plural(result.created, "user")} created,{" "}
+          {plural(result.existing, "user")} already existed (skipped, but still
+          assigned to the selected events).
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isPending || !file}
+          className={PRIMARY_BUTTON}
+        >
+          {isPending ? "Importing..." : "Import"}
+        </button>
+        <Link href="/admin/users" className={SECONDARY_BUTTON}>
+          Back to users
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getRepositories } from "@/db/container";
+import { SECONDARY_BUTTON } from "../buttons";
 import { outOfRangePageRedirect } from "@/utils/pagination";
 import { requireAdminPage } from "../require-admin";
 import { GuestsManager, type AdminUser } from "../guests-manager";
@@ -48,7 +50,12 @@ export default async function AdminUsersPage({
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+      <div className="flex items-center justify-between gap-2">
+        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+        <Link href="/admin/users/import" className={SECONDARY_BUTTON}>
+          Import CSV
+        </Link>
+      </div>
       <section aria-label="Users" className="space-y-4">
         <GuestsManager
           users={users}

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -152,6 +152,8 @@ export interface GuestsRepository {
   ): Promise<EventGuestPage>;
   findById(id: string): Promise<CompleteGuest | undefined>;
   findByEmail(email: string): Promise<CompleteGuest | undefined>;
+  /** Guests whose email matches any of `emails`, compared case-insensitively. */
+  findByEmails(emails: string[]): Promise<CompleteGuest[]>;
   create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest>;
   // Usage: an admin updates a user (name and private info such as email).
   update(
@@ -168,6 +170,16 @@ export interface GuestsRepository {
   findExistingIds(ids: string[]): Promise<string[]>;
   assignToEvent(eventId: string, guestIds: string[]): Promise<void>;
   removeFromEvent(eventId: string, guestIds: string[]): Promise<void>;
+  /**
+   * Matches `rows` to existing guests by email (case-insensitive), creates
+   * the missing ones, and assigns every resulting guest to each event in
+   * `eventIds`. Existing guests are left unchanged. Runs in a single
+   * transaction so a failure partway through leaves no partial writes.
+   */
+  importAndAssign(
+    rows: { name: string; email: string }[],
+    eventIds: string[]
+  ): Promise<{ created: number }>;
 }
 
 // ── Locations ─────────────────────────────────────────────────────────────────

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -201,6 +201,17 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return row ? rowToGuest(row) : undefined;
   }
 
+  async findByEmails(emails: string[]): Promise<CompleteGuest[]> {
+    if (emails.length === 0) return [];
+    const lowered = emails.map((e) => e.toLowerCase());
+    return this.db
+      .select()
+      .from(schema.guests)
+      .where(inArray(sql`lower(${schema.guests.email})`, lowered))
+      .all()
+      .map(rowToGuest);
+  }
+
   async create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest> {
     const id = nanoid();
     const {
@@ -264,6 +275,57 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .values(guestIds.map((guestId) => ({ eventId, guestId })))
       .onConflictDoNothing()
       .run();
+  }
+
+  async importAndAssign(
+    rows: { name: string; email: string }[],
+    eventIds: string[]
+  ): Promise<{ created: number }> {
+    let created = 0;
+    this.db.transaction((tx) => {
+      const existingByEmail = new Map(
+        (rows.length === 0
+          ? []
+          : tx
+              .select()
+              .from(schema.guests)
+              .where(
+                inArray(
+                  sql`lower(${schema.guests.email})`,
+                  rows.map((r) => r.email.toLowerCase())
+                )
+              )
+              .all()
+              .map(rowToGuest)
+        ).map((g) => [g.info.email.toLowerCase(), g])
+      );
+
+      const guestIds: string[] = [];
+      for (const row of rows) {
+        const existing = existingByEmail.get(row.email.toLowerCase());
+        if (existing) {
+          guestIds.push(existing.id);
+        } else {
+          const id = nanoid();
+          tx.insert(schema.guests)
+            .values({ id, name: row.name, email: row.email })
+            .run();
+          guestIds.push(id);
+          created++;
+        }
+      }
+
+      if (guestIds.length > 0) {
+        for (const eventId of eventIds) {
+          tx.insert(schema.eventGuests)
+            .values(guestIds.map((guestId) => ({ eventId, guestId })))
+            .onConflictDoNothing()
+            .run();
+        }
+      }
+    });
+
+    return { created };
   }
 
   async removeFromEvent(eventId: string, guestIds: string[]): Promise<void> {

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -190,6 +190,85 @@ test.describe("Admin UI", () => {
     ).toHaveCount(0);
   });
 
+  test("imports users from CSV and assigns them to an event", async ({
+    page,
+  }) => {
+    await adminLogin(page);
+    await gotoUsers(page);
+
+    const unique = Date.now();
+    const newName = `CSV Import User ${unique}`;
+    const newEmail = `csv-import-${unique}@test.example`;
+    // bob@test.com already exists in the seed, so he must be skipped.
+    const csv = `name,email\n${newName},${newEmail}\nBob Duplicate,bob@test.com\n`;
+
+    await page.getByRole("link", { name: "Import CSV" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Import users" })
+    ).toBeVisible();
+
+    await page.getByLabel("CSV file").setInputFiles({
+      name: "users.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+
+    // Pick an event through the searchable multi-select (opens on focus).
+    await page.getByLabel("Assign to events").click();
+    await page.keyboard.type("Alpha");
+    await page.getByRole("option", { name: "Conference Alpha" }).click();
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Import" }).click();
+    const summary = page.getByRole("status");
+    await expect(summary).toContainText("1 user created");
+    await expect(summary).toContainText("1 user already existed");
+
+    // The new user shows up in the users list, assigned to the event.
+    await gotoUsers(page);
+    const users = page.getByRole("region", { name: "Users" });
+    await users.getByRole("searchbox", { name: "Search" }).fill(newEmail);
+    await users.getByRole("button", { name: "Search" }).click();
+    const row = users.getByRole("listitem").filter({ hasText: newEmail });
+    await expect(row.getByText(newName)).toBeVisible();
+    await expect(
+      row.getByRole("link", { name: "Conference Alpha" })
+    ).toBeVisible();
+
+    // Clean up so the shared seed stays stable for other tests.
+    await row.getByRole("button", { name: "Delete", exact: true }).click();
+    await row.getByRole("button", { name: "Confirm delete" }).click();
+    await expect(row).toHaveCount(0);
+  });
+
+  test("rejects an invalid CSV file without importing anything", async ({
+    page,
+  }) => {
+    await adminLogin(page);
+    await gotoUsers(page);
+    await page.getByRole("link", { name: "Import CSV" }).click();
+
+    await page.getByLabel("CSV file").setInputFiles({
+      name: "users.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from("name,email\nBroken Row,not-an-email\n"),
+    });
+    await page.getByRole("button", { name: "Import" }).click();
+
+    const errors = page
+      .getByRole("alert")
+      .filter({ hasText: "Invalid CSV file" });
+    await expect(errors).toContainText("Line 2");
+    await expect(errors).toContainText("not-an-email");
+
+    // Nothing was imported.
+    await gotoUsers(page);
+    const users = page.getByRole("region", { name: "Users" });
+    await users.getByRole("searchbox", { name: "Search" }).fill("Broken Row");
+    await users.getByRole("button", { name: "Search" }).click();
+    await expect(users.getByText("No users match.")).toBeVisible();
+  });
+
   test("searches and paginates users", async ({ page }) => {
     await adminLogin(page);
     await gotoUsers(page);

--- a/tests/integration/admin-guest-import.test.ts
+++ b/tests/integration/admin-guest-import.test.ts
@@ -1,0 +1,195 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { importGuestsAction } from "@/app/actions/admin-guest-import";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("guests.findByEmails", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns guests matching any of the emails, case-insensitively", async () => {
+    const g1 = await createGuest({ email: "Alice@Example.com" });
+    await createGuest({ email: "bob@example.com" });
+    const { guests } = getRepositories();
+
+    const found = await guests.findByEmails(["alice@example.com"]);
+    expect(found.map((g) => g.id)).toEqual([g1.id]);
+  });
+
+  it("returns [] for an empty input", async () => {
+    const { guests } = getRepositories();
+    expect(await guests.findByEmails([])).toEqual([]);
+  });
+});
+
+describe("guests.importAndAssign", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("rolls back created guests when assignment fails partway through", async () => {
+    const { guests } = getRepositories();
+
+    await expect(
+      guests.importAndAssign(
+        [
+          { name: "Alice", email: "alice@example.com" },
+          { name: "Bob", email: "bob@example.com" },
+        ],
+        // No event with this id exists, so the event_guests insert violates
+        // its foreign key constraint partway through the transaction.
+        ["no-such-event"]
+      )
+    ).rejects.toThrow();
+
+    expect(await guests.list()).toHaveLength(0);
+  });
+});
+
+describe("importGuestsAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("creates new users from CSV", async () => {
+    const result = await importGuestsAction({
+      csvText: "name,email\nAlice,alice@example.com\nBob,bob@example.com\n",
+      eventIds: [],
+    });
+    expect(result).toEqual({ ok: true, created: 2, existing: 0 });
+
+    const { guests } = getRepositories();
+    const alice = await guests.findByEmail("alice@example.com");
+    expect(alice?.name).toBe("Alice");
+    const bob = await guests.findByEmail("bob@example.com");
+    expect(bob?.name).toBe("Bob");
+  });
+
+  it("skips existing users (matched by email, case-insensitive) without modifying them", async () => {
+    const existing = await createGuest({
+      name: "Original Name",
+      email: "Alice@Example.com",
+    });
+
+    const result = await importGuestsAction({
+      csvText: "name,email\nNew Name,alice@example.com\nBob,bob@example.com\n",
+      eventIds: [],
+    });
+    expect(result).toEqual({ ok: true, created: 1, existing: 1 });
+
+    const { guests } = getRepositories();
+    const unchanged = await guests.findById(existing.id);
+    expect(unchanged?.name).toBe("Original Name");
+    expect(unchanged?.info.email).toBe("Alice@Example.com");
+  });
+
+  it("assigns both new and existing users to the selected events", async () => {
+    const event1 = await createEvent();
+    const event2 = await createEvent();
+    const existing = await createGuest({ email: "alice@example.com" });
+
+    const result = await importGuestsAction({
+      csvText: "name,email\nAlice,alice@example.com\nBob,bob@example.com\n",
+      eventIds: [event1.id, event2.id],
+    });
+    expect(result).toEqual({ ok: true, created: 1, existing: 1 });
+
+    const { guests } = getRepositories();
+    for (const event of [event1, event2]) {
+      const assigned = await guests.listByEvent(event.id);
+      expect(assigned).toHaveLength(2);
+      expect(assigned.map((g) => g.id)).toContain(existing.id);
+    }
+  });
+
+  it("re-running the same import is idempotent", async () => {
+    const event = await createEvent();
+    const csvText = "name,email\nAlice,alice@example.com\n";
+
+    await importGuestsAction({ csvText, eventIds: [event.id] });
+    const result = await importGuestsAction({ csvText, eventIds: [event.id] });
+    expect(result).toEqual({ ok: true, created: 0, existing: 1 });
+
+    const { guests } = getRepositories();
+    const all = await guests.list();
+    expect(all).toHaveLength(1);
+    const assigned = await guests.listByEvent(event.id);
+    expect(assigned).toHaveLength(1);
+  });
+
+  it("rejects the whole file on validation errors and imports nothing", async () => {
+    const result = await importGuestsAction({
+      csvText: "name,email\nAlice,alice@example.com\nBob,broken\n",
+      eventIds: [],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.lineErrors).toHaveLength(1);
+      expect(result.lineErrors?.[0]).toMatch(/line 3/i);
+    }
+
+    const { guests } = getRepositories();
+    expect(await guests.list()).toHaveLength(0);
+  });
+
+  it("errors for an unknown event without importing", async () => {
+    const result = await importGuestsAction({
+      csvText: "name,email\nAlice,alice@example.com\n",
+      eventIds: ["no-such-event"],
+    });
+    expect(!result.ok && result.error).toBe("Event not found");
+
+    const { guests } = getRepositories();
+    expect(await guests.list()).toHaveLength(0);
+  });
+
+  it("rejects when not authenticated", async () => {
+    cookieJar.clear();
+    const result = await importGuestsAction({
+      csvText: "name,email\nAlice,alice@example.com\n",
+      eventIds: [],
+    });
+    expect(!result.ok && result.error).toBe("Unauthorized");
+  });
+});

--- a/tests/unit/user-import.test.ts
+++ b/tests/unit/user-import.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { parseUserImportCsv } from "@/utils/user-import";
+
+function expectOk(result: ReturnType<typeof parseUserImportCsv>) {
+  if (!result.ok)
+    throw new Error(`expected ok, got ${result.errors.join("; ")}`);
+  return result.rows;
+}
+
+function expectErrors(result: ReturnType<typeof parseUserImportCsv>) {
+  if (result.ok) throw new Error("expected errors, got ok");
+  return result.errors;
+}
+
+describe("parseUserImportCsv", () => {
+  it("parses name,email rows below a header", () => {
+    const rows = expectOk(
+      parseUserImportCsv(
+        "name,email\nAlice,alice@example.com\nBob,bob@example.com\n"
+      )
+    );
+    expect(rows).toEqual([
+      { name: "Alice", email: "alice@example.com" },
+      { name: "Bob", email: "bob@example.com" },
+    ]);
+  });
+
+  it("parses semicolon-delimited files (European Excel export)", () => {
+    const rows = expectOk(
+      parseUserImportCsv(
+        "name;email\nAlice;alice@example.com\nBob;bob@example.com\n"
+      )
+    );
+    expect(rows).toEqual([
+      { name: "Alice", email: "alice@example.com" },
+      { name: "Bob", email: "bob@example.com" },
+    ]);
+  });
+
+  it("parses tab-delimited files", () => {
+    const rows = expectOk(
+      parseUserImportCsv("name\temail\nAlice\talice@example.com\n")
+    );
+    expect(rows).toEqual([{ name: "Alice", email: "alice@example.com" }]);
+  });
+
+  it("keeps commas in values when the delimiter is a semicolon", () => {
+    const rows = expectOk(
+      parseUserImportCsv("name;email\nDoe, Jane;jane@example.com\n")
+    );
+    expect(rows).toEqual([{ name: "Doe, Jane", email: "jane@example.com" }]);
+  });
+
+  it("accepts any header column order and ignores extra columns", () => {
+    const rows = expectOk(
+      parseUserImportCsv("company,email,name\nAcme,alice@example.com,Alice\n")
+    );
+    expect(rows).toEqual([{ name: "Alice", email: "alice@example.com" }]);
+  });
+
+  it("matches header names case-insensitively and trims cells", () => {
+    const rows = expectOk(
+      parseUserImportCsv("Name , EMAIL\n Alice , alice@example.com \n")
+    );
+    expect(rows).toEqual([{ name: "Alice", email: "alice@example.com" }]);
+  });
+
+  it("handles quoted fields with commas, quotes and newlines", () => {
+    const rows = expectOk(
+      parseUserImportCsv(
+        'name,email\n"Doe, Jane ""JD""",jane@example.com\n"Multi\nLine",multi@example.com\n'
+      )
+    );
+    expect(rows).toEqual([
+      { name: 'Doe, Jane "JD"', email: "jane@example.com" },
+      { name: "Multi\nLine", email: "multi@example.com" },
+    ]);
+  });
+
+  it("handles CRLF line endings and skips blank lines", () => {
+    const rows = expectOk(
+      parseUserImportCsv(
+        "name,email\r\nAlice,alice@example.com\r\n\r\nBob,bob@example.com\r\n"
+      )
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it("rejects a missing header", () => {
+    const errors = expectErrors(parseUserImportCsv(""));
+    expect(errors.join(" ")).toMatch(/header/i);
+  });
+
+  it("rejects a header without the required columns", () => {
+    const errors = expectErrors(
+      parseUserImportCsv("name,mail\nAlice,alice@example.com\n")
+    );
+    expect(errors.join(" ")).toMatch(/email/i);
+  });
+
+  it("rejects invalid emails with the line number", () => {
+    const errors = expectErrors(
+      parseUserImportCsv(
+        "name,email\nAlice,alice@example.com\nBob,not-an-email\n"
+      )
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/line 3/i);
+    expect(errors[0]).toMatch(/not-an-email/);
+  });
+
+  it("rejects empty names with the line number", () => {
+    const errors = expectErrors(
+      parseUserImportCsv("name,email\n,alice@example.com\n")
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/line 2/i);
+    expect(errors[0]).toMatch(/name/i);
+  });
+
+  it("rejects duplicate emails within the file, case-insensitively", () => {
+    const errors = expectErrors(
+      parseUserImportCsv(
+        "name,email\nAlice,alice@example.com\nAlicia,ALICE@example.com\n"
+      )
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/line 3/i);
+    expect(errors[0]).toMatch(/duplicate/i);
+  });
+
+  it("reports all errors at once", () => {
+    const errors = expectErrors(
+      parseUserImportCsv("name,email\n,alice@example.com\nBob,broken\n")
+    );
+    expect(errors).toHaveLength(2);
+  });
+
+  it("rejects rows with more cells than the header", () => {
+    const errors = expectErrors(
+      parseUserImportCsv("name,email\nAlice,alice@example.com,extra\n")
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/line 2/i);
+  });
+
+  it("rejects a file with no data rows", () => {
+    const errors = expectErrors(parseUserImportCsv("name,email\n"));
+    expect(errors.join(" ")).toMatch(/no .*rows/i);
+  });
+
+  it("rejects an unterminated quoted field", () => {
+    const errors = expectErrors(
+      parseUserImportCsv('name,email\n"Alice,alice@example.com\n')
+    );
+    expect(errors[0]).toMatch(/line 2/i);
+    expect(errors[0]).toMatch(/unterminated/i);
+  });
+
+  it("rejects a quote appearing mid-field", () => {
+    const errors = expectErrors(
+      parseUserImportCsv('name,email\nAli"ce,alice@example.com\n')
+    );
+    expect(errors[0]).toMatch(/line 2/i);
+    expect(errors[0]).toMatch(/quote/i);
+  });
+
+  it("rejects stray characters after a closing quote", () => {
+    const errors = expectErrors(
+      parseUserImportCsv('name,email\n"Alice"x,alice@example.com\n')
+    );
+    expect(errors[0]).toMatch(/line 2/i);
+    expect(errors[0]).toMatch(/quote/i);
+  });
+});

--- a/utils/user-import.ts
+++ b/utils/user-import.ts
@@ -1,0 +1,204 @@
+export type UserImportRow = { name: string; email: string };
+
+export type UserImportParseResult =
+  { ok: true; rows: UserImportRow[] } | { ok: false; errors: string[] };
+
+const EMAIL_PATTERN = /^\S+@\S+\.\S+$/;
+
+type CsvRecord = { cells: string[]; line: number };
+
+const DELIMITERS = [",", ";", "\t"] as const;
+
+/**
+ * Picks the field delimiter by counting candidates on the first line, outside
+ * quotes. Handles the common European Excel export that uses `;`, plus tabs.
+ * Defaults to comma when the header has no delimiter at all.
+ */
+function detectDelimiter(text: string): string {
+  const counts = new Map<string, number>(DELIMITERS.map((d) => [d, 0]));
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') i++;
+        else inQuotes = false;
+      }
+      continue;
+    }
+    if (ch === '"') inQuotes = true;
+    else if (ch === "\n" || ch === "\r") break;
+    else if (counts.has(ch)) counts.set(ch, counts.get(ch)! + 1);
+  }
+  let best = ",";
+  let bestCount = 0;
+  for (const d of DELIMITERS) {
+    const c = counts.get(d)!;
+    if (c > bestCount) {
+      best = d;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+type CsvReadResult = { records: CsvRecord[]; errors: string[] };
+
+/**
+ * Minimal RFC-4180-style CSV reader: quoted fields may contain the delimiter,
+ * newlines and doubled quotes. A quote is only meaningful at the very start
+ * of a field; anywhere else (mid-field, or trailing after a closing quote)
+ * it is a structural error rather than silently-altered content, as is an
+ * unterminated quoted field at EOF. Returns records with the 1-based line
+ * number each record starts on, plus any structural errors found.
+ */
+function readCsvRecords(text: string, delimiter: string): CsvReadResult {
+  const records: CsvRecord[] = [];
+  const errors: string[] = [];
+  let cells: string[] = [];
+  let cell = "";
+  let cellState: "start" | "unquoted" | "quoted" | "afterQuote" = "start";
+  let fieldErrorReported = false;
+  let line = 1;
+  let recordStartLine = 1;
+  let recordHasContent = false;
+
+  const endCell = () => {
+    cells.push(cell);
+    cell = "";
+    cellState = "start";
+    fieldErrorReported = false;
+  };
+  const endRecord = () => {
+    endCell();
+    if (recordHasContent || cells.length > 1 || cells[0] !== "") {
+      records.push({ cells, line: recordStartLine });
+    }
+    cells = [];
+    recordHasContent = false;
+  };
+  const reportFieldError = (message: string) => {
+    if (!fieldErrorReported) {
+      errors.push(`Line ${recordStartLine}: ${message}`);
+      fieldErrorReported = true;
+    }
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (cellState === "quoted") {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          cellState = "afterQuote";
+        }
+      } else {
+        if (ch === "\n") line++;
+        cell += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      if (cellState === "start") {
+        cellState = "quoted";
+      } else {
+        reportFieldError(
+          "quote character is only allowed at the start of a field"
+        );
+      }
+      recordHasContent = true;
+    } else if (ch === delimiter) {
+      endCell();
+      recordHasContent = true;
+    } else if (ch === "\n" || ch === "\r") {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      endRecord();
+      line++;
+      recordStartLine = line;
+    } else {
+      if (cellState === "afterQuote") {
+        reportFieldError("unexpected character after closing quote");
+      }
+      if (cellState === "start") cellState = "unquoted";
+      cell += ch;
+      recordHasContent = true;
+    }
+  }
+  if (cellState === "quoted") {
+    errors.push(`Line ${recordStartLine}: unterminated quoted field`);
+  }
+  if (recordHasContent || cells.length > 0 || cell !== "") endRecord();
+
+  return { records, errors };
+}
+
+/**
+ * Parses a user-import CSV. Requires a header row containing `name` and
+ * `email` columns (any order, case-insensitive, extra columns ignored).
+ * All-or-nothing: any invalid row rejects the whole file, and every problem
+ * is reported with its line number.
+ */
+export function parseUserImportCsv(text: string): UserImportParseResult {
+  const { records, errors: structuralErrors } = readCsvRecords(
+    text,
+    detectDelimiter(text)
+  );
+  if (structuralErrors.length > 0) {
+    return { ok: false, errors: structuralErrors };
+  }
+  if (records.length === 0) {
+    return { ok: false, errors: ["Missing header row (expected name,email)"] };
+  }
+
+  const header = records[0].cells.map((c) => c.trim().toLowerCase());
+  const nameIdx = header.indexOf("name");
+  const emailIdx = header.indexOf("email");
+  const headerErrors: string[] = [];
+  if (nameIdx === -1) headerErrors.push('Header is missing a "name" column');
+  if (emailIdx === -1) headerErrors.push('Header is missing an "email" column');
+  if (headerErrors.length > 0) return { ok: false, errors: headerErrors };
+
+  const dataRecords = records.slice(1);
+  if (dataRecords.length === 0) {
+    return { ok: false, errors: ["File contains no data rows"] };
+  }
+
+  const rows: UserImportRow[] = [];
+  const errors: string[] = [];
+  const seenEmails = new Map<string, number>();
+
+  for (const record of dataRecords) {
+    if (record.cells.length > header.length) {
+      errors.push(
+        `Line ${record.line}: has ${record.cells.length} columns, expected ${header.length}`
+      );
+      continue;
+    }
+    const name = (record.cells[nameIdx] ?? "").trim();
+    const email = (record.cells[emailIdx] ?? "").trim();
+
+    if (!name) {
+      errors.push(`Line ${record.line}: name is missing`);
+      continue;
+    }
+    if (!EMAIL_PATTERN.test(email)) {
+      errors.push(`Line ${record.line}: invalid email "${email}"`);
+      continue;
+    }
+    const emailKey = email.toLowerCase();
+    const firstLine = seenEmails.get(emailKey);
+    if (firstLine !== undefined) {
+      errors.push(
+        `Line ${record.line}: duplicate email "${email}" (first seen on line ${firstLine})`
+      );
+      continue;
+    }
+    seenEmails.set(emailKey, record.line);
+    rows.push({ name, email });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, rows };
+}


### PR DESCRIPTION
Users are matched by email (case-insensitive): existing users are
skipped but still assigned to the selected events, so re-running an
import is idempotent. Invalid files are rejected as a whole with
line-numbered errors.

<!-- jip:pushed-commit=384c22c98e6400f82f272a2cfa8bb67bd965fef3 -->