### PR TITLE
feat: admin REST route to list users for seeding scripts

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+
+export const dynamic = "force-dynamic";
+
+// Without an explicit no-store, browsers heuristically cache this response;
+// user emails are sensitive and must never be served stale or from cache.
+const NO_STORE = { headers: { "cache-control": "no-store" } };
+
+// Admin-only user listing over plain HTTP, for external seeding scripts that
+// need to resolve an existing guest (by name or email) before submitting votes,
+// RSVPs, etc. The middleware already enforces site auth for /api/*; here we
+// additionally require the admin cookie, matching the other admin routes.
+//
+// Returns every user in one response. No pagination yet: no other API route
+// paginates, and the payload is wrapped in an object so a `total`/`page` can be
+// added later without breaking clients.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+export async function GET() {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { ...NO_STORE, status: 401 }
+    );
+  }
+
+  try {
+    const { guests } = getRepositories();
+    const users = (await guests.listFull()).map((g) => ({
+      id: g.id,
+      name: g.name,
+      email: g.info.email,
+    }));
+
+    return NextResponse.json({ users }, NO_STORE);
+  } catch (error) {
+    console.error("Error fetching admin users:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch users" },
+      { ...NO_STORE, status: 500 }
+    );
+  }
+}

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -108,6 +108,7 @@ export type EventGuestPage = {
 
 export interface GuestsRepository {
   list(): Promise<Guest[]>;
+  /** Every user with their private info (email). For admin export/lookup. */
   listFull(): Promise<CompleteGuest[]>;
   listByEvent(eventId: string): Promise<Guest[]>;
   /**

--- a/tests/integration/admin-users-route.test.ts
+++ b/tests/integration/admin-users-route.test.ts
@@ -1,0 +1,110 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { GET } from "@/app/api/admin/users/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+type User = { id: string; name: string; email: string };
+
+async function readUsers(res: Response): Promise<User[]> {
+  return ((await res.json()) as { users: User[] }).users;
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("GET /api/admin/users", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns an empty list when there are no users", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await readUsers(res)).toEqual([]);
+  });
+
+  it("returns every user with id, name and email", async () => {
+    const { guests } = getRepositories();
+    const anna = await guests.create({
+      name: "Anna Beck",
+      info: { email: "anna@foocorp.com" },
+    });
+    const tom = await guests.create({
+      name: "Tom Tailor",
+      info: { email: "tom@foocorp.com" },
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const users = await readUsers(res);
+
+    expect(users).toHaveLength(2);
+    const byId = new Map(users.map((u) => [u.id, u]));
+    expect(byId.get(anna.id)).toEqual({
+      id: anna.id,
+      name: "Anna Beck",
+      email: "anna@foocorp.com",
+    });
+    expect(byId.get(tom.id)).toEqual({
+      id: tom.id,
+      name: "Tom Tailor",
+      email: "tom@foocorp.com",
+    });
+  });
+
+  it("returns a structured 500 when the repository throws", async () => {
+    const { guests } = getRepositories();
+    vi.spyOn(guests, "listFull").mockRejectedValue(new Error("db down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.json()).toEqual({ error: "Failed to fetch users" });
+  });
+});


### PR DESCRIPTION
Add cache-control: no-store, error handling, and consistent header
usage matching other API routes.

<!-- jip:pushed-commit=e4b14dec08ddea76ddb73649edac24afda430370 -->