### PR TITLE
feat: fold past days on the schedule by default

### DIFF
--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -5,6 +5,8 @@ import {
   CalendarIcon,
   LinkIcon,
   ClipboardDocumentListIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import { DateTime } from "luxon";
 import { useSearchParams } from "next/navigation";
@@ -14,18 +16,34 @@ import { useState, useContext } from "react";
 import { EventContext } from "../context";
 import { hasPhases } from "@/app/(site)/utils/events";
 import Link from "next/link";
+import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
 import { SessionModal } from "./session-modal";
+import type { DayWithSessions } from "../context";
 
 export function EventDisplay() {
-  const { event, days, locations, guests, rsvps } = useContext(EventContext);
+  const { event, days, locations, guests, rsvps, now } =
+    useContext(EventContext);
   const searchParams = useSearchParams();
   const view = searchParams.get("view") ?? "grid";
   const viewSession = searchParams.get("viewSession");
   const [search, setSearch] = useState("");
+  const [unfoldedDayIds, setUnfoldedDayIds] = useState<Set<string>>(
+    () => new Set()
+  );
 
   if (!event) return <div>No event data available</div>;
 
   const daysForEvent = days.filter((day) => day.eventId === event.id);
+  const defaultFoldedDayIds = getDefaultFoldedDayIds(daysForEvent, now);
+  const isFolded = (dayId: string) =>
+    defaultFoldedDayIds.has(dayId) && !unfoldedDayIds.has(dayId);
+  const toggleDayFold = (dayId: string) =>
+    setUnfoldedDayIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(dayId)) next.delete(dayId);
+      else next.add(dayId);
+      return next;
+    });
   const locationsForEvent = locations;
   const multipleDays = event.start.getTime() !== event.end.getTime();
 
@@ -92,28 +110,56 @@ export function EventDisplay() {
         // - `dvh` (not `vh`) so the mobile address bar showing/hiding doesn't change the height.
         <div
           data-testid="schedule-scroll"
-          className="w-full overflow-auto sticky top-16 max-h-[calc(100dvh-6rem)] sm:max-h-[calc(100dvh-8rem)] rounded-lg border border-gray-200"
+          // `grid` with a single max-content column (rather than block flow)
+          // so the fold bar's `w-full` stretches to match the widest day's
+          // grid instead of the container's own (viewport-bound) width —
+          // otherwise its background falls short when scrolled horizontally.
+          className="w-full overflow-auto sticky top-16 max-h-[calc(100dvh-6rem)] sm:max-h-[calc(100dvh-8rem)] rounded-lg border border-gray-200 grid"
+          style={{ gridTemplateColumns: "max-content" }}
         >
           {daysForEvent.map((day) => (
-            <DayGrid
-              key={day.id}
-              day={day}
-              locations={locationsForEvent}
-              guests={guests}
-            />
+            <div key={day.id} className="contents">
+              {defaultFoldedDayIds.has(day.id) && (
+                <DayFoldBar
+                  day={day}
+                  timezone={event.timezone}
+                  folded={isFolded(day.id)}
+                  onToggle={() => toggleDayFold(day.id)}
+                />
+              )}
+              {!isFolded(day.id) && (
+                <DayGrid
+                  day={day}
+                  locations={locationsForEvent}
+                  guests={guests}
+                />
+              )}
+            </div>
           ))}
         </div>
       ) : (
         <div className="flex flex-col gap-12 w-full">
           {daysForEvent.map((day) => (
             <div key={day.id}>
-              <DayText
-                day={day}
-                search={search}
-                locations={locationsForEvent}
-                rsvps={view === "rsvp" ? rsvps : []}
-                eventSlug={event.slug}
-              />
+              {defaultFoldedDayIds.has(day.id) && (
+                <div className="max-w-3xl mx-auto">
+                  <DayFoldBar
+                    day={day}
+                    timezone={event.timezone}
+                    folded={isFolded(day.id)}
+                    onToggle={() => toggleDayFold(day.id)}
+                  />
+                </div>
+              )}
+              {!isFolded(day.id) && (
+                <DayText
+                  day={day}
+                  search={search}
+                  locations={locationsForEvent}
+                  rsvps={view === "rsvp" ? rsvps : []}
+                  eventSlug={event.slug}
+                />
+              )}
             </div>
           ))}
         </div>
@@ -122,5 +168,32 @@ export function EventDisplay() {
         <SessionModal sessionId={viewSession} eventSlug={event.slug} />
       )}
     </div>
+  );
+}
+
+// Collapsed/expandable header for a day that has already passed. In the grid
+// view the label sticks to the left edge so it stays readable while the wide
+// grid is scrolled horizontally.
+function DayFoldBar(props: {
+  day: DayWithSessions;
+  timezone: string;
+  folded: boolean;
+  onToggle: () => void;
+}) {
+  const { day, timezone, folded, onToggle } = props;
+  const date = DateTime.fromJSDate(day.start).setZone(timezone);
+  const Chevron = folded ? ChevronRightIcon : ChevronDownIcon;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="block w-full bg-gray-50 hover:bg-gray-100 transition-colors border-b border-gray-200 text-left"
+    >
+      <span className="sticky left-0 inline-flex items-center gap-1.5 px-2 py-1.5 text-xs text-gray-500">
+        <Chevron className="h-3.5 w-3.5 stroke-2" />
+        <span className="font-medium">{date.toFormat("EEEE, MMMM d")}</span>
+        <span>· day has passed · {folded ? "show" : "hide"}</span>
+      </span>
+    </button>
   );
 }

--- a/app/(site)/[eventSlug]/layout-content.tsx
+++ b/app/(site)/[eventSlug]/layout-content.tsx
@@ -46,6 +46,9 @@ export async function EventLayoutContent({
     locations,
     guests,
     rsvps,
+    // Computed on the server so SSR and hydration agree on which days
+    // default to folded (see getDefaultFoldedDayIds).
+    now: new Date(),
   };
 
   return (

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -38,6 +38,9 @@ export interface EventContextType {
   locations: Location[];
   guests: Guest[];
   rsvps: Rsvp[];
+  // Captured once on the server so SSR and hydration agree on time-dependent
+  // decisions (e.g. which schedule days default to folded).
+  now: Date;
   rsvpdForSession: (sessionId: string) => boolean;
   localSessions: Session[];
   userBusySessions: () => Session[];
@@ -55,6 +58,7 @@ export const EventContext = createContext<EventContextType>({
   locations: [],
   guests: [],
   rsvps: [],
+  now: new Date(0),
   localSessions: [],
   userBusySessions: () => [],
   rsvpdForSession: () => false,

--- a/tests/unit/schedule-fold.test.ts
+++ b/tests/unit/schedule-fold.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
+
+function day(id: string, start: string, end: string) {
+  return { id, start: new Date(start), end: new Date(end) };
+}
+
+const now = new Date("2026-07-07T12:00:00Z");
+
+describe("getDefaultFoldedDayIds", () => {
+  it("folds days that have fully passed", () => {
+    const days = [
+      day("d1", "2026-07-05T09:00:00Z", "2026-07-05T18:00:00Z"),
+      day("d2", "2026-07-06T09:00:00Z", "2026-07-06T18:00:00Z"),
+      day("d3", "2026-07-08T09:00:00Z", "2026-07-08T18:00:00Z"),
+    ];
+    expect(getDefaultFoldedDayIds(days, now)).toEqual(new Set(["d1", "d2"]));
+  });
+
+  it("does not fold the day currently in progress", () => {
+    const days = [
+      day("d1", "2026-07-07T09:00:00Z", "2026-07-07T18:00:00Z"),
+      day("d2", "2026-07-08T09:00:00Z", "2026-07-08T18:00:00Z"),
+    ];
+    expect(getDefaultFoldedDayIds(days, now)).toEqual(new Set());
+  });
+
+  it("folds nothing when all days are in the future", () => {
+    const days = [day("d1", "2026-07-08T09:00:00Z", "2026-07-08T18:00:00Z")];
+    expect(getDefaultFoldedDayIds(days, now)).toEqual(new Set());
+  });
+
+  it("folds nothing when the whole event has passed", () => {
+    const days = [
+      day("d1", "2026-07-01T09:00:00Z", "2026-07-01T18:00:00Z"),
+      day("d2", "2026-07-02T09:00:00Z", "2026-07-02T18:00:00Z"),
+    ];
+    expect(getDefaultFoldedDayIds(days, now)).toEqual(new Set());
+  });
+
+  it("folds nothing for an empty day list", () => {
+    expect(getDefaultFoldedDayIds([], now)).toEqual(new Set());
+  });
+});

--- a/utils/schedule-fold.ts
+++ b/utils/schedule-fold.ts
@@ -1,0 +1,20 @@
+// Decides which schedule days start out folded (collapsed) for the viewer.
+
+type DayWindow = {
+  id: string;
+  end: Date;
+};
+
+/**
+ * Days that have fully passed are folded by default so the schedule opens on
+ * what's current. Exception: when every day has passed the schedule is an
+ * archive, so nothing is folded.
+ */
+export function getDefaultFoldedDayIds(
+  days: DayWindow[],
+  now: Date
+): Set<string> {
+  const past = days.filter((day) => day.end.getTime() <= now.getTime());
+  if (past.length === days.length) return new Set();
+  return new Set(past.map((day) => day.id));
+}


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [4f835e5](https://github.com/LWCW-Europe/schellingboard/pull/555/commits/4f835e5d9e76008777dc74f14c5a2f8a081d458b).

PRs:
* #577
* ➡️ #555 (this PR, base of the stack — can be merged first)

---

## Description

Past days collapse to a toggle bar so the schedule opens on what's
current. When the whole event is over nothing folds (archive view).

closes #308

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=4f835e5d9e76008777dc74f14c5a2f8a081d458b -->