### PR TITLE
fix: copy sharp's native libs into Docker runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 # Migrations are loaded at runtime relative to process.cwd()
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+# sharp's native addon loads libvips via dlopen, which Next's file-tracer
+# can't detect, so the standalone output omits it; copy it in explicitly
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/sharp ./node_modules/sharp
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@img ./node_modules/@img
 
 RUN mkdir -p /data && chown nextjs:nodejs /data
 


### PR DESCRIPTION
Next's standalone-output tracer can't detect sharp's dlopen() of
libvips-cpp.so, so it silently omitted the package, breaking image
uploads at runtime.

<!-- jip:pushed-commit=191469f3601579660a9ab6fee0656807a3ca3429 -->