### PR TITLE
feat: admin REST routes to create guests and proposals

### DIFF
--- a/app/actions/admin-guests.ts
+++ b/app/actions/admin-guests.ts
@@ -33,11 +33,16 @@ export async function createGuestAction(input: {
   if (validationError) return { ok: false, error: validationError };
 
   const { guests } = getRepositories();
-  if (await guests.findByEmail(email)) {
+  // findOrCreateByEmail is atomic (unique index on lower(email)), so a
+  // concurrent create with the same email can't slip past this check.
+  const { created } = await guests.findOrCreateByEmail({
+    name,
+    info: { email },
+  });
+  if (!created) {
     return { ok: false, error: "A user with this email already exists" };
   }
 
-  await guests.create({ name, info: { email } });
   revalidatePath("/admin/users");
   return { ok: true };
 }
@@ -60,7 +65,23 @@ export async function updateGuestAction(input: {
     return { ok: false, error: "A user with this email already exists" };
   }
 
-  const updated = await guests.update(input.id, { name, info: { email } });
+  let updated;
+  try {
+    updated = await guests.update(input.id, { name, info: { email } });
+  } catch (e) {
+    // A concurrent update/create can win the race between the findByEmail
+    // check above and this update; translate the constraint violation into
+    // the same friendly error instead of surfacing a 500.
+    if (
+      e instanceof Error &&
+      e.message.includes(
+        "UNIQUE constraint failed: index 'guests_email_unique'"
+      )
+    ) {
+      return { ok: false, error: "A user with this email already exists" };
+    }
+    throw e;
+  }
   if (!updated) return { ok: false, error: "User not found" };
 
   revalidatePath("/admin/users");

--- a/app/api/admin/create-guest/route.ts
+++ b/app/api/admin/create-guest/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only guest creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = { name?: string; email?: string; eventSlug?: string };
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (
+    (body.name !== undefined && typeof body.name !== "string") ||
+    (body.email !== undefined && typeof body.email !== "string")
+  ) {
+    return NextResponse.json(
+      { error: "name and email must be strings" },
+      { status: 400 }
+    );
+  }
+  const name = (body.name ?? "").trim();
+  const email = (body.email ?? "").trim();
+
+  if (!name) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 });
+  }
+  if (!email || !/^\S+@\S+\.\S+$/.test(email)) {
+    return NextResponse.json(
+      { error: "Invalid email address" },
+      { status: 400 }
+    );
+  }
+
+  const { guests, events } = getRepositories();
+
+  let eventId: string | undefined;
+  if (body.eventSlug) {
+    const event = await events.findBySlug(body.eventSlug);
+    if (!event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+    eventId = event.id;
+  }
+
+  // Idempotent by email (case-insensitive) so concurrent seeding scripts
+  // re-running an import do not race into duplicate guests.
+  const { guest, created } = await guests.findOrCreateByEmail({
+    name,
+    info: { email },
+  });
+
+  if (eventId) {
+    await guests.assignToEvent(eventId, [guest.id]);
+  }
+
+  return NextResponse.json({ id: guest.id, created });
+}

--- a/app/api/admin/create-proposal/route.ts
+++ b/app/api/admin/create-proposal/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only proposal creation over plain HTTP, for external seeding scripts.
+// Unlike the site's createProposal server action this has no phase gate: an
+// admin seeds proposals regardless of the event phase.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = {
+  eventSlug?: string;
+  title?: string;
+  description?: string;
+  durationMinutes?: number | null;
+  hostIds?: string[];
+};
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (
+    (body.title !== undefined && typeof body.title !== "string") ||
+    (body.description !== undefined && typeof body.description !== "string") ||
+    (body.hostIds !== undefined && !Array.isArray(body.hostIds))
+  ) {
+    return NextResponse.json(
+      { error: "title and description must be strings, hostIds an array" },
+      { status: 400 }
+    );
+  }
+  const title = (body.title ?? "").trim();
+  if (!title) {
+    return NextResponse.json({ error: "Title is required" }, { status: 400 });
+  }
+
+  const duration = body.durationMinutes;
+  if (
+    duration !== null &&
+    duration !== undefined &&
+    (!Number.isInteger(duration) || duration < 0)
+  ) {
+    return NextResponse.json(
+      { error: "Duration must be a non-negative integer" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.eventSlug) {
+    return NextResponse.json(
+      { error: "eventSlug is required" },
+      { status: 400 }
+    );
+  }
+
+  const { sessionProposals, guests, events } = getRepositories();
+  const event = await events.findBySlug(body.eventSlug);
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const hostIds = [...new Set((body.hostIds ?? []).filter(Boolean))];
+  for (const guestId of hostIds) {
+    if (!(await guests.findById(guestId))) {
+      return NextResponse.json(
+        { error: `Guest not found: ${guestId}` },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Keep hosts as members of the event so they show up in its guest list.
+  if (hostIds.length > 0) {
+    await guests.assignToEvent(event.id, hostIds);
+  }
+
+  const proposal = await sessionProposals.create({
+    eventId: event.id,
+    title,
+    description: body.description?.trim() || undefined,
+    hostIds,
+    durationMinutes: duration ?? undefined,
+  });
+
+  return NextResponse.json({ id: proposal.id });
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import {
+  verifyPassword,
+  verifyAdminPassword,
+  isPasswordProtectionEnabled,
+  isAdminEnabled,
+  createAuthCookie,
+  createAdminAuthCookie,
+} from "@/utils/auth";
+
+export const dynamic = "force-dynamic";
+
+type LoginBody = { password?: string; scope?: "site" | "admin" };
+
+// Exchanges a password for an auth cookie. Mirrors the browser login server
+// actions (loginAction / adminLoginAction) but over plain HTTP, so scripts can
+// authenticate without replaying Next's server-action wire protocol. Lives
+// under /api/auth/, which the middleware allows through without a prior cookie.
+export async function POST(req: Request) {
+  let parsed: unknown;
+  try {
+    parsed = await req.json();
+  } catch {
+    parsed = undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const { password = "", scope = "site" } = parsed as LoginBody;
+
+  // Strict, so a script's typo'd scope fails loudly instead of silently
+  // falling back to site auth.
+  if (scope !== "site" && scope !== "admin") {
+    return NextResponse.json({ error: "Unknown scope" }, { status: 400 });
+  }
+
+  if (scope === "admin") {
+    if (!isAdminEnabled()) {
+      return NextResponse.json(
+        { error: "Admin access is disabled" },
+        { status: 403 }
+      );
+    }
+    if (!verifyAdminPassword(password)) {
+      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    }
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set(await createAdminAuthCookie());
+    return res;
+  }
+
+  // scope === "site": when protection is disabled every request is already
+  // authorized, so there is nothing to hand out.
+  if (!isPasswordProtectionEnabled()) {
+    return NextResponse.json({ ok: true });
+  }
+  if (!verifyPassword(password)) {
+    return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(await createAuthCookie());
+  return res;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Montserrat, Roboto } from "next/font/google";
 import "./globals.css";
 import { CONSTS } from "@/utils/constants";
@@ -21,6 +21,11 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.ico",
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -152,10 +152,19 @@ export interface GuestsRepository {
     }
   ): Promise<EventGuestPage>;
   findById(id: string): Promise<CompleteGuest | undefined>;
+  // Matches the email case-insensitively.
   findByEmail(email: string): Promise<CompleteGuest | undefined>;
   /** Guests whose email matches any of `emails`, compared case-insensitively. */
   findByEmails(emails: string[]): Promise<CompleteGuest[]>;
   create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest>;
+  /**
+   * Atomically creates a guest, or returns the existing one if a guest with
+   * the same email (case-insensitive) already exists. Safe under concurrent
+   * calls with the same email (backed by a DB-level unique index).
+   */
+  findOrCreateByEmail(
+    data: Omit<CompleteGuest, "id">
+  ): Promise<{ guest: CompleteGuest; created: boolean }>;
   // Usage: an admin updates a user (name and private info such as email).
   update(
     id: string,

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -197,7 +197,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
     const row = this.db
       .select()
       .from(schema.guests)
-      .where(eq(schema.guests.email, email))
+      .where(sql`lower(${schema.guests.email}) = lower(${email})`)
       .get();
     return row ? rowToGuest(row) : undefined;
   }
@@ -222,6 +222,36 @@ export class SqliteGuestsRepository implements GuestsRepository {
 
     this.db.insert(schema.guests).values({ id, name, email }).run();
     return { id, ...data };
+  }
+
+  async findOrCreateByEmail(
+    data: Omit<CompleteGuest, "id">
+  ): Promise<{ guest: CompleteGuest; created: boolean }> {
+    const id = nanoid();
+    const {
+      name,
+      info: { email },
+    } = data;
+
+    // Atomic under concurrency: the unique index on lower(email) makes the
+    // insert the single source of truth, instead of racing a prior read.
+    const inserted = this.db
+      .insert(schema.guests)
+      .values({ id, name, email })
+      .onConflictDoNothing()
+      .returning()
+      .all();
+    if (inserted.length > 0) {
+      return { guest: rowToGuest(inserted[0]), created: true };
+    }
+
+    const existing = await this.findByEmail(email);
+    if (!existing) {
+      throw new Error(
+        `Guest insert conflicted but no existing row for email ${email}`
+      );
+    }
+    return { guest: existing, created: false };
   }
 
   async update(

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   sqliteTable,
   text,
@@ -6,14 +7,21 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
-export const guests = sqliteTable("guests", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  email: text("email").notNull(),
-  aboutMe: text("about_me"),
-  pronouns: text("pronouns"),
-  avatarUrl: text("avatar_url"),
-});
+export const guests = sqliteTable(
+  "guests",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull(),
+    aboutMe: text("about_me"),
+    pronouns: text("pronouns"),
+    avatarUrl: text("avatar_url"),
+  },
+  (table) => [
+    // Case-insensitive: two guests must never share an email up to case.
+    uniqueIndex("guests_email_unique").on(sql`lower(${table.email})`),
+  ]
+);
 
 export const events = sqliteTable(
   "events",

--- a/drizzle/0015_guests_email_unique.sql
+++ b/drizzle/0015_guests_email_unique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `guests_email_unique` ON `guests` (lower("email"));

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,913 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "29951640-ab89-47d5-8f12-94abc8be019b",
+  "prevId": "58c2fd11-f07b-4bc9-8fa5-b48f5cb72e9d",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1783757368893,
       "tag": "0014_profile_pronouns",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1783801789716,
+      "tag": "0015_guests_email_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -11,9 +11,10 @@ import { sanitizeGuest } from "@/utils/guests";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// Date.now() alone can collide when two events are created in the same
-// millisecond, violating the unique event slug.
+// Date.now() alone can collide when two events (or guests) are created in
+// the same millisecond, violating the unique event slug (or guest email).
 let eventCounter = 0;
+let guestCounter = 0;
 
 export async function createEvent(opts?: {
   phase?: "proposal" | "voting" | "scheduling";
@@ -87,7 +88,7 @@ export async function createGuest(opts?: {
   email?: string;
 }): Promise<Guest> {
   const { guests } = getRepositories();
-  const unique = Date.now();
+  const unique = ++guestCounter;
   return guests
     .create({
       name: opts?.name ?? `Test Guest ${unique}`,

--- a/tests/integration/admin-create-guest-route.test.ts
+++ b/tests/integration/admin-create-guest-route.test.ts
@@ -1,0 +1,163 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-guest/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-guest", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(
+  res: Response
+): Promise<{ id: string; created: boolean }> {
+  return (await res.json()) as { id: string; created: boolean };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("POST /api/admin/create-guest", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }));
+    expect(res.status).toBe(401);
+    expect(
+      await getRepositories().guests.findByEmail("tom@foocorp.com")
+    ).toBeUndefined();
+  });
+
+  it("creates a guest and returns its id", async () => {
+    const res = await POST(
+      makeReq({ name: "Tom Tailor", email: "tom.tailor@foocorp.com" })
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.created).toBe(true);
+    expect(body.id).toBeTruthy();
+
+    const guest = await getRepositories().guests.findByEmail(
+      "tom.tailor@foocorp.com"
+    );
+    expect(guest?.id).toBe(body.id);
+    expect(guest?.name).toBe("Tom Tailor");
+  });
+
+  it("is idempotent by email: returns the existing id with created=false", async () => {
+    const first = await readJson(
+      await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }))
+    );
+    const res = await POST(
+      makeReq({ name: "Tom Different", email: "tom@foocorp.com" })
+    );
+    const body = await readJson(res);
+    expect(body.created).toBe(false);
+    expect(body.id).toBe(first.id);
+  });
+
+  it("assigns the guest to the event when eventSlug is given", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({
+        name: "Anna Beck",
+        email: "anna.beck@foocorp.com",
+        eventSlug: event.slug,
+      })
+    );
+    const body = await readJson(res);
+    const members = await getRepositories().guests.listByEvent(event.id);
+    expect(members.map((g) => g.id)).toContain(body.id);
+  });
+
+  it("matches existing emails case-insensitively", async () => {
+    const first = await readJson(
+      await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }))
+    );
+    const res = await POST(makeReq({ name: "Tom", email: "Tom@Foocorp.com" }));
+    const body = await readJson(res);
+    expect(body.created).toBe(false);
+    expect(body.id).toBe(first.id);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-guest", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid email with 400", async () => {
+    const res = await POST(makeReq({ name: "Bad", email: "not-an-email" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing name with 400", async () => {
+    const res = await POST(makeReq({ name: "  ", email: "x@foocorp.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string name with 400", async () => {
+    const res = await POST(makeReq({ name: 123, email: "x@foocorp.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string email with 400", async () => {
+    const res = await POST(makeReq({ name: "Tom", email: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown eventSlug", async () => {
+    const res = await POST(
+      makeReq({
+        name: "X",
+        email: "x@foocorp.com",
+        eventSlug: "does-not-exist",
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/integration/admin-create-proposal-route.test.ts
+++ b/tests/integration/admin-create-proposal-route.test.ts
@@ -1,0 +1,157 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-proposal/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-proposal", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("POST /api/admin/create-proposal", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({ eventSlug: event.slug, title: "T", hostIds: [] })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a proposal with hosts and duration, returning its id", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const host = await createGuest();
+    const res = await POST(
+      makeReq({
+        eventSlug: event.slug,
+        title: "Prompt engineering basics",
+        description: "hands-on intro",
+        durationMinutes: 45,
+        hostIds: [host.id],
+      })
+    );
+    expect(res.status).toBe(200);
+    const { id } = (await res.json()) as { id: string };
+
+    const proposal = await getRepositories().sessionProposals.findById(id);
+    expect(proposal?.title).toBe("Prompt engineering basics");
+    expect(proposal?.durationMinutes).toBe(45);
+    expect(proposal?.hosts.map((h) => h.id)).toEqual([host.id]);
+  });
+
+  it("assigns the hosts to the event", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const host = await createGuest();
+    await POST(
+      makeReq({ eventSlug: event.slug, title: "T", hostIds: [host.id] })
+    );
+    const members = await getRepositories().guests.listByEvent(event.id);
+    expect(members.map((g) => g.id)).toContain(host.id);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-proposal", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing title with 400", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({ eventSlug: event.slug, title: "  ", hostIds: [] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown host id with 400", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({ eventSlug: event.slug, title: "T", hostIds: ["nope"] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string title with 400", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({ eventSlug: event.slug, title: 123, hostIds: [] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string description with 400", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({
+        eventSlug: event.slug,
+        title: "T",
+        description: 123,
+        hostIds: [],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-array hostIds with 400", async () => {
+    const event = await createEvent({ phase: "voting" });
+    const res = await POST(
+      makeReq({ eventSlug: event.slug, title: "T", hostIds: "nope" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown eventSlug", async () => {
+    const res = await POST(
+      makeReq({ eventSlug: "does-not-exist", title: "T", hostIds: [] })
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/integration/auth-login-route.test.ts
+++ b/tests/integration/auth-login-route.test.ts
@@ -1,0 +1,93 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { POST } from "@/app/api/auth/login/route";
+import {
+  isAuthCookieValid,
+  isAdminCookieValid,
+  AUTH_COOKIE_NAME,
+  ADMIN_COOKIE_NAME,
+} from "@/utils/auth";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/login", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("sets a valid site cookie for the correct site password", async () => {
+    const res = await POST(makeReq({ password: "site-pw" }));
+    expect(res.status).toBe(200);
+    const cookie = res.cookies.get(AUTH_COOKIE_NAME);
+    expect(cookie).toBeDefined();
+    expect(await isAuthCookieValid(cookie!.value)).toBe(true);
+  });
+
+  it("rejects a wrong site password with 401 and no cookie", async () => {
+    const res = await POST(makeReq({ password: "nope" }));
+    expect(res.status).toBe(401);
+    expect(res.cookies.get(AUTH_COOKIE_NAME)).toBeUndefined();
+  });
+
+  it("sets a valid admin cookie for scope=admin with the correct password", async () => {
+    const res = await POST(makeReq({ password: "admin-pw", scope: "admin" }));
+    expect(res.status).toBe(200);
+    const cookie = res.cookies.get(ADMIN_COOKIE_NAME);
+    expect(cookie).toBeDefined();
+    expect(await isAdminCookieValid(cookie!.value)).toBe(true);
+  });
+
+  it("rejects a wrong admin password with 401", async () => {
+    const res = await POST(makeReq({ password: "nope", scope: "admin" }));
+    expect(res.status).toBe(401);
+    expect(res.cookies.get(ADMIN_COOKIE_NAME)).toBeUndefined();
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/auth/login", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a null JSON body with 400", async () => {
+    const res = await POST(makeReq(null));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown scope with 400", async () => {
+    const res = await POST(makeReq({ password: "site-pw", scope: "Admin" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 for scope=admin when admin is disabled", async () => {
+    vi.stubEnv("ADMIN_PASSWORD", "");
+    const res = await POST(makeReq({ password: "whatever", scope: "admin" }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -13,6 +13,51 @@ describe("guest profile repositories", () => {
   beforeAll(() => setupTestDb());
   beforeEach(() => resetTestDb());
 
+  describe("guests.findOrCreateByEmail", () => {
+    it("creates a new guest when the email is unused", async () => {
+      const { guests } = getRepositories();
+      const { guest, created } = await guests.findOrCreateByEmail({
+        name: "New Guest",
+        info: { email: "new@test.example" },
+      });
+      expect(created).toBe(true);
+      expect(await guests.findById(guest.id)).toMatchObject({
+        name: "New Guest",
+      });
+    });
+
+    it("returns the existing guest without creating a duplicate row when the email (any case) already exists", async () => {
+      const { guests } = getRepositories();
+      const existing = await createGuest({
+        name: "Existing",
+        email: "dup@test.example",
+      });
+
+      const { guest, created } = await guests.findOrCreateByEmail({
+        name: "Someone Else",
+        info: { email: "Dup@Test.Example" },
+      });
+
+      expect(created).toBe(false);
+      expect(guest.id).toBe(existing.id);
+      expect(guest.name).toBe("Existing");
+      const all = await guests.listFull();
+      expect(
+        all.filter((g) => g.info.email.toLowerCase() === "dup@test.example")
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("guests table uniqueness", () => {
+    it("rejects inserting two guests with the same email up to case", async () => {
+      const { guests } = getRepositories();
+      await createGuest({ name: "A", email: "case@test.example" });
+      await expect(
+        guests.create({ name: "B", info: { email: "Case@Test.Example" } })
+      ).rejects.toThrow(/UNIQUE constraint failed/i);
+    });
+  });
+
   describe("guests.updateProfile", () => {
     it("updates name and aboutMe, leaving email intact", async () => {
       const { guests } = getRepositories();


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [1aae13f](https://github.com/LWCW-Europe/schellingboard/pull/566/commits/1aae13f369494e73216fef18b2518e513f3bec58).

PRs:
* #579
* ➡️ #566 (this PR, base of the stack — can be merged first)

---

## Description

Add plain-HTTP endpoints so external scripts can seed data without
replaying Next's server-action wire protocol:

- POST /api/auth/login exchanges a password for a site or admin cookie
- POST /api/admin/create-guest (idempotent by email; optional event
  assignment)
- POST /api/admin/create-proposal (no phase gate: admins seed
  proposals in any phase)

The admin routes sit behind site auth (middleware) and additionally
require the admin cookie. Votes reuse the existing /api/add-vote.

Emails are matched case-insensitively: findByEmail now compares with
lower(), so the route's idempotency and the admin UI's duplicate
checks treat Tom@X and tom@x as the same guest.

The frontend intentionally does not use these routes: it keeps using
server actions (idiomatic Next), whose semantics deliberately differ
(phase gates, duplicate email as an error). These routes exist solely
for scripts, which also get strict 400s on malformed bodies or an
unknown login scope.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=1aae13f369494e73216fef18b2518e513f3bec58 -->