### PR TITLE
feat(admin): searchable host multi-select in proposal form

### DIFF
--- a/app/admin/events/[id]/event-proposals-manager.tsx
+++ b/app/admin/events/[id]/event-proposals-manager.tsx
@@ -13,6 +13,7 @@ import {
   DANGER_BUTTON,
 } from "@/app/admin/buttons";
 import { DataTable } from "../../data-table";
+import { SelectHosts } from "@/app/select-hosts";
 
 export type ProposalRow = {
   id: string;
@@ -46,9 +47,7 @@ function ProposalItem({
   const [duration, setDuration] = useState(
     proposal.durationMinutes === null ? "" : String(proposal.durationMinutes)
   );
-  const [hostIds, setHostIds] = useState<string[]>(
-    proposal.hosts.map((h) => h.id)
-  );
+  const [hosts, setHosts] = useState<EventGuest[]>(proposal.hosts);
   const [isSaving, startSave] = useTransition();
   const [deleteMode, setDeleteMode] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
@@ -56,7 +55,7 @@ function ProposalItem({
 
   // Offer event-assigned guests as hosts, plus any current host that is not
   // (or no longer) assigned to the event so existing hosts are never dropped.
-  const candidates: EventGuest[] = [
+  const hostCandidates: EventGuest[] = [
     ...eventGuests,
     ...proposal.hosts.filter((h) => !eventGuests.some((g) => g.id === h.id)),
   ];
@@ -67,13 +66,8 @@ function ProposalItem({
     setDuration(
       proposal.durationMinutes === null ? "" : String(proposal.durationMinutes)
     );
-    setHostIds(proposal.hosts.map((h) => h.id));
+    setHosts(proposal.hosts);
   };
-
-  const toggleHost = (id: string) =>
-    setHostIds((prev) =>
-      prev.includes(id) ? prev.filter((h) => h !== id) : [...prev, id]
-    );
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
@@ -93,7 +87,7 @@ function ProposalItem({
           title,
           description,
           durationMinutes,
-          hostIds,
+          hostIds: hosts.map((h) => h.id),
         });
         if (!result.ok) {
           onError(result.error);
@@ -261,32 +255,27 @@ function ProposalItem({
           className="w-full h-10"
         />
       </div>
-      <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Hosts</legend>
-        {candidates.length === 0 ? (
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={`prop-hosts-${proposal.id}`}
+          className="text-sm text-gray-600"
+        >
+          Hosts
+        </label>
+        {hostCandidates.length === 0 ? (
           <p className="text-sm text-gray-500">
             No guests assigned to this event yet.
           </p>
         ) : (
-          <div className="flex flex-col gap-1">
-            {candidates.map((g) => (
-              <label
-                key={g.id}
-                className="flex items-center gap-2 text-sm text-gray-700"
-              >
-                <input
-                  type="checkbox"
-                  checked={hostIds.includes(g.id)}
-                  onChange={() => toggleHost(g.id)}
-                  aria-label={`Host ${g.name}`}
-                  className="h-4 w-4 cursor-pointer"
-                />
-                {g.name}
-              </label>
-            ))}
-          </div>
+          <SelectHosts
+            guests={hostCandidates}
+            hosts={hosts}
+            setHosts={setHosts}
+            id={`prop-hosts-${proposal.id}`}
+            selectMany
+          />
         )}
-      </fieldset>
+      </div>
       <div className="flex gap-2">
         <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
           {isSaving ? "Saving..." : "Save"}

--- a/app/select-hosts.tsx
+++ b/app/select-hosts.tsx
@@ -32,15 +32,16 @@ export function SelectHosts<T extends { id: string; name: string }>(props: {
                   className="py-1 px-2 bg-gray-100 rounded text-nowrap text-sm flex items-center gap-1"
                 >
                   {host.name}
-                  <span
+                  <button
+                    type="button"
                     onClick={(e) => {
                       setHosts(hosts.filter((h) => h.id !== host.id));
                       e.stopPropagation();
                     }}
-                    role="button"
+                    aria-label={`Remove ${host.name}`}
                   >
                     <XMarkIcon className="h-4 w-4 text-gray-400 hover:text-gray-700" />
-                  </span>
+                  </button>
                 </span>
               ))}
             </>

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1110,28 +1110,32 @@ test.describe("Admin UI proposals", () => {
       .getByRole("button", { name: /^Edit/ })
       .click();
 
-    // Host checkboxes for the event's assigned guests are shown
-    await expect(proposals.getByLabel("Host Charlie Test")).toBeVisible();
+    // Add a host through the searchable multi-select (opens on focus).
+    await proposals.getByLabel("Hosts").click();
+    await page.keyboard.type("Alice");
+    await page.getByRole("option", { name: "Alice Test" }).click();
+    await page.keyboard.press("Escape");
 
     await proposals.getByLabel("Title *").fill(edited);
     await proposals.getByRole("button", { name: "Save", exact: true }).click();
 
-    // Server refreshes; the renamed proposal is shown
-    await expect(
-      proposals.getByRole("listitem").filter({ hasText: edited })
-    ).toBeVisible();
-
-    // Revert the title to keep the seed data clean for other tests
-    await proposals
+    // Server refreshes; the renamed proposal shows the added host
+    const editedRow = proposals
       .getByRole("listitem")
-      .filter({ hasText: edited })
-      .getByRole("button", { name: /^Edit/ })
-      .click();
+      .filter({ hasText: edited });
+    await expect(editedRow).toBeVisible();
+    await expect(editedRow).toContainText("Alice Test");
+
+    // Revert title and hosts to keep the seed data clean for other tests
+    await editedRow.getByRole("button", { name: /^Edit/ }).click();
+    await proposals.getByRole("button", { name: "Remove Alice Test" }).click();
     await proposals.getByLabel("Title *").fill(original);
     await proposals.getByRole("button", { name: "Save", exact: true }).click();
-    await expect(
-      proposals.getByRole("listitem").filter({ hasText: original })
-    ).toBeVisible();
+    const revertedRow = proposals
+      .getByRole("listitem")
+      .filter({ hasText: original });
+    await expect(revertedRow).toBeVisible();
+    await expect(revertedRow).not.toContainText("Alice Test");
   });
 
   test("deletes a proposal via named confirm", async ({ page }) => {


### PR DESCRIPTION
Same rationale as the session form: host checkboxes don't scale to
hundreds of guests, so reuse the shared SelectHosts combobox. Also give
the chip-remove button an accessible name and make it keyboard-operable.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=6dcce751627fc6d5a34be874fe0ea9e193e1079e -->