### PR TITLE
feat: kiosk mode for schedule screens at the venue (?kiosk=1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a public open-source fork of [rachelweinberg12/scheduling-app](https://g
 - **Scheduling board** — drag sessions onto a time/location grid
 - **Event phases** — proposal, voting, and scheduling phases with configurable date ranges
 - **Multi-event support** — host multiple events from one deployment
+- **Kiosk mode** — append `?kiosk=1` to a schedule URL for large screens at the venue: a red line marks the current time, the schedule auto-scrolls to it and refreshes periodically, and the screen is kept awake. The schedule stays fully interactive. Combine with `loc` filters (e.g. `?kiosk=1&loc=Main+Hall`) to show only some rooms.
 - **Site password protection** — optional single-password gate for the whole app
 
 ![Scheduling board](docs/screenshot-schedule.png)

--- a/app/(site)/[eventSlug]/day-grid.tsx
+++ b/app/(site)/[eventSlug]/day-grid.tsx
@@ -3,7 +3,8 @@ import { LocationCol } from "./location-col";
 import clsx from "clsx";
 import { useSearchParams } from "next/navigation";
 import { TIME_FORMAT } from "@/utils/utils";
-import { getNumSlots } from "@/utils/slots";
+import { getNumSlots, getNowOffsetPx } from "@/utils/slots";
+import { useKioskMode, useTickingNow } from "./kiosk";
 import { useContext } from "react";
 import Image from "next/image";
 import { Tooltip } from "./tooltip";
@@ -41,6 +42,12 @@ export function DayGrid(props: {
   const numSlots = getNumSlots(day.start, day.end, slotIncrement);
   const hasImages = includedLocations.some((loc) => loc.imageUrl);
   const date = DateTime.fromJSDate(day.start).setZone(timezone);
+
+  // Kiosk mode: a red line across the day at the current time. Client-only
+  // (useTickingNow is null on the server) so hydration stays consistent.
+  const now = useTickingNow(useKioskMode());
+  const nowOffsetPx =
+    now === null ? null : getNowOffsetPx(day, now, slotIncrement);
 
   return (
     <div
@@ -132,6 +139,14 @@ export function DayGrid(props: {
               .toFormat(TIME_FORMAT)}
           </div>
         ))}
+        {nowOffsetPx !== null && (
+          <div
+            data-testid="now-line"
+            aria-hidden="true"
+            className="absolute inset-x-0 z-10 h-0.5 bg-red-500 pointer-events-none"
+            style={{ top: nowOffsetPx }}
+          />
+        )}
       </div>
       {includedLocations.map((location) => (
         <LocationCol
@@ -142,6 +157,7 @@ export function DayGrid(props: {
           guests={guests}
           day={day}
           location={location}
+          nowOffsetPx={nowOffsetPx}
         />
       ))}
     </div>

--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -17,6 +17,7 @@ import { EventContext } from "../context";
 import { hasPhases } from "@/app/(site)/utils/events";
 import Link from "next/link";
 import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
+import { KioskController, useKioskMode } from "./kiosk";
 import { SessionModal } from "./session-modal";
 import type { DayWithSessions } from "../context";
 
@@ -26,6 +27,7 @@ export function EventDisplay() {
   const searchParams = useSearchParams();
   const view = searchParams.get("view") ?? "grid";
   const viewSession = searchParams.get("viewSession");
+  const kiosk = useKioskMode();
   const [search, setSearch] = useState("");
   const [unfoldedDayIds, setUnfoldedDayIds] = useState<Set<string>>(
     () => new Set()
@@ -167,6 +169,7 @@ export function EventDisplay() {
       {viewSession && (
         <SessionModal sessionId={viewSession} eventSlug={event.slug} />
       )}
+      {kiosk && <KioskController />}
     </div>
   );
 }

--- a/app/(site)/[eventSlug]/kiosk.tsx
+++ b/app/(site)/[eventSlug]/kiosk.tsx
@@ -1,0 +1,141 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+// Kiosk mode (?kiosk=1) is for unattended large screens at the venue: a red
+// line marks the current time on the grid and is scrolled into view at
+// regular intervals. All normal interaction stays available so visitors
+// without a phone can still RSVP or add sessions from the display.
+
+/** How often the now line re-reads the clock. */
+const NOW_TICK_MS = 60 * 1000;
+/** How often the schedule is scrolled back to the now line. */
+const SCROLL_INTERVAL_MS = 3 * 60 * 1000;
+/** First scroll after load, once the grid and now line have rendered. */
+const INITIAL_SCROLL_DELAY_MS = 1000;
+/** Someone is using the display — don't yank the schedule away from them. */
+const INTERACTION_IDLE_MS = 60 * 1000;
+/** How often the event data is refetched so the display never goes stale. */
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+/** The scroll container's `sticky top-16` offset (see EventDisplay). */
+const STICKY_TOP_PX = 64;
+
+export function useKioskMode(): boolean {
+  const searchParams = useSearchParams();
+  return searchParams?.get("kiosk") != null;
+}
+
+/**
+ * The current time, updated every NOW_TICK_MS. Null on the server and during
+ * hydration (and when disabled) so SSR and client markup agree.
+ */
+export function useTickingNow(enabled: boolean): Date | null {
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNow(new Date());
+    const id = setInterval(() => setNow(new Date()), NOW_TICK_MS);
+    return () => {
+      clearInterval(id);
+      setNow(null);
+    };
+  }, [enabled]);
+  return now;
+}
+
+/**
+ * Renderless controller for the kiosk behaviors that act on the page as a
+ * whole: periodic data refresh, keeping the screen awake, and scrolling the
+ * schedule back to the now line.
+ */
+export function KioskController() {
+  const router = useRouter();
+
+  // Kiosk screens stay open for days while organizers move sessions around;
+  // without this the display would show the schedule as of page load.
+  useEffect(() => {
+    const id = setInterval(() => router.refresh(), REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [router]);
+
+  // Keep the screen awake where the Wake Lock API is available; elsewhere the
+  // device's display settings have to allow for it.
+  useEffect(() => {
+    let lock: WakeLockSentinel | null = null;
+    let disposed = false;
+    const acquire = () => {
+      navigator.wakeLock
+        ?.request("screen")
+        .then((sentinel) => {
+          if (disposed) void sentinel.release().catch(() => undefined);
+          else lock = sentinel;
+        })
+        .catch(() => undefined); // unsupported or denied — not fatal
+    };
+    acquire();
+    // The lock is released whenever the tab is hidden; take it again.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") acquire();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      disposed = true;
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      void lock?.release().catch(() => undefined);
+    };
+  }, []);
+
+  // Periodically bring the now line back into view: scroll the window so the
+  // grid is at its sticky resting position and the grid so the line sits a
+  // third from the top. Paused while someone is interacting with the display.
+  useEffect(() => {
+    let lastInteraction = -Infinity;
+    const markInteraction = () => {
+      lastInteraction = Date.now();
+    };
+    const interactionEvents = [
+      "pointerdown",
+      "wheel",
+      "touchstart",
+      "keydown",
+    ] as const;
+    for (const name of interactionEvents) {
+      document.addEventListener(name, markInteraction, { passive: true });
+    }
+
+    const scrollToNow = () => {
+      if (Date.now() - lastInteraction < INTERACTION_IDLE_MS) return;
+      const container = document.querySelector(
+        '[data-testid="schedule-scroll"]'
+      );
+      const line = document.querySelector('[data-testid="now-line"]');
+      if (!container || !line) return;
+      const containerTop = container.getBoundingClientRect().top;
+      window.scrollTo({
+        top: window.scrollY + containerTop - STICKY_TOP_PX,
+        behavior: "smooth",
+      });
+      container.scrollTo({
+        top:
+          container.scrollTop +
+          line.getBoundingClientRect().top -
+          containerTop -
+          container.clientHeight / 3,
+        behavior: "smooth",
+      });
+    };
+
+    const initial = setTimeout(scrollToNow, INITIAL_SCROLL_DELAY_MS);
+    const interval = setInterval(scrollToNow, SCROLL_INTERVAL_MS);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+      for (const name of interactionEvents) {
+        document.removeEventListener(name, markInteraction);
+      }
+    };
+  }, []);
+
+  return null;
+}

--- a/app/(site)/[eventSlug]/location-col.tsx
+++ b/app/(site)/[eventSlug]/location-col.tsx
@@ -10,13 +10,15 @@ export function LocationCol(props: {
   location: Location;
   day: DayWithSessions;
   guests: Guest[];
+  /** Kiosk now-line offset from the top of the slot grid; null hides it. */
+  nowOffsetPx?: number | null;
 }) {
-  const { sessions, location, day, guests } = props;
+  const { sessions, location, day, guests, nowOffsetPx } = props;
   const slotIncrement = useSlotIncrement();
   const sessionsWithBlanks = insertBlankSessions(sessions, day, slotIncrement);
   const numSlots = getNumSlots(day.start, day.end, slotIncrement);
   return (
-    <div className={"px-0.5"}>
+    <div className={"relative px-0.5"}>
       <div
         className={clsx("grid h-full", `grid-rows-[repeat(${numSlots},44px)]`)}
       >
@@ -32,6 +34,16 @@ export function LocationCol(props: {
           );
         })}
       </div>
+      {/* Each column draws its own segment of the kiosk now line; together
+          with the gutter's segment (see DayGrid) they form one continuous
+          line across the day. */}
+      {nowOffsetPx != null && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-0 z-10 h-0.5 bg-red-500 pointer-events-none"
+          style={{ top: nowOffsetPx }}
+        />
+      )}
     </div>
   );
 }

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -1,0 +1,58 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { DateTime } from "luxon";
+
+// Kiosk mode (?kiosk=1) is meant for large screens at the venue: it draws a
+// red line across the grid at the current time and keeps it scrolled into
+// view. The seeded events lie ~2 weeks in the future (see
+// scripts/seed-database.ts: Conference Gamma's first day is today+14, running
+// 09:00–18:00 Europe/Berlin), so the test moves the browser clock to a moment
+// within that first day to make the now line appear.
+
+// 16:00 Berlin on Gamma's first event day — late enough in the day that the
+// line starts outside the visible schedule area and only auto-scrolling
+// brings it into view.
+const duringGammaDayOne = DateTime.now()
+  .setZone("Europe/Berlin")
+  .plus({ days: 14 })
+  .set({ hour: 16, minute: 0, second: 0, millisecond: 0 })
+  .toJSDate();
+
+// The page must load and hydrate at (roughly) real time — the server renders
+// with the real clock, and a client clock jumped ahead makes hydration
+// disagree about which slots are in the past. So: install a naturally ticking
+// clock, load the page, and only then jump to the target time and fast-forward
+// through the kiosk mode intervals so the now line appears and scrolls without
+// waiting minutes of wall-clock time.
+async function openGammaScheduleDuringEvent(page: Page, path: string) {
+  await page.clock.install();
+  await login(page);
+  await page.goto(path);
+  await expect(
+    page.getByRole("heading", { name: /Conference Gamma Schedule/ })
+  ).toBeVisible();
+  // The heading comes from server-rendered HTML, so the page may still be
+  // hydrating. Only hydrated React reacts to the view toggle by rewriting the
+  // URL — once that works, hydration is done and the clock can jump safely.
+  await expect(async () => {
+    await page.getByRole("button", { name: "Text" }).click();
+    await expect(page).toHaveURL(/view=text/, { timeout: 1000 });
+  }).toPass();
+  await page.getByRole("button", { name: "Grid" }).click();
+  await expect(page).toHaveURL(/view=grid/);
+  await page.clock.setFixedTime(duringGammaDayOne);
+  await page.clock.runFor("05:00");
+}
+
+test("kiosk mode draws a now line and auto-scrolls it into view", async ({
+  page,
+}) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma?kiosk=1");
+  await expect(page.getByTestId("now-line")).toBeInViewport();
+});
+
+test("without the kiosk parameter there is no now line", async ({ page }) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+});

--- a/tests/unit/slots.test.ts
+++ b/tests/unit/slots.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   SLOT_INCREMENT_OPTIONS,
+  SLOT_HEIGHT_PX,
   isValidSlotIncrement,
   getNumSlots,
+  getNowOffsetPx,
   isSlotAligned,
   slotDurationOptions,
   snapDurationToSlots,
@@ -48,6 +50,35 @@ describe("getNumSlots", () => {
 
   it("rounds a misaligned window up so it still renders", () => {
     expect(getNumSlots(at(9), at(17), 45)).toBe(11); // 480 min / 45 = 10.67
+  });
+});
+
+// ── getNowOffsetPx ───────────────────────────────────────────────────────────
+
+describe("getNowOffsetPx", () => {
+  const at = (h: number, m = 0) => new Date(Date.UTC(2026, 8, 1, h, m));
+  const day = { start: at(9), end: at(18) };
+
+  it("day start → 0", () => {
+    expect(getNowOffsetPx(day, at(9), 30)).toBe(0);
+  });
+
+  it("one slot in → one slot height", () => {
+    expect(getNowOffsetPx(day, at(9, 30), 30)).toBe(SLOT_HEIGHT_PX);
+    expect(getNowOffsetPx(day, at(9, 15), 15)).toBe(SLOT_HEIGHT_PX);
+  });
+
+  it("interpolates within a slot", () => {
+    expect(getNowOffsetPx(day, at(9, 15), 30)).toBe(SLOT_HEIGHT_PX / 2);
+  });
+
+  it("before the day window → null", () => {
+    expect(getNowOffsetPx(day, at(8, 59), 30)).toBeNull();
+  });
+
+  it("at or after the day end → null", () => {
+    expect(getNowOffsetPx(day, at(18), 30)).toBeNull();
+    expect(getNowOffsetPx(day, at(23), 30)).toBeNull();
   });
 });
 

--- a/utils/slots.ts
+++ b/utils/slots.ts
@@ -12,6 +12,9 @@ export const DEFAULT_SLOT_INCREMENT_MINUTES = 30;
 
 const MS_PER_MINUTE = 60 * 1000;
 
+/** Rendered height of one slot row in the schedule grid. */
+export const SLOT_HEIGHT_PX = 44;
+
 export function isValidSlotIncrement(minutes: number): boolean {
   return SLOT_INCREMENT_OPTIONS.some((opt) => opt === minutes);
 }
@@ -27,6 +30,20 @@ export function getNumSlots(
 ): number {
   const lengthMs = end.getTime() - start.getTime();
   return Math.ceil(lengthMs / MS_PER_MINUTE / incrementMinutes);
+}
+
+/**
+ * Vertical pixel offset of `now` from the top of a day's slot grid (kiosk
+ * now-line), or null when `now` falls outside [start, end).
+ */
+export function getNowOffsetPx(
+  day: { start: Date; end: Date },
+  now: Date,
+  incrementMinutes: number
+): number | null {
+  const offsetMs = now.getTime() - day.start.getTime();
+  if (offsetMs < 0 || now.getTime() >= day.end.getTime()) return null;
+  return (offsetMs / (incrementMinutes * MS_PER_MINUTE)) * SLOT_HEIGHT_PX;
 }
 
 /** True when `date` sits a whole number of slots away from `anchor`. */


### PR DESCRIPTION
Large displays at the event location need an unattended view: a red
line marks the current time and the schedule auto-scrolls back to it
at regular intervals (paused while someone uses the display), the
event data is refreshed periodically so the screen never goes stale,
and a screen wake lock keeps the display on. The schedule stays fully
interactive so visitors without a phone can still RSVP or add
sessions from the display.

closes #13
closes #307

<!-- jip:pushed-commit=79cf7adff187d3a3ed8a216698cd9c91090d707d -->