### PR TITLE
fix: keep EventContext's now fresh for long-lived pages

### DIFF
--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -17,6 +17,7 @@ import {
 } from "../context";
 import { sessionsOverlap } from "../session_utils";
 import { getStartTimePlusBreak, TIME_FORMAT } from "@/utils/utils";
+import { isBookableSlot } from "@/utils/session-bookable";
 import { LockIcon } from "../lock-icon";
 import { viewSessionLinkFromOwner } from "./modal-nav";
 
@@ -27,7 +28,7 @@ export function SessionBlock(props: {
   guests: Guest[];
 }) {
   const { session, location, day, guests } = props;
-  const { rsvpdForSession, event } = useContext(EventContext);
+  const { rsvpdForSession, event, now } = useContext(EventContext);
   const eventSlug = event?.slug ?? "";
   const timezone = event?.timezone ?? "UTC";
   const { user } = useContext(UserContext);
@@ -40,13 +41,15 @@ export function SessionBlock(props: {
   const numSlots = sessionLength / 1000 / 60 / slotIncrement;
 
   const isBlank = !session.title;
-  const isBookable =
-    !!isBlank &&
-    !!location.bookable &&
-    startTime > new Date().getTime() &&
-    (!day.startBookings || startTime >= day.startBookings.getTime()) &&
-    (!day.endBookings || startTime < day.endBookings.getTime()) &&
-    !session.blocker;
+  const isBookable = isBookableSlot({
+    isBlank,
+    locationBookable: !!location.bookable,
+    blocker: !!session.blocker,
+    startTime,
+    now: now.getTime(),
+    startBookings: day.startBookings?.getTime(),
+    endBookings: day.endBookings?.getTime(),
+  });
   return isBookable ? (
     <BookableSessionCard
       eventSlug={eventSlug}

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -18,6 +18,7 @@ import type {
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
 import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 import { DEFAULT_SLOT_INCREMENT_MINUTES } from "@/utils/slots";
+import { startNowTicker } from "@/utils/now-ticker";
 
 export type DayWithSessions = Day & { sessions: Session[] };
 
@@ -38,8 +39,10 @@ export interface EventContextType {
   locations: Location[];
   guests: Guest[];
   rsvps: Rsvp[];
-  // Captured once on the server so SSR and hydration agree on time-dependent
-  // decisions (e.g. which schedule days default to folded).
+  // Starts as the server-rendered value so SSR and hydration agree on
+  // time-dependent decisions (e.g. which schedule days default to folded),
+  // then ticks forward on the client (see startNowTicker) so long-lived
+  // pages don't treat a stale `now` as current (e.g. bookable-slot checks).
   now: Date;
   rsvpdForSession: (sessionId: string) => boolean;
   localSessions: Session[];
@@ -157,6 +160,9 @@ export function EventProvider({
   const [rsvpCountDeltas, setRsvpCountDeltas] = useState(
     () => new Map<string, number>()
   );
+  const [now, setNow] = useState(value.now);
+
+  useEffect(() => startNowTicker(setNow), []);
 
   const localSessions = serverSessions.map((session) => {
     const delta = rsvpCountDeltas.get(session.id) ?? 0;
@@ -292,6 +298,7 @@ export function EventProvider({
 
   const contextValue: EventContextType = {
     ...value,
+    now,
     rsvps,
     localSessions,
     userBusySessions,

--- a/tests/unit/now-ticker.test.ts
+++ b/tests/unit/now-ticker.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { startNowTicker } from "@/utils/now-ticker";
+
+describe("startNowTicker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls onTick with the current time at each interval", () => {
+    const onTick = vi.fn();
+    startNowTicker(onTick, 1000);
+
+    expect(onTick).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+    expect(onTick).toHaveBeenLastCalledWith(expect.any(Date));
+
+    vi.advanceTimersByTime(2000);
+    expect(onTick).toHaveBeenCalledTimes(3);
+    expect(onTick).toHaveBeenLastCalledWith(expect.any(Date));
+  });
+
+  it("stops ticking once the returned cleanup function is called", () => {
+    const onTick = vi.fn();
+    const stop = startNowTicker(onTick, 1000);
+
+    vi.advanceTimersByTime(1000);
+    stop();
+    vi.advanceTimersByTime(5000);
+
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/session-bookable.test.ts
+++ b/tests/unit/session-bookable.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isBookableSlot } from "@/utils/session-bookable";
+
+const baseParams = {
+  isBlank: true,
+  locationBookable: true,
+  blocker: false,
+  startTime: new Date("2026-07-11T10:00:00Z").getTime(),
+  now: new Date("2026-07-11T09:00:00Z").getTime(),
+  startBookings: new Date("2026-07-11T00:00:00Z").getTime(),
+  endBookings: new Date("2026-07-11T23:59:00Z").getTime(),
+};
+
+describe("isBookableSlot", () => {
+  it("is bookable when the slot is blank, in a bookable location, and in the future", () => {
+    expect(isBookableSlot(baseParams)).toBe(true);
+  });
+
+  it("is not bookable once the slot's start time has passed", () => {
+    expect(
+      isBookableSlot({ ...baseParams, now: baseParams.startTime + 1 })
+    ).toBe(false);
+  });
+
+  it("is not bookable when the slot has a title", () => {
+    expect(isBookableSlot({ ...baseParams, isBlank: false })).toBe(false);
+  });
+
+  it("is not bookable when the location isn't bookable", () => {
+    expect(isBookableSlot({ ...baseParams, locationBookable: false })).toBe(
+      false
+    );
+  });
+
+  it("is not bookable when the slot is a blocker", () => {
+    expect(isBookableSlot({ ...baseParams, blocker: true })).toBe(false);
+  });
+
+  it("is not bookable before the day's booking window opens", () => {
+    expect(
+      isBookableSlot({ ...baseParams, startBookings: baseParams.startTime + 1 })
+    ).toBe(false);
+  });
+
+  it("is not bookable at or after the day's booking window closes", () => {
+    expect(
+      isBookableSlot({ ...baseParams, endBookings: baseParams.startTime })
+    ).toBe(false);
+  });
+});

--- a/utils/now-ticker.ts
+++ b/utils/now-ticker.ts
@@ -1,0 +1,15 @@
+// How often EventContext's `now` refreshes on the client after the initial,
+// server-rendered value. See startNowTicker.
+export const NOW_REFRESH_INTERVAL_MS = 60_000;
+
+// Periodically reports the current time via onTick, starting after the first
+// interval elapses (the caller already has an initial value to render with).
+// Kept as a plain function, separate from the React effect that calls it, so
+// the scheduling behavior can be unit-tested without rendering a component.
+export function startNowTicker(
+  onTick: (now: Date) => void,
+  intervalMs: number = NOW_REFRESH_INTERVAL_MS
+): () => void {
+  const interval = setInterval(() => onTick(new Date()), intervalMs);
+  return () => clearInterval(interval);
+}

--- a/utils/session-bookable.ts
+++ b/utils/session-bookable.ts
@@ -1,0 +1,32 @@
+// Whether a blank slot can be booked by a guest. Time comparisons take `now`
+// as a parameter rather than reading it internally, so callers can pass
+// EventContext's `now` — seeded from the server-rendered value to avoid an
+// SSR/hydration mismatch, then ticked forward on the client — instead of a
+// fresh client-side `new Date()`.
+export function isBookableSlot(params: {
+  isBlank: boolean;
+  locationBookable: boolean;
+  blocker: boolean;
+  startTime: number;
+  now: number;
+  startBookings?: number;
+  endBookings?: number;
+}): boolean {
+  const {
+    isBlank,
+    locationBookable,
+    blocker,
+    startTime,
+    now,
+    startBookings,
+    endBookings,
+  } = params;
+  return (
+    isBlank &&
+    locationBookable &&
+    startTime > now &&
+    (startBookings === undefined || startTime >= startBookings) &&
+    (endBookings === undefined || startTime < endBookings) &&
+    !blocker
+  );
+}


### PR DESCRIPTION
Freezing now at the server-rendered value fixed the SSR/hydration
mismatch for time-dependent decisions (bookable-slot checks, default
day folding), but left it frozen for as long as the layout stayed
mounted. Tick it forward on the client every 60s after the initial
render so the staleness is bounded instead of unbounded.

Side effect: a day can now auto-fold once it fully passes while the
viewer has it open, if they haven't manually unfolded it. Desirable,
not just a bookable-slot fix.

<!-- jip:pushed-commit=4a3c905cc11fee366307f5cec92ce59ffda0117b -->