### PR TITLE
fix: header no longer overlays content with a single event

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -40,7 +40,7 @@ export default async function SiteLayout({
       <main
         className={clsx(
           "lg:px-24 sm:p-3 flex-1",
-          multipleEvents ? "sm:py-24 lg:pb-16" : "pt-20 lg:pb-16"
+          multipleEvents ? "sm:py-24 lg:pb-16" : "pt-20 sm:pt-24 lg:pb-16"
         )}
       >
         {children}


### PR DESCRIPTION
The single-event <main> used a base-layer `pt-20`, which `sm:p-3`
overrode at the sm breakpoint and up, collapsing top padding so
content slid under the fixed nav bar. Add `sm:pt-24` so top padding
survives, matching the multi-event branch.

<!-- jip:pushed-commit=b713ccf2383eff2ec6baabb999be0e49bb749d8a -->