### PR TITLE
fix: enforce admin API auth in proxy, not per-route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- **Admin API auth hardened**: the `/api/admin/*` seeding endpoints are now authenticated in the proxy rather than in each route, so they reply with JSON (401/403/404) instead of an HTML login redirect, no longer require a site cookie alongside the admin one, and reject cross-site requests (CSRF). Scripts that only handled a 401 should also handle 403 (cross-site) and 404 (admin API disabled)
 - Documentation is built with [docmd](https://docmd.io) from `docs/public/`, which holds a single copy — the next release's documentation — with no per-version snapshots in the working tree. Published versions are reconstructed from release tags at build time, so releasing documentation is tagging the repository, and a published version can be corrected without a release by pushing a `docs-<version>` branch. Developer documentation (ADRs, design notes) moved to `docs/dev/` and stays out of the published site. See [CONTRIBUTING.md § Documentation](CONTRIBUTING.md#documentation)
 
 ## [3.1.0] - 2026-07-24

--- a/app/api/admin/create-day/route.ts
+++ b/app/api/admin/create-day/route.ts
@@ -1,23 +1,17 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 import { dayAlignmentError, daysOverlap } from "@/utils/day-window";
 
 export const dynamic = "force-dynamic";
 
 // Admin-only day creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 //
 // Behaves the same as createDayAction: a day overlapping an existing one
 // (including an exact duplicate) is a 409; otherwise multiple days can be
 // created freely, same as in the admin UI.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
 type Body = {
   eventSlug?: string;
   start?: string;
@@ -37,8 +31,9 @@ function badRequest(error: string) {
 }
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 import {
   eventNameToSlug,
   normalizeWebsiteUrl,
@@ -16,13 +15,8 @@ import {
 export const dynamic = "force-dynamic";
 
 // Admin-only event creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 type Body = {
   name?: string;
   description?: string;
@@ -59,8 +53,9 @@ function badRequest(error: string) {
 }
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-guest/route.ts
+++ b/app/api/admin/create-guest/route.ts
@@ -1,23 +1,18 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 
 export const dynamic = "force-dynamic";
 
 // Admin-only guest creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 type Body = { name?: string; email?: string; eventSlug?: string };
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-location/route.ts
+++ b/app/api/admin/create-location/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 import { normalizeLocationColor } from "@/utils/location-colors";
 
 export const dynamic = "force-dynamic";
-
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
 
 type Body = {
   name?: string;
@@ -27,16 +21,17 @@ function badRequest(error: string) {
 }
 
 // Admin-only location creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 //
 // Always creates a new location, same as the admin UI action: locations
 // aren't unique by name, so a name matching an existing location is not
 // treated as a duplicate to reuse. Image upload stays exclusive to the
 // admin UI action.
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-proposal/route.ts
+++ b/app/api/admin/create-proposal/route.ts
@@ -1,18 +1,14 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 
 export const dynamic = "force-dynamic";
 
 // Admin-only proposal creation over plain HTTP, for external seeding scripts.
 // Unlike the site's createProposal server action this has no phase gate: an
 // admin seeds proposals regardless of the event phase.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 type Body = {
   eventSlug?: string;
   title?: string;
@@ -22,8 +18,9 @@ type Body = {
 };
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-rsvp/route.ts
+++ b/app/api/admin/create-rsvp/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 
 export const dynamic = "force-dynamic";
 
 // Admin-only RSVP creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 //
 // Unlike /api/toggle-rsvp there is no scheduling-phase gate, so an import
 // never depends on the event's current phase. rsvpCapacityHardLimit is still
@@ -15,16 +14,12 @@ export const dynamic = "force-dynamic";
 // overbook. The guest is auto-assigned to the session's event so the RSVP is
 // never orphaned from the UI's member lists. Idempotent per (session, guest)
 // via the repository's onConflictDoNothing.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
 type Body = { sessionId?: string; guestId?: string };
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/create-session/route.ts
+++ b/app/api/admin/create-session/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { requireProxyVerifiedAdmin } from "@/utils/auth";
 import { sessionSlotAlignmentError } from "@/utils/day-window";
 
 export const dynamic = "force-dynamic";
 
 // Admin-only session creation over plain HTTP, for external seeding scripts.
-// The middleware already enforces site auth for /api/*; here we additionally
-// require the admin cookie, matching the admin server actions.
+// Auth is decided by the proxy (see requireAdminAuthApi), which forwards a
+// header this route re-checks so it fails closed if the proxy didn't run.
 //
 // Unlike /api/add-session this returns the created id (which the RSVP step
 // needs), takes absolute ISO times instead of the SessionParams shape, and —
@@ -19,11 +18,6 @@ export const dynamic = "force-dynamic";
 // aren't deduplicated, so a repeated request is a location conflict (409),
 // not a silent no-op. Hosts and locations are auto-assigned to the event so
 // imported sessions are fully visible without extra calls.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
 type Body = {
   eventSlug?: string;
   title?: string;
@@ -48,8 +42,9 @@ function badRequest(error: string) {
 }
 
 export async function POST(req: Request) {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   let body: Body;

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,33 +1,22 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { NO_STORE, requireProxyVerifiedAdmin } from "@/utils/auth";
 
 export const dynamic = "force-dynamic";
 
-// Without an explicit no-store, browsers heuristically cache this response;
-// user emails are sensitive and must never be served stale or from cache.
-const NO_STORE = { headers: { "cache-control": "no-store" } };
-
 // Admin-only user listing over plain HTTP, for external seeding scripts that
 // need to resolve an existing guest (by name or email) before submitting votes,
-// RSVPs, etc. The middleware already enforces site auth for /api/*; here we
-// additionally require the admin cookie, matching the other admin routes.
+// RSVPs, etc. Auth is decided by the proxy (see requireAdminAuthApi), which
+// forwards a header this route re-checks so it fails closed if the proxy
+// didn't run.
 //
 // Returns every user in one response. No pagination yet: no other API route
 // paginates, and the payload is wrapped in an object so a `total`/`page` can be
 // added later without breaking clients.
-async function isAdminRequest(): Promise<boolean> {
-  const cookieStore = await cookies();
-  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
-}
-
-export async function GET() {
-  if (!(await isAdminRequest())) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { ...NO_STORE, status: 401 }
-    );
+export async function GET(req: Request) {
+  const unverified = requireProxyVerifiedAdmin(req);
+  if (unverified) {
+    return unverified;
   }
 
   try {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,10 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   ADMIN_DISABLED_MESSAGE,
+  ADMIN_VERIFIED_HEADER,
   isAdminEnabled,
   requireAdminAuth,
+  requireAdminAuthApi,
   requireAuth,
 } from "./utils/auth";
+
+// Only requireAdminAuthApi may grant ADMIN_VERIFIED_HEADER (and only ever
+// sets it to "1"); every other forwarded request must have any
+// client-supplied copy of it removed so a route added outside /api/admin/*
+// can never be tricked into trusting a forged value.
+function forwardWithoutAdminHeader(request: NextRequest): NextResponse {
+  const headers = new Headers(request.headers);
+  headers.delete(ADMIN_VERIFIED_HEADER);
+  return NextResponse.next({ request: { headers } });
+}
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -15,10 +27,10 @@ export async function proxy(request: NextRequest) {
     pathname === "/api/health" ||
     pathname.startsWith("/api/auth/")
   ) {
-    return NextResponse.next();
+    return forwardWithoutAdminHeader(request);
   }
 
-  // Admin routes are independent of site auth: they require only admin
+  // Admin UI routes are independent of site auth: they require only admin
   // authentication (and return 404 when the admin UI is disabled)
   if (pathname === "/admin" || pathname.startsWith("/admin/")) {
     if (!isAdminEnabled()) {
@@ -30,7 +42,15 @@ export async function proxy(request: NextRequest) {
         return adminResponse;
       }
     }
-    return NextResponse.next();
+    return forwardWithoutAdminHeader(request);
+  }
+
+  // Admin API routes are likewise independent of site auth: they require
+  // only the admin cookie, checked here (route handlers trust the resulting
+  // ADMIN_VERIFIED_HEADER instead of re-checking the cookie themselves, but
+  // do require its presence — see requireProxyVerifiedAdmin).
+  if (pathname === "/api/admin" || pathname.startsWith("/api/admin/")) {
+    return requireAdminAuthApi(request);
   }
 
   // Check authentication for all other routes
@@ -39,7 +59,7 @@ export async function proxy(request: NextRequest) {
     return authResponse;
   }
 
-  return NextResponse.next();
+  return forwardWithoutAdminHeader(request);
 }
 
 export const config = {

--- a/tests/helpers/through-proxy.ts
+++ b/tests/helpers/through-proxy.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { proxy } from "@/proxy";
+import { createAdminAuthCookie } from "@/utils/auth";
+
+type ProxyResult =
+  { ok: true; request: Request } | { ok: false; response: NextResponse };
+
+/**
+ * Drives a request through the real `proxy` middleware and, if it lets the
+ * request continue, reconstructs the forwarded request the way Next.js does
+ * for `NextResponse.next({ request: { headers } })` (via the
+ * `x-middleware-override-headers` / `x-middleware-request-*` response
+ * headers). This is what lets route handler tests exercise proxy-set trust
+ * headers (e.g. ADMIN_VERIFIED_HEADER) instead of bypassing the proxy.
+ */
+export async function throughProxy(
+  path: string,
+  init: RequestInit = {},
+  cookies: { name: string; value: string }[] = []
+): Promise<ProxyResult> {
+  const proxyReq = new NextRequest(
+    `http://test${path}`,
+    init as ConstructorParameters<typeof NextRequest>[1]
+  );
+  for (const cookie of cookies) proxyReq.cookies.set(cookie);
+
+  const proxyRes = await proxy(proxyReq);
+  if (proxyRes.headers.get("x-middleware-next") !== "1") {
+    return { ok: false, response: proxyRes };
+  }
+
+  // `x-middleware-override-headers` is the COMPLETE new header set (every key
+  // present in the Headers object the middleware passed to
+  // `NextResponse.next({ request: { headers } })`), not a diff — Next
+  // discards the original request headers and rebuilds only from this list.
+  // A header the middleware deleted has no `x-middleware-request-*` entry and
+  // is simply absent from the list, so it must not survive here either.
+  const overridden = proxyRes.headers.get("x-middleware-override-headers");
+  const headers =
+    overridden === null
+      ? new Headers(proxyReq.headers)
+      : new Headers(
+          overridden
+            .split(",")
+            .map((name) => name.trim())
+            .filter((name) => name.length > 0)
+            .map((name): [string, string] => [
+              name,
+              proxyRes.headers.get(`x-middleware-request-${name}`) ?? "",
+            ])
+        );
+
+  // If `init.body` is a ReadableStream that's already been read (e.g. by
+  // something upstream), this throws — Request bodies can't be replayed.
+  // Not a concern today: no caller passes a stream body, and `proxy()` never
+  // reads the request body.
+  return {
+    ok: true,
+    request: new Request(`http://test${path}`, { ...init, headers }),
+  };
+}
+
+/**
+ * Drives a request through the real proxy, authenticated as admin unless
+ * `authed: false` is passed, and dispatches to `handler` if the proxy lets
+ * it through.
+ */
+export async function callThroughProxy(
+  handler: (req: Request) => Response | Promise<Response>,
+  path: string,
+  init: RequestInit = {},
+  opts: { authed?: boolean } = {}
+): Promise<Response> {
+  const cookies = opts.authed === false ? [] : [await createAdminAuthCookie()];
+  const result = await throughProxy(path, init, cookies);
+  return result.ok ? handler(result.request) : result.response;
+}

--- a/tests/integration/admin-create-day-route.test.ts
+++ b/tests/integration/admin-create-day-route.test.ts
@@ -8,41 +8,29 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent } from "../helpers/factories";
 import type { Event } from "@/db/repositories/interfaces";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-day/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-day";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-day", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(res: Response): Promise<{ id: string }> {
   return (await res.json()) as { id: string };
-}
-
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
 }
 
 function validBody(event: Event) {
@@ -62,24 +50,21 @@ describe("POST /api/admin/create-day", () => {
 
   beforeEach(async () => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
     event = await createEvent();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(makeReq(validBody(event)));
+    const res = await postJson(validBody(event), { authed: false });
     expect(res.status).toBe(401);
     expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
   });
 
   it("creates a day and returns its id", async () => {
-    const res = await POST(makeReq(validBody(event)));
+    const res = await postJson(validBody(event));
     expect(res.status).toBe(201);
     const body = await readJson(res);
 
@@ -93,63 +78,56 @@ describe("POST /api/admin/create-day", () => {
   });
 
   it("allows creating multiple non-overlapping days, same as the admin UI", async () => {
-    await POST(makeReq(validBody(event)));
-    const res = await POST(
-      makeReq({
-        ...validBody(event),
-        start: "2026-09-02T08:00:00Z",
-        end: "2026-09-02T18:00:00Z",
-        startBookings: "2026-09-02T09:00:00Z",
-        endBookings: "2026-09-02T17:00:00Z",
-      })
-    );
+    await postJson(validBody(event));
+    const res = await postJson({
+      ...validBody(event),
+      start: "2026-09-02T08:00:00Z",
+      end: "2026-09-02T18:00:00Z",
+      startBookings: "2026-09-02T09:00:00Z",
+      endBookings: "2026-09-02T17:00:00Z",
+    });
     expect(res.status).toBe(201);
     expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(2);
   });
 
   it("rejects a day identical to an existing one with 409, same as the admin UI", async () => {
-    await POST(makeReq(validBody(event)));
-    const res = await POST(makeReq(validBody(event)));
+    await postJson(validBody(event));
+    const res = await postJson(validBody(event));
     expect(res.status).toBe(409);
     expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(1);
   });
 
   it("rejects an overlapping non-identical day with 409", async () => {
-    await POST(makeReq(validBody(event)));
-    const res = await POST(
-      makeReq({
-        ...validBody(event),
-        start: "2026-09-01T09:00:00Z",
-        startBookings: "2026-09-01T09:00:00Z",
-      })
-    );
+    await postJson(validBody(event));
+    const res = await postJson({
+      ...validBody(event),
+      start: "2026-09-01T09:00:00Z",
+      startBookings: "2026-09-01T09:00:00Z",
+    });
     expect(res.status).toBe(409);
     expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(1);
   });
 
   it("rejects a day misaligned to the event's slot increment with 400", async () => {
     // The factory event uses 30-minute slots; 18:10 is not on a boundary.
-    const res = await POST(
-      makeReq({ ...validBody(event), end: "2026-09-01T18:10:00Z" })
-    );
+    const res = await postJson({
+      ...validBody(event),
+      end: "2026-09-01T18:10:00Z",
+    });
     expect(res.status).toBe(400);
     expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
   });
 
   it("returns 404 for an unknown eventSlug", async () => {
-    const res = await POST(
-      makeReq({ ...validBody(event), eventSlug: "does-not-exist" })
-    );
+    const res = await postJson({
+      ...validBody(event),
+      eventSlug: "does-not-exist",
+    });
     expect(res.status).toBe(404);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-day", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
@@ -191,7 +169,7 @@ describe("POST /api/admin/create-day", () => {
       }),
     ],
   ])("rejects %s with 400", async (_label, mutate) => {
-    const res = await POST(makeReq(mutate(validBody(event))));
+    const res = await postJson(mutate(validBody(event)));
     expect(res.status).toBe(400);
     expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
   });

--- a/tests/integration/admin-create-event-route.test.ts
+++ b/tests/integration/admin-create-event-route.test.ts
@@ -8,41 +8,29 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-event/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-event";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-event", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(
   res: Response
 ): Promise<{ id: string; slug: string } | { error: string }> {
   return (await res.json()) as { id: string; slug: string } | { error: string };
-}
-
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
 }
 
 const VALID_BODY = {
@@ -54,25 +42,22 @@ const VALID_BODY = {
 describe("POST /api/admin/create-event", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(async () => {
+  beforeEach(() => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(makeReq(VALID_BODY));
+    const res = await postJson(VALID_BODY, { authed: false });
     expect(res.status).toBe(401);
     expect(await getRepositories().events.list()).toEqual([]);
   });
 
   it("creates an event with defaults and returns id and slug", async () => {
-    const res = await POST(makeReq(VALID_BODY));
+    const res = await postJson(VALID_BODY);
     expect(res.status).toBe(201);
     const body = (await readJson(res)) as { id: string; slug: string };
     expect(body.slug).toBe("Summer-Camp");
@@ -92,36 +77,32 @@ describe("POST /api/admin/create-event", () => {
   });
 
   it("adds an https:// scheme to a bare website domain", async () => {
-    const res = await POST(makeReq({ ...VALID_BODY, website: "example.com" }));
+    const res = await postJson({ ...VALID_BODY, website: "example.com" });
     expect(res.status).toBe(201);
     const event = await getRepositories().events.findBySlug("Summer-Camp");
     expect(event?.website).toBe("https://example.com");
   });
 
   it("keeps an already-schemed website URL unchanged", async () => {
-    const res = await POST(
-      makeReq({
-        ...VALID_BODY,
-        website: "https://example.com",
-      })
-    );
+    const res = await postJson({
+      ...VALID_BODY,
+      website: "https://example.com",
+    });
     expect(res.status).toBe(201);
     const event = await getRepositories().events.findBySlug("Summer-Camp");
     expect(event?.website).toBe("https://example.com");
   });
 
   it("accepts explicit timezone, durations and scheduling phase", async () => {
-    const res = await POST(
-      makeReq({
-        ...VALID_BODY,
-        timezone: "Europe/Berlin",
-        maxSessionDuration: 90,
-        breakMinutes: 0,
-        slotIncrementMinutes: 15,
-        schedulingPhaseStart: "2026-08-01T00:00:00Z",
-        schedulingPhaseEnd: "2026-09-03T00:00:00Z",
-      })
-    );
+    const res = await postJson({
+      ...VALID_BODY,
+      timezone: "Europe/Berlin",
+      maxSessionDuration: 90,
+      breakMinutes: 0,
+      slotIncrementMinutes: 15,
+      schedulingPhaseStart: "2026-08-01T00:00:00Z",
+      schedulingPhaseEnd: "2026-09-03T00:00:00Z",
+    });
     expect(res.status).toBe(201);
     const { id } = (await readJson(res)) as { id: string; slug: string };
 
@@ -137,13 +118,15 @@ describe("POST /api/admin/create-event", () => {
   });
 
   it("rejects with 409 when the slug already exists", async () => {
-    const first = (await readJson(await POST(makeReq(VALID_BODY)))) as {
+    const first = (await readJson(await postJson(VALID_BODY))) as {
       id: string;
       slug: string;
     };
-    const res = await POST(
-      makeReq({ ...VALID_BODY, name: "Summer Camp", breakMinutes: 42 })
-    );
+    const res = await postJson({
+      ...VALID_BODY,
+      name: "Summer Camp",
+      breakMinutes: 42,
+    });
     expect(res.status).toBe(409);
     const body = (await readJson(res)) as { error: string };
     expect(body.error).toMatch(/already exists/);
@@ -153,12 +136,7 @@ describe("POST /api/admin/create-event", () => {
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-event", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
@@ -185,7 +163,7 @@ describe("POST /api/admin/create-event", () => {
       },
     ],
   ])("rejects %s with 400", async (_label, body) => {
-    const res = await POST(makeReq(body));
+    const res = await postJson(body);
     expect(res.status).toBe(400);
     expect(await getRepositories().events.list()).toEqual([]);
   });

--- a/tests/integration/admin-create-guest-route.test.ts
+++ b/tests/integration/admin-create-guest-route.test.ts
@@ -8,31 +8,24 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-guest/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-guest";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-guest", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(
@@ -41,27 +34,22 @@ async function readJson(
   return (await res.json()) as { id: string; created: boolean };
 }
 
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
-}
-
 describe("POST /api/admin/create-guest", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(async () => {
+  beforeEach(() => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }));
+    const res = await postJson(
+      { name: "Tom", email: "tom@foocorp.com" },
+      { authed: false }
+    );
     expect(res.status).toBe(401);
     expect(
       await getRepositories().guests.findByEmail("tom@foocorp.com")
@@ -69,9 +57,10 @@ describe("POST /api/admin/create-guest", () => {
   });
 
   it("creates a guest and returns its id", async () => {
-    const res = await POST(
-      makeReq({ name: "Tom Tailor", email: "tom.tailor@foocorp.com" })
-    );
+    const res = await postJson({
+      name: "Tom Tailor",
+      email: "tom.tailor@foocorp.com",
+    });
     expect(res.status).toBe(201);
     const body = await readJson(res);
     expect(body.created).toBe(true);
@@ -86,11 +75,12 @@ describe("POST /api/admin/create-guest", () => {
 
   it("is idempotent by email: returns the existing id with created=false", async () => {
     const first = await readJson(
-      await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }))
+      await postJson({ name: "Tom", email: "tom@foocorp.com" })
     );
-    const res = await POST(
-      makeReq({ name: "Tom Different", email: "tom@foocorp.com" })
-    );
+    const res = await postJson({
+      name: "Tom Different",
+      email: "tom@foocorp.com",
+    });
     expect(res.status).toBe(200);
     const body = await readJson(res);
     expect(body.created).toBe(false);
@@ -99,13 +89,11 @@ describe("POST /api/admin/create-guest", () => {
 
   it("assigns the guest to the event when eventSlug is given", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({
-        name: "Anna Beck",
-        email: "anna.beck@foocorp.com",
-        eventSlug: event.slug,
-      })
-    );
+    const res = await postJson({
+      name: "Anna Beck",
+      email: "anna.beck@foocorp.com",
+      eventSlug: event.slug,
+    });
     const body = await readJson(res);
     const members = await getRepositories().guests.listByEvent(event.id);
     expect(members.map((g) => g.id)).toContain(body.id);
@@ -113,52 +101,45 @@ describe("POST /api/admin/create-guest", () => {
 
   it("matches existing emails case-insensitively", async () => {
     const first = await readJson(
-      await POST(makeReq({ name: "Tom", email: "tom@foocorp.com" }))
+      await postJson({ name: "Tom", email: "tom@foocorp.com" })
     );
-    const res = await POST(makeReq({ name: "Tom", email: "Tom@Foocorp.com" }));
+    const res = await postJson({ name: "Tom", email: "Tom@Foocorp.com" });
     const body = await readJson(res);
     expect(body.created).toBe(false);
     expect(body.id).toBe(first.id);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-guest", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
   it("rejects an invalid email with 400", async () => {
-    const res = await POST(makeReq({ name: "Bad", email: "not-an-email" }));
+    const res = await postJson({ name: "Bad", email: "not-an-email" });
     expect(res.status).toBe(400);
   });
 
   it("rejects a missing name with 400", async () => {
-    const res = await POST(makeReq({ name: "  ", email: "x@foocorp.com" }));
+    const res = await postJson({ name: "  ", email: "x@foocorp.com" });
     expect(res.status).toBe(400);
   });
 
   it("rejects a non-string name with 400", async () => {
-    const res = await POST(makeReq({ name: 123, email: "x@foocorp.com" }));
+    const res = await postJson({ name: 123, email: "x@foocorp.com" });
     expect(res.status).toBe(400);
   });
 
   it("rejects a non-string email with 400", async () => {
-    const res = await POST(makeReq({ name: "Tom", email: 123 }));
+    const res = await postJson({ name: "Tom", email: 123 });
     expect(res.status).toBe(400);
   });
 
   it("returns 404 for an unknown eventSlug", async () => {
-    const res = await POST(
-      makeReq({
-        name: "X",
-        email: "x@foocorp.com",
-        eventSlug: "does-not-exist",
-      })
-    );
+    const res = await postJson({
+      name: "X",
+      email: "x@foocorp.com",
+      eventSlug: "does-not-exist",
+    });
     expect(res.status).toBe(404);
   });
 });

--- a/tests/integration/admin-create-location-route.test.ts
+++ b/tests/integration/admin-create-location-route.test.ts
@@ -8,65 +8,50 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { DEFAULT_LOCATION_COLOR } from "@/utils/location-colors";
 import { POST } from "@/app/api/admin/create-location/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-location";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-location", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(res: Response): Promise<{ id: string }> {
   return (await res.json()) as { id: string };
 }
 
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
-}
-
 describe("POST /api/admin/create-location", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(async () => {
+  beforeEach(() => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(makeReq({ name: "Main Hall" }));
+    const res = await postJson({ name: "Main Hall" }, { authed: false });
     expect(res.status).toBe(401);
     expect(await getRepositories().locations.list()).toEqual([]);
   });
 
   it("creates a location with defaults and returns its id", async () => {
-    const res = await POST(makeReq({ name: "Main Hall" }));
+    const res = await postJson({ name: "Main Hall" });
     expect(res.status).toBe(201);
     const body = await readJson(res);
 
@@ -80,18 +65,16 @@ describe("POST /api/admin/create-location", () => {
   });
 
   it("accepts explicit fields and auto-increments sortIndex", async () => {
-    await POST(makeReq({ name: "Main Hall" }));
-    const res = await POST(
-      makeReq({
-        name: "Workshop Room",
-        description: "First floor",
-        areaDescription: "North wing",
-        capacity: 25,
-        color: "blue",
-        hidden: true,
-        bookable: true,
-      })
-    );
+    await postJson({ name: "Main Hall" });
+    const res = await postJson({
+      name: "Workshop Room",
+      description: "First floor",
+      areaDescription: "North wing",
+      capacity: 25,
+      color: "blue",
+      hidden: true,
+      bookable: true,
+    });
     const { id } = await readJson(res);
 
     const location = await getRepositories().locations.findById(id);
@@ -106,9 +89,9 @@ describe("POST /api/admin/create-location", () => {
 
   it("creates a new location even when the name matches an existing one", async () => {
     const first = await readJson(
-      await POST(makeReq({ name: "Main Hall", capacity: 100 }))
+      await postJson({ name: "Main Hall", capacity: 100 })
     );
-    const res = await POST(makeReq({ name: "main hall", capacity: 5 }));
+    const res = await postJson({ name: "main hall", capacity: 5 });
     const body = await readJson(res);
     expect(body.id).not.toBe(first.id);
 
@@ -119,9 +102,7 @@ describe("POST /api/admin/create-location", () => {
 
   it("assigns the location to the event when eventSlug is given", async () => {
     const event = await createEvent();
-    const res = await POST(
-      makeReq({ name: "Main Hall", eventSlug: event.slug })
-    );
+    const res = await postJson({ name: "Main Hall", eventSlug: event.slug });
     const { id } = await readJson(res);
 
     const assigned = await getRepositories().locations.listLocationIdsByEvent(
@@ -131,11 +112,9 @@ describe("POST /api/admin/create-location", () => {
   });
 
   it("creates a new location and assigns it to the event, even when the name matches an existing location", async () => {
-    const first = await readJson(await POST(makeReq({ name: "Main Hall" })));
+    const first = await readJson(await postJson({ name: "Main Hall" }));
     const event = await createEvent();
-    const res = await POST(
-      makeReq({ name: "Main Hall", eventSlug: event.slug })
-    );
+    const res = await postJson({ name: "Main Hall", eventSlug: event.slug });
     const body = await readJson(res);
     expect(body.id).not.toBe(first.id);
 
@@ -146,20 +125,16 @@ describe("POST /api/admin/create-location", () => {
   });
 
   it("returns 404 for an unknown eventSlug", async () => {
-    const res = await POST(
-      makeReq({ name: "Main Hall", eventSlug: "does-not-exist" })
-    );
+    const res = await postJson({
+      name: "Main Hall",
+      eventSlug: "does-not-exist",
+    });
     expect(res.status).toBe(404);
     expect(await getRepositories().locations.list()).toEqual([]);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-location", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
@@ -173,7 +148,7 @@ describe("POST /api/admin/create-location", () => {
     ["non-string color", { name: "Main Hall", color: 123 }],
     ["non-string eventSlug", { name: "Main Hall", eventSlug: 123 }],
   ])("rejects %s with 400", async (_label, body) => {
-    const res = await POST(makeReq(body));
+    const res = await postJson(body);
     expect(res.status).toBe(400);
     expect(await getRepositories().locations.list()).toEqual([]);
   });

--- a/tests/integration/admin-create-proposal-route.test.ts
+++ b/tests/integration/admin-create-proposal-route.test.ts
@@ -8,56 +8,42 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-proposal/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-proposal";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-proposal", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
 }
 
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 describe("POST /api/admin/create-proposal", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(async () => {
+  beforeEach(() => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
   });
 
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({ eventSlug: event.slug, title: "T", hostIds: [] })
+    const res = await postJson(
+      { eventSlug: event.slug, title: "T", hostIds: [] },
+      { authed: false }
     );
     expect(res.status).toBe(401);
   });
@@ -65,15 +51,13 @@ describe("POST /api/admin/create-proposal", () => {
   it("creates a proposal with hosts and duration, returning its id", async () => {
     const event = await createEvent({ phase: "voting" });
     const host = await createGuest();
-    const res = await POST(
-      makeReq({
-        eventSlug: event.slug,
-        title: "Prompt engineering basics",
-        description: "hands-on intro",
-        durationMinutes: 45,
-        hostIds: [host.id],
-      })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: "Prompt engineering basics",
+      description: "hands-on intro",
+      durationMinutes: 45,
+      hostIds: [host.id],
+    });
     expect(res.status).toBe(201);
     const { id } = (await res.json()) as { id: string };
 
@@ -86,72 +70,73 @@ describe("POST /api/admin/create-proposal", () => {
   it("assigns the hosts to the event", async () => {
     const event = await createEvent({ phase: "voting" });
     const host = await createGuest();
-    await POST(
-      makeReq({ eventSlug: event.slug, title: "T", hostIds: [host.id] })
-    );
+    await postJson({ eventSlug: event.slug, title: "T", hostIds: [host.id] });
     const members = await getRepositories().guests.listByEvent(event.id);
     expect(members.map((g) => g.id)).toContain(host.id);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-proposal", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
   it("rejects a missing title with 400", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({ eventSlug: event.slug, title: "  ", hostIds: [] })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: "  ",
+      hostIds: [],
+    });
     expect(res.status).toBe(400);
   });
 
   it("rejects an unknown host id with 400", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({ eventSlug: event.slug, title: "T", hostIds: ["nope"] })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: "T",
+      hostIds: ["nope"],
+    });
     expect(res.status).toBe(400);
   });
 
   it("rejects a non-string title with 400", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({ eventSlug: event.slug, title: 123, hostIds: [] })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: 123,
+      hostIds: [],
+    });
     expect(res.status).toBe(400);
   });
 
   it("rejects a non-string description with 400", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({
-        eventSlug: event.slug,
-        title: "T",
-        description: 123,
-        hostIds: [],
-      })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: "T",
+      description: 123,
+      hostIds: [],
+    });
     expect(res.status).toBe(400);
   });
 
   it("rejects a non-array hostIds with 400", async () => {
     const event = await createEvent({ phase: "voting" });
-    const res = await POST(
-      makeReq({ eventSlug: event.slug, title: "T", hostIds: "nope" })
-    );
+    const res = await postJson({
+      eventSlug: event.slug,
+      title: "T",
+      hostIds: "nope",
+    });
     expect(res.status).toBe(400);
   });
 
   it("returns 404 for an unknown eventSlug", async () => {
-    const res = await POST(
-      makeReq({ eventSlug: "does-not-exist", title: "T", hostIds: [] })
-    );
+    const res = await postJson({
+      eventSlug: "does-not-exist",
+      title: "T",
+      hostIds: [],
+    });
     expect(res.status).toBe(404);
   });
 });

--- a/tests/integration/admin-create-rsvp-route.test.ts
+++ b/tests/integration/admin-create-rsvp-route.test.ts
@@ -8,43 +8,31 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import type { Event, Guest, Session } from "@/db/repositories/interfaces";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-rsvp/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-rsvp";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-rsvp", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(
   res: Response
 ): Promise<{ id: string; created: boolean }> {
   return (await res.json()) as { id: string; created: boolean };
-}
-
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
 }
 
 describe("POST /api/admin/create-rsvp", () => {
@@ -56,10 +44,8 @@ describe("POST /api/admin/create-rsvp", () => {
 
   beforeEach(async () => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
     // Proposal phase on purpose: unlike toggle-rsvp, this route must work
     // in any phase.
     event = await createEvent({ phase: "proposal" });
@@ -70,18 +56,16 @@ describe("POST /api/admin/create-rsvp", () => {
   afterEach(() => vi.unstubAllEnvs());
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(
-      makeReq({ sessionId: session.id, guestId: guest.id })
+    const res = await postJson(
+      { sessionId: session.id, guestId: guest.id },
+      { authed: false }
     );
     expect(res.status).toBe(401);
     expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
   });
 
   it("creates an RSVP regardless of phase and returns its id", async () => {
-    const res = await POST(
-      makeReq({ sessionId: session.id, guestId: guest.id })
-    );
+    const res = await postJson({ sessionId: session.id, guestId: guest.id });
     expect(res.status).toBe(201);
     const body = await readJson(res);
     expect(body.created).toBe(true);
@@ -93,18 +77,16 @@ describe("POST /api/admin/create-rsvp", () => {
   });
 
   it("assigns the guest to the session's event", async () => {
-    await POST(makeReq({ sessionId: session.id, guestId: guest.id }));
+    await postJson({ sessionId: session.id, guestId: guest.id });
     const members = await getRepositories().guests.listByEvent(event.id);
     expect(members.map((g) => g.id)).toContain(guest.id);
   });
 
   it("is idempotent per session and guest", async () => {
     const first = await readJson(
-      await POST(makeReq({ sessionId: session.id, guestId: guest.id }))
+      await postJson({ sessionId: session.id, guestId: guest.id })
     );
-    const res = await POST(
-      makeReq({ sessionId: session.id, guestId: guest.id })
-    );
+    const res = await postJson({ sessionId: session.id, guestId: guest.id });
     expect(res.status).toBe(200);
     const body = await readJson(res);
     expect(body.created).toBe(false);
@@ -115,38 +97,33 @@ describe("POST /api/admin/create-rsvp", () => {
   });
 
   it("returns 404 for an unknown session", async () => {
-    const res = await POST(makeReq({ sessionId: "nope", guestId: guest.id }));
+    const res = await postJson({ sessionId: "nope", guestId: guest.id });
     expect(res.status).toBe(404);
   });
 
   it("returns 404 for an unknown guest", async () => {
-    const res = await POST(makeReq({ sessionId: session.id, guestId: "nope" }));
+    const res = await postJson({ sessionId: session.id, guestId: "nope" });
     expect(res.status).toBe(404);
     expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-rsvp", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
   it("rejects missing ids with 400", async () => {
-    expect((await POST(makeReq({ guestId: guest.id }))).status).toBe(400);
-    expect((await POST(makeReq({ sessionId: session.id }))).status).toBe(400);
+    expect((await postJson({ guestId: guest.id })).status).toBe(400);
+    expect((await postJson({ sessionId: session.id })).status).toBe(400);
   });
 
   it("rejects non-string ids with 400", async () => {
-    expect(
-      (await POST(makeReq({ sessionId: 1, guestId: guest.id }))).status
-    ).toBe(400);
-    expect(
-      (await POST(makeReq({ sessionId: session.id, guestId: 1 }))).status
-    ).toBe(400);
+    expect((await postJson({ sessionId: 1, guestId: guest.id })).status).toBe(
+      400
+    );
+    expect((await postJson({ sessionId: session.id, guestId: 1 })).status).toBe(
+      400
+    );
   });
 
   it("returns 409 when the session is full under a hard capacity limit", async () => {
@@ -160,14 +137,16 @@ describe("POST /api/admin/create-rsvp", () => {
     const first = await createGuest();
     const second = await createGuest();
 
-    const okRes = await POST(
-      makeReq({ sessionId: cappedSession.id, guestId: first.id })
-    );
+    const okRes = await postJson({
+      sessionId: cappedSession.id,
+      guestId: first.id,
+    });
     expect(okRes.status).toBe(201);
 
-    const fullRes = await POST(
-      makeReq({ sessionId: cappedSession.id, guestId: second.id })
-    );
+    const fullRes = await postJson({
+      sessionId: cappedSession.id,
+      guestId: second.id,
+    });
     expect(fullRes.status).toBe(409);
     expect(
       await getRepositories().rsvps.listBySession(cappedSession.id)
@@ -184,10 +163,11 @@ describe("POST /api/admin/create-rsvp", () => {
     });
     const first = await createGuest();
 
-    await POST(makeReq({ sessionId: cappedSession.id, guestId: first.id }));
-    const res = await POST(
-      makeReq({ sessionId: cappedSession.id, guestId: first.id })
-    );
+    await postJson({ sessionId: cappedSession.id, guestId: first.id });
+    const res = await postJson({
+      sessionId: cappedSession.id,
+      guestId: first.id,
+    });
     expect(res.status).toBe(200);
     const body = await readJson(res);
     expect(body.created).toBe(false);

--- a/tests/integration/admin-create-session-route.test.ts
+++ b/tests/integration/admin-create-session-route.test.ts
@@ -8,18 +8,6 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -29,25 +17,25 @@ import {
 } from "../helpers/factories";
 import type { Event, Guest, Location } from "@/db/repositories/interfaces";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { POST } from "@/app/api/admin/create-session/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/create-session";
 
-function makeReq(body: unknown): Request {
-  return new Request("http://test/api/admin/create-session", {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+function post(rawBody: string, opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(POST, PATH, { method: "POST", body: rawBody }, opts);
+}
+
+function postJson(
+  body: unknown,
+  opts?: { authed?: boolean }
+): Promise<Response> {
+  return post(JSON.stringify(body), opts);
 }
 
 async function readJson(res: Response): Promise<{ id: string }> {
   return (await res.json()) as { id: string };
-}
-
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
 }
 
 describe("POST /api/admin/create-session", () => {
@@ -59,10 +47,8 @@ describe("POST /api/admin/create-session", () => {
 
   beforeEach(async () => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
     event = await createEvent();
     host = await createGuest();
     room = await createLocation({ capacity: 12 });
@@ -83,14 +69,13 @@ describe("POST /api/admin/create-session", () => {
   }
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await POST(makeReq(validBody()));
+    const res = await postJson(validBody(), { authed: false });
     expect(res.status).toBe(401);
     expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
   });
 
   it("creates a session and returns its id", async () => {
-    const res = await POST(makeReq(validBody()));
+    const res = await postJson(validBody());
     expect(res.status).toBe(201);
     const body = await readJson(res);
 
@@ -111,7 +96,7 @@ describe("POST /api/admin/create-session", () => {
   });
 
   it("assigns hosts and locations to the event", async () => {
-    await POST(makeReq(validBody()));
+    await postJson(validBody());
     const repos = getRepositories();
     const members = await repos.guests.listByEvent(event.id);
     expect(members.map((g) => g.id)).toContain(host.id);
@@ -120,14 +105,12 @@ describe("POST /api/admin/create-session", () => {
   });
 
   it("accepts explicit capacity, adminManaged and closed", async () => {
-    const res = await POST(
-      makeReq({
-        ...validBody(),
-        capacity: 5,
-        adminManaged: true,
-        closed: true,
-      })
-    );
+    const res = await postJson({
+      ...validBody(),
+      capacity: 5,
+      adminManaged: true,
+      closed: true,
+    });
     const { id } = await readJson(res);
     const session = await getRepositories().sessions.findById(id);
     expect(session?.capacity).toBe(5);
@@ -136,18 +119,19 @@ describe("POST /api/admin/create-session", () => {
   });
 
   it("defaults capacity to 0 without a location", async () => {
-    const res = await POST(makeReq({ ...validBody(), locationIds: [] }));
+    const res = await postJson({ ...validBody(), locationIds: [] });
     const { id } = await readJson(res);
     const session = await getRepositories().sessions.findById(id);
     expect(session?.capacity).toBe(0);
   });
 
   it("creates a new session even when title and start time match an existing one in a different location", async () => {
-    const first = await readJson(await POST(makeReq(validBody())));
+    const first = await readJson(await postJson(validBody()));
     const otherRoom = await createLocation({ capacity: 20 });
-    const res = await POST(
-      makeReq({ ...validBody(), locationIds: [otherRoom.id] })
-    );
+    const res = await postJson({
+      ...validBody(),
+      locationIds: [otherRoom.id],
+    });
     expect(res.status).toBe(201);
     const body = await readJson(res);
     expect(body.id).not.toBe(first.id);
@@ -157,15 +141,13 @@ describe("POST /api/admin/create-session", () => {
   });
 
   it("rejects an overlapping session in the same location with 409", async () => {
-    await POST(makeReq(validBody()));
-    const res = await POST(
-      makeReq({
-        ...validBody(),
-        title: "Advanced Juggling",
-        startTime: "2026-09-01T10:30:00Z",
-        endTime: "2026-09-01T11:30:00Z",
-      })
-    );
+    await postJson(validBody());
+    const res = await postJson({
+      ...validBody(),
+      title: "Advanced Juggling",
+      startTime: "2026-09-01T10:30:00Z",
+      endTime: "2026-09-01T11:30:00Z",
+    });
     expect(res.status).toBe(409);
     expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
       1
@@ -173,8 +155,8 @@ describe("POST /api/admin/create-session", () => {
   });
 
   it("rejects a repeated identical request with 409 instead of silently reusing it", async () => {
-    await POST(makeReq(validBody()));
-    const res = await POST(makeReq(validBody()));
+    await postJson(validBody());
+    const res = await postJson(validBody());
     expect(res.status).toBe(409);
     expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
       1
@@ -188,31 +170,25 @@ describe("POST /api/admin/create-session", () => {
       startBookings: new Date("2026-09-01T09:00:00Z"),
       endBookings: new Date("2026-09-01T17:00:00Z"),
     });
-    const res = await POST(
-      makeReq({
-        ...validBody(),
-        startTime: "2026-09-01T10:07:00Z",
-        endTime: "2026-09-01T11:00:00Z",
-      })
-    );
+    const res = await postJson({
+      ...validBody(),
+      startTime: "2026-09-01T10:07:00Z",
+      endTime: "2026-09-01T11:00:00Z",
+    });
     expect(res.status).toBe(400);
     expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
   });
 
   it("returns 404 for an unknown eventSlug", async () => {
-    const res = await POST(
-      makeReq({ ...validBody(), eventSlug: "does-not-exist" })
-    );
+    const res = await postJson({
+      ...validBody(),
+      eventSlug: "does-not-exist",
+    });
     expect(res.status).toBe(404);
   });
 
   it("rejects a malformed JSON body with 400", async () => {
-    const res = await POST(
-      new Request("http://test/api/admin/create-session", {
-        method: "POST",
-        body: "{not json",
-      })
-    );
+    const res = await post("{not json");
     expect(res.status).toBe(400);
   });
 
@@ -263,7 +239,7 @@ describe("POST /api/admin/create-session", () => {
       (b: Record<string, unknown>) => ({ ...b, locationIds: "nope" }),
     ],
   ])("rejects %s with 400", async (_label, mutate) => {
-    const res = await POST(makeReq(mutate(validBody())));
+    const res = await postJson(mutate(validBody()));
     expect(res.status).toBe(400);
     expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
   });

--- a/tests/integration/admin-route-proxy-bypass.test.ts
+++ b/tests/integration/admin-route-proxy-bypass.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { POST as createDay } from "@/app/api/admin/create-day/route";
+import { POST as createEvent } from "@/app/api/admin/create-event/route";
+import { POST as createGuest } from "@/app/api/admin/create-guest/route";
+import { POST as createLocation } from "@/app/api/admin/create-location/route";
+import { POST as createProposal } from "@/app/api/admin/create-proposal/route";
+import { POST as createRsvp } from "@/app/api/admin/create-rsvp/route";
+import { POST as createSession } from "@/app/api/admin/create-session/route";
+import { GET as listUsers } from "@/app/api/admin/users/route";
+import { ADMIN_VERIFIED_HEADER } from "@/utils/auth";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+// Auth for /api/admin/* is decided once, in the proxy. These tests pin the
+// other half of that contract: a route must fail closed when it is reached
+// *without* the proxy's verified header, so that a matcher change or a
+// middleware-bypass bug can never leave the seeding API wide open. A valid
+// admin cookie on the request must not help — only the proxy may vouch.
+const routes: [string, (req: Request) => Promise<Response>][] = [
+  ["create-day", createDay],
+  ["create-event", createEvent],
+  ["create-guest", createGuest],
+  ["create-location", createLocation],
+  ["create-proposal", createProposal],
+  ["create-rsvp", createRsvp],
+  ["create-session", createSession],
+  ["users", listUsers],
+];
+
+describe("/api/admin/* routes reached without the proxy", () => {
+  beforeEach(() => {
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(routes)("%s returns a no-store 401", async (name, handler) => {
+    const res = await handler(
+      new Request(`http://test/api/admin/${name}`, {
+        method: "POST",
+        body: "{}",
+      })
+    );
+    expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it.each(routes)(
+    "%s rejects a client-forged verified header value",
+    async (name, handler) => {
+      const res = await handler(
+        new Request(`http://test/api/admin/${name}`, {
+          method: "POST",
+          body: "{}",
+          headers: { [ADMIN_VERIFIED_HEADER]: "true" },
+        })
+      );
+      expect(res.status).toBe(401);
+    }
+  );
+});

--- a/tests/integration/admin-users-route.test.ts
+++ b/tests/integration/admin-users-route.test.ts
@@ -8,45 +8,31 @@ import {
   vi,
 } from "vitest";
 
-const cookieJar = new Map<string, string>();
-
-vi.mock("next/headers", () => ({
-  cookies: () =>
-    Promise.resolve({
-      get: (name: string) => {
-        const value = cookieJar.get(name);
-        return value === undefined ? undefined : { name, value };
-      },
-    }),
-}));
-
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { getRepositories } from "@/db/container";
-import { createAdminAuthCookie } from "@/utils/auth";
+import { callThroughProxy } from "../helpers/through-proxy";
 import { GET } from "@/app/api/admin/users/route";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+const PATH = "/api/admin/users";
 
 type User = { id: string; name: string; email: string };
+
+function get(opts?: { authed?: boolean }): Promise<Response> {
+  return callThroughProxy(GET, PATH, {}, opts);
+}
 
 async function readUsers(res: Response): Promise<User[]> {
   return ((await res.json()) as { users: User[] }).users;
 }
 
-async function loginAsAdmin() {
-  const c = await createAdminAuthCookie();
-  cookieJar.set(c.name, c.value);
-}
-
 describe("GET /api/admin/users", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(async () => {
+  beforeEach(() => {
     resetTestDb();
-    cookieJar.clear();
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    await loginAsAdmin();
   });
 
   afterEach(() => {
@@ -55,14 +41,12 @@ describe("GET /api/admin/users", () => {
   });
 
   it("rejects the request without an admin cookie", async () => {
-    cookieJar.clear();
-    const res = await GET();
+    const res = await get({ authed: false });
     expect(res.status).toBe(401);
-    expect(res.headers.get("cache-control")).toBe("no-store");
   });
 
   it("returns an empty list when there are no users", async () => {
-    const res = await GET();
+    const res = await get();
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toBe("no-store");
     expect(await readUsers(res)).toEqual([]);
@@ -79,7 +63,7 @@ describe("GET /api/admin/users", () => {
       info: { email: "tom@foocorp.com" },
     });
 
-    const res = await GET();
+    const res = await get();
     expect(res.status).toBe(200);
     const users = await readUsers(res);
 
@@ -102,7 +86,7 @@ describe("GET /api/admin/users", () => {
     vi.spyOn(guests, "listFull").mockRejectedValue(new Error("db down"));
     vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const res = await GET();
+    const res = await get();
     expect(res.status).toBe(500);
     expect(res.headers.get("cache-control")).toBe("no-store");
     expect(await res.json()).toEqual({ error: "Failed to fetch users" });

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ADMIN_VERIFIED_HEADER, createAdminAuthCookie } from "@/utils/auth";
+import { throughProxy } from "../helpers/through-proxy";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+describe("proxy: /api/admin/* auth", () => {
+  beforeEach(() => {
+    vi.stubEnv("SITE_PASSWORD", "site-pw");
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("allows a request carrying only the admin cookie (no site cookie) and forwards a trusted header", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy("/api/admin/create-guest", {}, [admin]);
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+    expect(result.request.headers.get(ADMIN_VERIFIED_HEADER)).toBe("1");
+  });
+
+  it("returns a no-store JSON 401 (not an HTML redirect) when the admin cookie is missing", async () => {
+    const result = await throughProxy("/api/admin/create-guest", {}, []);
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(401);
+    expect(result.response.headers.get("location")).toBeNull();
+    expect(result.response.headers.get("cache-control")).toBe("no-store");
+    expect(await result.response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns a no-store 404 when the admin feature is disabled, without touching site auth", async () => {
+    vi.stubEnv("ADMIN_PASSWORD", "");
+    const result = await throughProxy("/api/admin/create-guest", {}, []);
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("also gates the exact /api/admin path (no trailing segment)", async () => {
+    const result = await throughProxy("/api/admin", {}, []);
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(401);
+  });
+
+  it("still requires site auth for non-admin API routes", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy("/api/votes", {}, [admin]);
+    if (result.ok) throw new Error("expected proxy to redirect the request");
+    expect(result.response.headers.get("location")).toMatch(/\/login/);
+  });
+
+  it("strips a client-forged admin-verified header from every forwarded request", async () => {
+    const result = await throughProxy("/api/health", {
+      headers: { [ADMIN_VERIFIED_HEADER]: "1" },
+    });
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+    expect(result.request.headers.get(ADMIN_VERIFIED_HEADER)).toBeNull();
+  });
+
+  it("rejects a request whose Origin header doesn't match the request's own origin (CSRF)", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy(
+      "/api/admin/create-guest",
+      { headers: { origin: "https://evil.example" } },
+      [admin]
+    );
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(403);
+    expect(result.response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("rejects a cross-site request flagged by Sec-Fetch-Site even without an Origin header", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy(
+      "/api/admin/create-guest",
+      { headers: { "sec-fetch-site": "cross-site" } },
+      [admin]
+    );
+    if (result.ok) throw new Error("expected proxy to reject the request");
+    expect(result.response.status).toBe(403);
+  });
+
+  it("allows a request with a matching Origin header", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy(
+      "/api/admin/create-guest",
+      { headers: { origin: "http://test" } },
+      [admin]
+    );
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+  });
+
+  it("allows a script request with neither Origin nor Sec-Fetch-Site header", async () => {
+    const admin = await createAdminAuthCookie();
+    const result = await throughProxy("/api/admin/create-guest", {}, [admin]);
+    if (!result.ok) throw new Error("expected proxy to forward the request");
+  });
+});

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -16,6 +16,17 @@ export const GUEST_COOKIE_NAME = "guest";
 export type GuestAuthLevel = "open" | "verified";
 export const ADMIN_DISABLED_MESSAGE =
   "Admin UI is disabled: set the ADMIN_PASSWORD environment variable on the server to enable it. See the project documentation.";
+// Set by the proxy on requests it has verified carry a valid admin cookie,
+// and only then — route handlers trust its presence instead of
+// re-validating the cookie themselves. Safe because the proxy always runs
+// ahead of the route for real traffic and strips any client-supplied copy of
+// this header from every forwarded request before checking auth.
+export const ADMIN_VERIFIED_HEADER = "x-admin-verified";
+const ADMIN_VERIFIED_VALUE = "1";
+// Without an explicit no-store, browsers heuristically cache admin API
+// responses; some carry sensitive data (e.g. user emails) and must never be
+// served stale or from cache.
+export const NO_STORE = { headers: { "cache-control": "no-store" } };
 const ADMIN_SCOPE = "admin";
 const COOKIE_MAX_AGE_SEC = 7 * 24 * 60 * 60;
 const COOKIE_MAX_AGE_MS = COOKIE_MAX_AGE_SEC * 1000;
@@ -359,4 +370,99 @@ export async function requireAdminAuth(
     request.nextUrl.pathname + request.nextUrl.search
   );
   return NextResponse.redirect(loginUrl);
+}
+
+// CSRF defense for the cookie-authenticated admin API: `SameSite=Lax` alone
+// doesn't cover cross-site top-level GET navigations (e.g. a link or
+// auto-submitting <form method=get>), which still carry the cookie without an
+// `Origin` header. `Sec-Fetch-Site` is sent by all modern browsers for those
+// requests too, so checking both closes the gap Origin alone leaves open.
+// Non-browser clients (curl, scripts) send neither header, so they fall
+// through to "trusted" — matching this API's intended audience.
+//
+// `request.nextUrl.origin` is derived from the Host/X-Forwarded-* headers
+// Next.js sees, so this comparison is only correct if a fronting reverse
+// proxy forwards `X-Forwarded-Proto`/`Host` accurately; a misconfigured proxy
+// that drops `X-Forwarded-Proto` could make this reject legitimate
+// same-origin browser requests (e.g. nextUrl resolves to http:// while the
+// browser's real Origin is https://).
+function isTrustedOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get("origin");
+  if (origin && origin !== request.nextUrl.origin) {
+    return false;
+  }
+  const site = request.headers.get("sec-fetch-site");
+  if (site === "cross-site") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Admin-API counterpart of {@link requireAdminAuth}: same admin-cookie check,
+ * plus a CSRF check the UI branch doesn't need (see {@link isTrustedOrigin}
+ * — the UI relies on Next's built-in server-action Origin check instead). On
+ * failure this returns JSON (matching the API's contract) instead of a
+ * redirect to the admin login page; on success it forwards the request with
+ * {@link ADMIN_VERIFIED_HEADER} set so the route handler doesn't need to
+ * re-check the cookie — it only checks that header, via
+ * {@link requireProxyVerifiedAdmin}.
+ *
+ * Deliberate contract change from the routes' previous per-route checks:
+ * those always returned 401 regardless of why auth failed, whereas this
+ * returns 404 when the admin API is disabled (mirroring the /admin UI
+ * branch), 403 for a cross-site request, and 401 only for a missing/invalid
+ * admin cookie. External clients that only branched on 401 need to handle
+ * 404 and 403 too.
+ */
+export async function requireAdminAuthApi(
+  request: NextRequest
+): Promise<NextResponse> {
+  if (!isAdminEnabled()) {
+    return NextResponse.json(
+      { error: "Admin API is disabled" },
+      { ...NO_STORE, status: 404 }
+    );
+  }
+  if (!isTrustedOrigin(request)) {
+    return NextResponse.json(
+      { error: "Cross-site request rejected" },
+      { ...NO_STORE, status: 403 }
+    );
+  }
+  if (!(await isAdminAuthenticated(request))) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { ...NO_STORE, status: 401 }
+    );
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set(ADMIN_VERIFIED_HEADER, ADMIN_VERIFIED_VALUE);
+  return NextResponse.next({ request: { headers } });
+}
+
+/**
+ * Route-handler half of the {@link requireAdminAuthApi} contract: returns a
+ * 401 response unless the request carries the header the proxy sets after a
+ * successful admin-cookie check, or `null` to proceed.
+ *
+ * This is not a second authentication — the proxy already decided that, and
+ * a client can't reach a route with this header set because the proxy strips
+ * any client-supplied copy from every forwarded request. It exists so the
+ * routes fail *closed* rather than open if the proxy ever doesn't run ahead
+ * of them (a matcher edit, a route moved outside `/api/admin/`, a
+ * middleware-bypass bug in Next). Without it these seeding endpoints have no
+ * auth of their own at all.
+ */
+export function requireProxyVerifiedAdmin(
+  request: Request
+): NextResponse | null {
+  if (request.headers.get(ADMIN_VERIFIED_HEADER) === ADMIN_VERIFIED_VALUE) {
+    return null;
+  }
+  return NextResponse.json(
+    { error: "Unauthorized" },
+    { ...NO_STORE, status: 401 }
+  );
 }


### PR DESCRIPTION
/api/admin/* previously fell through to site-auth middleware and
required both site and admin cookies, replying with an HTML 302
instead of JSON on failure. The proxy now gates /api/admin/* on the
admin cookie alone (mirroring /admin/*) and forwards a trusted
ADMIN_VERIFIED_HEADER; every admin route drops its own cookie check and
only asserts that header (requireProxyVerifiedAdmin), so the auth
decision lives in exactly one place while the routes still fail closed
if the proxy ever doesn't run ahead of them.

Tests now drive requests through the real proxy (tests/helpers/through-proxy.ts)
instead of calling route handlers directly, so auth is exercised for real.

The proxy strips any client-supplied copy of ADMIN_VERIFIED_HEADER from
every forwarded request, so a client can never present it itself, admin
API auth failures carry cache-control: no-store, and the path match
covers the exact /api/admin path like the /admin UI branch does.

SameSite=Lax cookies still ride along on cross-site top-level GET
navigations, so the admin API is CSRFable despite the cookie.
requireAdminAuthApi now rejects requests whose Origin header doesn't
match its own origin, and falls back to Sec-Fetch-Site ("cross-site")
to catch the navigation case where browsers omit Origin. Non-browser
clients send neither header and are unaffected. isTrustedOrigin's
correctness depends on the reverse proxy forwarding Host/X-Forwarded-Proto
accurately.

<!-- jip:pushed-commit=e8f99c84d5b996808028224aa44152c4fc4006fd -->