### PR TITLE
fix: use jj for app version, fall back to git

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,41 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
-function getAppVersion() {
+/**
+ * @param {string} file
+ * @param {readonly string[]} args
+ */
+function runQuiet(file, args) {
   try {
-    return execSync("git describe --tags --always --dirty", {
+    return execFileSync(file, args, {
       encoding: "utf-8",
       cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
   } catch {
-    return "unknown";
+    return null;
   }
+}
+
+function getAppVersion() {
+  // Prefer jj: some workspaces (e.g. `jj workspace add`) have no `.git` dir,
+  // where git commands always fail. Fall back to git for devs without jj.
+  const jjVersion = runQuiet("jj", [
+    "log",
+    "-r",
+    "@",
+    "--no-graph",
+    "-T",
+    'commit_id.short(8) ++ if(!empty, "-dirty")',
+  ]);
+  if (jjVersion) return jjVersion;
+
+  const gitVersion = runQuiet("git", [
+    "describe",
+    "--tags",
+    "--always",
+    "--dirty",
+  ]);
+  return gitVersion ?? "unknown";
 }
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
jj workspaces created via `jj workspace add` have no `.git` dir, so
`git describe` always failed there, printing a stderr warning during
e2e test runs. Prefer jj (short commit id, -dirty if uncommitted
changes) and fall back to git for devs without jj installed.

<!-- jip:pushed-commit=5905880d2c0cf4b15cc55b1a6d4af9c8a4ce03e4 -->