### PR TITLE
fix: store location colors as Tailwind palette names

### DIFF
--- a/app/(site)/class-constants.tsx
+++ b/app/(site)/class-constants.tsx
@@ -41,31 +41,6 @@ export const rowSpanVars = [
   "row-span-38",
 ];
 
-export const allLocationColors = [
-  "bg-slate-500 bg-slate-200 bg-slate-100 bg-slate-400 border-slate-400 border-slate-600 focus:ring-slate-400 text-slate-400 text-slate-500 bg-slate-100",
-  "bg-gray-500 bg-gray-200 bg-gray-100 bg-gray-400 border-gray-400 border-gray-600 focus:ring-gray-400 text-gray-400 text-gray-500 bg-gray-100",
-  "bg-zinc-500 bg-zinc-200 bg-zinc-100 bg-zinc-400 border-zinc-400 border-zinc-600 focus:ring-zinc-400 text-zinc-400 text-zinc-500 bg-zinc-100",
-  "bg-neutral-500 bg-neutral-200 bg-neutral-100 bg-neutral-400 border-neutral-400 border-neutral-600 focus:ring-neutral-400 text-neutral-400 text-neutral-500 bg-neutral-100",
-  "bg-stone-500 bg-stone-200 bg-stone-100 bg-stone-400 border-stone-400 border-stone-600 focus:ring-stone-400 text-stone-400 text-stone-500 bg-stone-100",
-  "bg-red-500 bg-red-200 bg-red-100 bg-red-400 border-red-400 border-red-600 focus:ring-red-400 text-red-400 text-red-500 bg-red-100",
-  "bg-orange-500 bg-orange-200 bg-orange-100 bg-orange-400 border-orange-400 border-orange-600 focus:ring-orange-400 text-orange-400 text-orange-500 bg-orange-100",
-  "bg-amber-500 bg-amber-200 bg-amber-100 bg-amber-400 border-amber-400 border-amber-600 focus:ring-amber-400 text-amber-400 text-amber-500 bg-amber-100",
-  "bg-yellow-500 bg-yellow-200 bg-yellow-100 bg-yellow-400 border-yellow-400 border-yellow-600 focus:ring-yellow-400 text-yellow-400 text-yellow-500 bg-yellow-100",
-  "bg-lime-500 bg-lime-200 bg-lime-100 bg-lime-400 border-lime-400 border-lime-600 focus:ring-lime-400 text-lime-400 text-lime-500 bg-lime-100",
-  "bg-green-500 bg-green-200 bg-green-100 bg-green-400 border-green-400 border-green-600 focus:ring-green-400 text-green-400  text-green-500 bg-green-100",
-  "bg-emerald-500 bg-emerald-200 bg-emerald-100 bg-emerald-400 border-emerald-400 border-emerald-600 focus:ring-emerald-400 text-emerald-400 text-emerald-500 bg-emerald-100",
-  "bg-teal-500 bg-teal-200 bg-teal-100 bg-teal-400 border-teal-400 border-teal-600 focus:ring-teal-400 text-teal-400 text-teal-500 bg-teal-100",
-  "bg-cyan-500 bg-cyan-200 bg-cyan-100 bg-cyan-400 border-cyan-400 border-cyan-600 focus:ring-cyan-400 text-cyan-400 text-cyan-500 bg-cyan-100",
-  "bg-sky-500 bg-sky-200 bg-sky-100 bg-sky-400 border-sky-400 border-sky-600 focus:ring-sky-400 text-sky-400 text-sky-500 bg-sky-100",
-  "bg-blue-500 bg-blue-200 bg-blue-100 bg-blue-400 border-blue-400 border-blue-600 focus:ring-blue-400 text-blue-400 text-blue-500 bg-blue-100",
-  "bg-indigo-500 bg-indigo-200 bg-indigo-100 bg-indigo-400 border-indigo-400 border-indigo-600 focus:ring-indigo-400 text-indigo-400 text-indigo-500 bg-indigo-100",
-  "bg-violet-500 bg-violet-200 bg-violet-100 bg-violet-400 border-violet-400 border-violet-600 focus:ring-violet-400 text-violet-400 text-violet-500 bg-violet-100",
-  "bg-purple-500 bg-purple-200 bg-purple-100 bg-purple-400 border-purple-400 border-purple-600 focus:ring-purple-400 text-purple-400 text-purple-500 bg-purple-100",
-  "bg-fuchsia-500 bg-fuchsia-200 bg-fuchsia-100 bg-fuchsia-400 border-fuchsia-400 border-fuchsia-600 focus:ring-fuchsia-400 text-fuchsia-400 text-fuchsia-500 bg-fuchsia-100",
-  "bg-pink-500 bg-pink-200 bg-pink-100 bg-pink-400 border-pink-400 border-pink-600 focus:ring-pink-400 text-pink-400 text-pink-500 bg-pink-100",
-  "bg-rose-500 bg-rose-200 bg-rose-100 bg-rose-400 border-rose-400 border-rose-600 focus:ring-rose-400 text-rose-400 text-rose-500 bg-rose-100",
-];
-
 export const dayGridRowVars = [
   "grid-rows-[repeat(1,minmax(0,1fr))]",
   "grid-rows-[repeat(2,minmax(0,1fr))]",

--- a/app/actions/admin-locations.ts
+++ b/app/actions/admin-locations.ts
@@ -10,6 +10,7 @@ import {
   validateLocationImage,
 } from "@/utils/location-images";
 import type { Location } from "@/db/repositories/interfaces";
+import { normalizeLocationColor } from "@/utils/location-colors";
 import type { AdminActionResult } from "./admin-guests";
 
 async function isAdminRequest(): Promise<boolean> {
@@ -46,10 +47,7 @@ function parseLocationForm(
     return { error: "Capacity must be a non-negative whole number" };
   }
 
-  const color = formString(formData, "color");
-  if (color && !/^#[0-9a-fA-F]{6}$/.test(color)) {
-    return { error: "Color must be a hex value like #aabbcc" };
-  }
+  const color = normalizeLocationColor(formString(formData, "color"));
 
   const areaDescription = formString(formData, "areaDescription");
   const imageEntry = formData.get("image");

--- a/app/admin/locations-manager.tsx
+++ b/app/admin/locations-manager.tsx
@@ -13,6 +13,11 @@ import {
   moveLocationAction,
 } from "../actions/admin-locations";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON, DANGER_BUTTON } from "./buttons";
+import {
+  LOCATION_COLOR_NAMES,
+  DEFAULT_LOCATION_COLOR,
+  isLocationColorName,
+} from "@/utils/location-colors";
 
 export type AdminLocation = {
   location: Location;
@@ -42,6 +47,11 @@ function LocationForm({
   const [isPending, startTransition] = useTransition();
   const formRef = useRef<HTMLFormElement>(null);
   const idPrefix = location ? `loc-${location.id}` : "loc-new";
+  const [color, setColor] = useState<string>(
+    location && isLocationColorName(location.color)
+      ? location.color
+      : DEFAULT_LOCATION_COLOR
+  );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -128,13 +138,28 @@ function LocationForm({
           >
             Color
           </label>
-          <input
-            id={`${idPrefix}-color`}
-            name="color"
-            type="color"
-            defaultValue={location?.color || "#94a3b8"}
-            className="h-10 w-20 rounded-md border border-gray-300 bg-white"
-          />
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className={clsx(
+                "h-10 w-10 shrink-0 rounded-md border border-gray-300",
+                `bg-${color}-500`
+              )}
+            />
+            <select
+              id={`${idPrefix}-color`}
+              name="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="h-10 flex-1 rounded-md border border-gray-300 bg-white px-2 capitalize shadow-sm focus:ring-2 focus:ring-rose-400 focus:outline-0"
+            >
+              {LOCATION_COLOR_NAMES.map((name) => (
+                <option key={name} value={name} className="capitalize">
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
 
@@ -347,11 +372,13 @@ function LocationRow({
         )}
         <div className="flex-1 min-w-0">
           <p className="font-medium text-gray-900 truncate flex items-center gap-2">
-            {location.color && (
+            {isLocationColorName(location.color) && (
               <span
                 aria-hidden
-                className="inline-block w-3 h-3 rounded-full border border-gray-300 shrink-0"
-                style={{ backgroundColor: location.color }}
+                className={clsx(
+                  "inline-block w-3 h-3 rounded-full border border-gray-300 shrink-0",
+                  `bg-${location.color}-500`
+                )}
               />
             )}
             {location.name}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,19 @@
 @import "tailwindcss";
 @config "../tailwind.config.ts";
 
+/*
+ * Location colors are stored as Tailwind palette names and rendered as
+ * dynamic classes (bg-${color}-500, …), which Tailwind's static content
+ * scanner can't see. Safelist every shade actually used across the app.
+ * Keep the color list here in sync with LOCATION_COLOR_NAMES in
+ * utils/location-colors.ts — tests/unit/location-colors-safelist.test.ts
+ * enforces it.
+ */
+@source inline("bg-{slate,gray,zinc,neutral,stone,red,orange,amber,yellow,lime,green,emerald,teal,cyan,sky,blue,indigo,violet,purple,fuchsia,pink,rose}-{100,200,400,500}");
+@source inline("border-{slate,gray,zinc,neutral,stone,red,orange,amber,yellow,lime,green,emerald,teal,cyan,sky,blue,indigo,violet,purple,fuchsia,pink,rose}-{400,600}");
+@source inline("text-{slate,gray,zinc,neutral,stone,red,orange,amber,yellow,lime,green,emerald,teal,cyan,sky,blue,indigo,violet,purple,fuchsia,pink,rose}-{400,500}");
+@source inline("focus:ring-{slate,gray,zinc,neutral,stone,red,orange,amber,yellow,lime,green,emerald,teal,cyan,sky,blue,indigo,violet,purple,fuchsia,pink,rose}-400");
+
 html {
   scrollbar-gutter: stable;
 }

--- a/drizzle/0011_location_color_names.sql
+++ b/drizzle/0011_location_color_names.sql
@@ -1,0 +1,5 @@
+UPDATE `locations` SET `color` = 'slate' WHERE `color` NOT IN (
+  'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber',
+  'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky', 'blue',
+  'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose'
+);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,884 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f8ff41f1-f1da-45a3-bb07-4b26dae51b15",
+  "prevId": "33d87c8f-982e-4701-9adf-97c8540fff0f",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attendee_scheduled": {
+          "name": "attendee_scheduled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1783288151579,
       "tag": "0010_equal_turbo",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1783288200000,
+      "tag": "0011_location_color_names",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -105,7 +105,7 @@ export async function createLocation(opts?: {
     imageUrl: "",
     description: "",
     capacity: opts?.capacity ?? 30,
-    color: "#3b82f6",
+    color: "blue",
     hidden: false,
     bookable: opts?.bookable ?? true,
     sortIndex: 0,

--- a/tests/integration/admin-locations.test.ts
+++ b/tests/integration/admin-locations.test.ts
@@ -57,7 +57,7 @@ function locationFormData(
   formData.set("name", "Main Hall");
   formData.set("description", "The big one");
   formData.set("capacity", "50");
-  formData.set("color", "#aabbcc");
+  formData.set("color", "teal");
   for (const [key, value] of Object.entries(overrides)) {
     formData.set(key, value);
   }
@@ -133,12 +133,22 @@ describe("admin location actions", () => {
         name: "Main Hall",
         description: "The big one",
         capacity: 50,
-        color: "#aabbcc",
+        color: "teal",
         hidden: true,
         bookable: true,
         areaDescription: "First floor",
         imageUrl: "",
       });
+    });
+
+    it("coerces an invalid colour to the default palette name", async () => {
+      const result = await createLocationAction(
+        locationFormData({ color: "#aabbcc" })
+      );
+      expect(result).toEqual({ ok: true });
+
+      const [created] = await getRepositories().locations.list();
+      expect(created.color).toBe("slate");
     });
 
     it("appends new locations at the end of the sort order", async () => {

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -176,6 +176,63 @@ describe("runMigrations", () => {
     ]);
   });
 
+  // The locations table with a `color` column holding legacy values, so the
+  // colour-coercion migration runs against realistic pre-existing data.
+  const legacyLocationsTable = `CREATE TABLE \`locations\` (
+      \`id\` text PRIMARY KEY NOT NULL,
+      \`name\` text NOT NULL,
+      \`image_url\` text DEFAULT '' NOT NULL,
+      \`description\` text DEFAULT '' NOT NULL,
+      \`capacity\` integer DEFAULT 0 NOT NULL,
+      \`color\` text DEFAULT '' NOT NULL,
+      \`hidden\` integer DEFAULT false NOT NULL,
+      \`bookable\` integer DEFAULT false NOT NULL,
+      \`sort_index\` integer DEFAULT 0 NOT NULL,
+      \`area_description\` text
+    );`;
+
+  function readColorMigration(): string[] {
+    const drizzleDir = path.join(process.cwd(), "drizzle");
+    const file = fs
+      .readdirSync(drizzleDir)
+      .filter((f) => /^\d+_.*\.sql$/.test(f))
+      .find((f) =>
+        fs
+          .readFileSync(path.join(drizzleDir, f), "utf8")
+          .includes("UPDATE `locations` SET `color`")
+      );
+    expect(file, "location colour migration not found").toBeDefined();
+    return fs
+      .readFileSync(path.join(drizzleDir, file!), "utf8")
+      .split("--> statement-breakpoint\n");
+  }
+
+  it("the colour migration coerces legacy hex/empty location colours", () => {
+    writeMigrations(tmpDir, [
+      [
+        legacyLocationsTable,
+        `INSERT INTO locations (id, name, color) VALUES
+           ('l1', 'Hex', '#aabbcc'),
+           ('l2', 'Old default', '#94a3b8'),
+           ('l3', 'Empty', ''),
+           ('l4', 'Already valid', 'teal');`,
+      ],
+      readColorMigration(),
+    ]);
+
+    runMigrations(sqlite, tmpDir);
+
+    const rows = sqlite
+      .prepare("SELECT id, color FROM locations ORDER BY id")
+      .all();
+    expect(rows).toEqual([
+      { id: "l1", color: "slate" },
+      { id: "l2", color: "slate" },
+      { id: "l3", color: "slate" },
+      { id: "l4", color: "teal" },
+    ]);
+  });
+
   it("leaves foreign key enforcement enabled afterwards", () => {
     writeMigration(tmpDir, ["CREATE TABLE t (id text PRIMARY KEY);"]);
 

--- a/tests/unit/location-colors-safelist.test.ts
+++ b/tests/unit/location-colors-safelist.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import { LOCATION_COLOR_NAMES } from "@/utils/location-colors";
+
+const GLOBALS_CSS_PATH = path.join(__dirname, "../../app/globals.css");
+
+function extractSafelistedColors(css: string, prefix: string): string[] {
+  const match = css.match(new RegExp(`${prefix}-\\{([^}]+)\\}`));
+  if (!match) return [];
+  return match[1].split(",").map((name) => name.trim());
+}
+
+describe("Tailwind safelist for location colors", () => {
+  const css = readFileSync(GLOBALS_CSS_PATH, "utf8");
+  const expected = [...LOCATION_COLOR_NAMES].sort();
+
+  it.each(["bg", "border", "text", "focus:ring"])(
+    "safelists every LOCATION_COLOR_NAMES entry for %s-*",
+    (prefix) => {
+      const safelisted = extractSafelistedColors(css, prefix).sort();
+      expect(safelisted).toEqual(expected);
+    }
+  );
+});

--- a/utils/location-colors.ts
+++ b/utils/location-colors.ts
@@ -1,0 +1,47 @@
+// The schedule renders location colours as Tailwind palette classes
+// (`bg-${color}-500`, `border-${color}-600`, …), so a location's `color` must
+// be one of Tailwind's palette *names* — not an arbitrary hex value. The full
+// set of shade classes for every name below is safelisted via `@source
+// inline(...)` in `app/globals.css` so the production build keeps them.
+// tests/unit/location-colors-safelist.test.ts keeps the two lists in sync.
+
+export const LOCATION_COLOR_NAMES = [
+  "slate",
+  "gray",
+  "zinc",
+  "neutral",
+  "stone",
+  "red",
+  "orange",
+  "amber",
+  "yellow",
+  "lime",
+  "green",
+  "emerald",
+  "teal",
+  "cyan",
+  "sky",
+  "blue",
+  "indigo",
+  "violet",
+  "purple",
+  "fuchsia",
+  "pink",
+  "rose",
+] as const;
+
+export type LocationColorName = (typeof LOCATION_COLOR_NAMES)[number];
+
+export const DEFAULT_LOCATION_COLOR: LocationColorName = "slate";
+
+const NAMES = new Set<string>(LOCATION_COLOR_NAMES);
+
+export function isLocationColorName(value: string): value is LocationColorName {
+  return NAMES.has(value);
+}
+
+/** Coerces stored/submitted input to a valid palette name, defaulting safely. */
+export function normalizeLocationColor(value: string): LocationColorName {
+  const trimmed = value.trim();
+  return isLocationColorName(trimmed) ? trimmed : DEFAULT_LOCATION_COLOR;
+}


### PR DESCRIPTION
The schedule renders a location's color as Tailwind shade classes
(bg-${color}-500, border-${color}-600), which requires a palette *name*.
The admin locations UI instead stored a hex value from <input type=color>,
producing invalid classes (bg-#aabbcc-500) that left schedule blocks white
— and invisible on host/RSVP'd sessions where text is white.

Switch the admin form to a palette-name select and coerce stored colors to
a valid name; the schedule is unchanged. A data migration rewrites existing
locations whose stored color is a hex/empty value to the default palette
name, so already-seeded data renders correctly without re-saving each
location by hand.

Safelist every shade class actually used, via Tailwind v4's `@source
inline(...)` in app/globals.css (the v3-style `safelist` config key is a
no-op in v4 — verified empirically). A test keeps the safelisted colors in
sync with LOCATION_COLOR_NAMES.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=8625b12e130a9eee99f36849754e0c633781ee8f -->