### PR TITLE
feat(api): admin route to create events

### DIFF
--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { eventNameToSlug } from "@/utils/utils";
+import { eventNameToSlug, RESERVED_EVENT_SLUGS } from "@/utils/utils";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import type { Event } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
@@ -107,10 +107,6 @@ function parseEventInput(input: EventInput): ParseResult {
   };
 }
 
-// Top-level route segments served by this app (see app/); an event slug
-// matching one of these would shadow or be shadowed by that route.
-const RESERVED_SLUGS = new Set(["admin", "api", "login", "media"]);
-
 // A new increment only works if every day window and every scheduled session
 // still falls on slot boundaries; otherwise sessions would silently drop out
 // of the schedule grid. The admin must fix the misaligned data first.
@@ -159,7 +155,7 @@ export async function createEventAction(
   if (!slug) {
     return { ok: false, error: "Name must contain a letter or number" };
   }
-  if (RESERVED_SLUGS.has(slug.toLowerCase())) {
+  if (RESERVED_EVENT_SLUGS.has(slug.toLowerCase())) {
     return {
       ok: false,
       error: `"${slug}" is a reserved URL and cannot be used as an event name`,

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { eventNameToSlug, RESERVED_EVENT_SLUGS } from "@/utils/utils";
+import {
+  DEFAULT_SLOT_INCREMENT_MINUTES,
+  SLOT_INCREMENT_OPTIONS,
+  isValidSlotIncrement,
+} from "@/utils/slots";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only event creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = {
+  name?: string;
+  description?: string;
+  website?: string;
+  start?: string;
+  end?: string;
+  timezone?: string;
+  maxSessionDuration?: number;
+  breakMinutes?: number;
+  slotIncrementMinutes?: number;
+  schedulingPhaseStart?: string;
+  schedulingPhaseEnd?: string;
+};
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+// The admin UI offers a timezone dropdown; scripts get a strict 400 instead.
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function badRequest(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  for (const field of ["name", "description", "website", "timezone"] as const) {
+    if (body[field] !== undefined && typeof body[field] !== "string") {
+      return badRequest(`${field} must be a string`);
+    }
+  }
+
+  const name = (body.name ?? "").trim();
+  if (!name) return badRequest("Name is required");
+
+  const start = parseDate(body.start);
+  if (!start) return badRequest("Invalid start date");
+
+  const end = parseDate(body.end);
+  if (!end) return badRequest("Invalid end date");
+
+  if (end <= start) return badRequest("End date must be after start date");
+
+  const timezone = (body.timezone ?? "").trim() || "UTC";
+  if (!isValidTimezone(timezone)) return badRequest("Unknown timezone");
+
+  const maxSessionDuration = body.maxSessionDuration ?? 120;
+  if (!Number.isInteger(maxSessionDuration) || maxSessionDuration <= 0) {
+    return badRequest("Max session duration must be a positive number");
+  }
+
+  const breakMinutes = body.breakMinutes ?? 10;
+  if (!Number.isInteger(breakMinutes) || breakMinutes < 0) {
+    return badRequest("Break must be zero or a positive number");
+  }
+
+  const slotIncrementMinutes =
+    body.slotIncrementMinutes ?? DEFAULT_SLOT_INCREMENT_MINUTES;
+  if (!isValidSlotIncrement(slotIncrementMinutes)) {
+    return badRequest(
+      `Slot increment must be one of ${SLOT_INCREMENT_OPTIONS.join(", ")} minutes`
+    );
+  }
+
+  // Omitting both leaves the event phase-less, so admin seeding and RSVPs
+  // work immediately (inSchedPhase treats no phases as always-on).
+  const schedulingPhaseStart = parseDate(body.schedulingPhaseStart);
+  if (body.schedulingPhaseStart && !schedulingPhaseStart) {
+    return badRequest("Invalid scheduling phase start");
+  }
+  const schedulingPhaseEnd = parseDate(body.schedulingPhaseEnd);
+  if (body.schedulingPhaseEnd && !schedulingPhaseEnd) {
+    return badRequest("Invalid scheduling phase end");
+  }
+  if (
+    schedulingPhaseStart &&
+    schedulingPhaseEnd &&
+    schedulingPhaseEnd <= schedulingPhaseStart
+  ) {
+    return badRequest("Scheduling phase end must be after its start");
+  }
+
+  const slug = eventNameToSlug(name);
+  if (!slug) return badRequest("Name must contain a letter or number");
+  if (RESERVED_EVENT_SLUGS.has(slug.toLowerCase())) {
+    return badRequest(
+      `"${slug}" is a reserved URL and cannot be used as an event name`
+    );
+  }
+
+  const { events } = getRepositories();
+  // Best-effort: a concurrent request between this check and the create()
+  // below can still race and fail on the slug's unique constraint.
+  const existing = await events.findBySlug(slug);
+  if (existing) {
+    return NextResponse.json({
+      id: existing.id,
+      slug: existing.slug,
+      created: false,
+    });
+  }
+
+  const event = await events.create({
+    name,
+    description: (body.description ?? "").trim(),
+    website: (body.website ?? "").trim(),
+    start,
+    end,
+    timezone,
+    maxSessionDuration,
+    breakMinutes,
+    slotIncrementMinutes,
+    schedulingPhaseStart,
+    schedulingPhaseEnd,
+  });
+
+  return NextResponse.json({ id: event.id, slug: event.slug, created: true });
+}

--- a/tests/integration/admin-create-event-route.test.ts
+++ b/tests/integration/admin-create-event-route.test.ts
@@ -1,0 +1,172 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-event/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-event", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(
+  res: Response
+): Promise<{ id: string; slug: string; created: boolean }> {
+  return (await res.json()) as { id: string; slug: string; created: boolean };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+const VALID_BODY = {
+  name: "Summer Camp",
+  start: "2026-09-01T00:00:00Z",
+  end: "2026-09-03T00:00:00Z",
+};
+
+describe("POST /api/admin/create-event", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+    expect(await getRepositories().events.list()).toEqual([]);
+  });
+
+  it("creates an event with defaults and returns id and slug", async () => {
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.created).toBe(true);
+    expect(body.slug).toBe("Summer-Camp");
+
+    const event = await getRepositories().events.findBySlug("Summer-Camp");
+    expect(event?.id).toBe(body.id);
+    expect(event?.name).toBe("Summer Camp");
+    expect(event?.start).toEqual(new Date("2026-09-01T00:00:00Z"));
+    expect(event?.end).toEqual(new Date("2026-09-03T00:00:00Z"));
+    expect(event?.timezone).toBe("UTC");
+    expect(event?.maxSessionDuration).toBe(120);
+    expect(event?.breakMinutes).toBe(10);
+    expect(event?.slotIncrementMinutes).toBe(30);
+    // Phase-less so admin seeding and RSVPs work immediately.
+    expect(event?.schedulingPhaseStart).toBeUndefined();
+    expect(event?.schedulingPhaseEnd).toBeUndefined();
+  });
+
+  it("accepts explicit timezone, durations and scheduling phase", async () => {
+    const res = await POST(
+      makeReq({
+        ...VALID_BODY,
+        timezone: "Europe/Berlin",
+        maxSessionDuration: 90,
+        breakMinutes: 0,
+        slotIncrementMinutes: 15,
+        schedulingPhaseStart: "2026-08-01T00:00:00Z",
+        schedulingPhaseEnd: "2026-09-03T00:00:00Z",
+      })
+    );
+    expect(res.status).toBe(200);
+    const { id } = await readJson(res);
+
+    const event = await getRepositories().events.findById(id);
+    expect(event?.timezone).toBe("Europe/Berlin");
+    expect(event?.maxSessionDuration).toBe(90);
+    expect(event?.breakMinutes).toBe(0);
+    expect(event?.slotIncrementMinutes).toBe(15);
+    expect(event?.schedulingPhaseStart).toEqual(
+      new Date("2026-08-01T00:00:00Z")
+    );
+    expect(event?.schedulingPhaseEnd).toEqual(new Date("2026-09-03T00:00:00Z"));
+  });
+
+  it("returns the existing event with created=false when the slug already exists", async () => {
+    const first = await readJson(await POST(makeReq(VALID_BODY)));
+    const res = await POST(
+      makeReq({ ...VALID_BODY, name: "Summer Camp", breakMinutes: 42 })
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.created).toBe(false);
+    expect(body.id).toBe(first.id);
+    // Create-if-absent: the existing event is not updated.
+    const event = await getRepositories().events.findById(first.id);
+    expect(event?.breakMinutes).toBe(10);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-event", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ["missing name", { ...VALID_BODY, name: "  " }],
+    ["non-string name", { ...VALID_BODY, name: 123 }],
+    ["name without letters or numbers", { ...VALID_BODY, name: "!!!" }],
+    ["reserved slug", { ...VALID_BODY, name: "Admin" }],
+    ["invalid start", { ...VALID_BODY, start: "not-a-date" }],
+    ["end before start", { ...VALID_BODY, end: "2026-08-31T00:00:00Z" }],
+    ["invalid timezone", { ...VALID_BODY, timezone: "Mars/Olympus" }],
+    [
+      "non-positive maxSessionDuration",
+      { ...VALID_BODY, maxSessionDuration: 0 },
+    ],
+    ["negative breakMinutes", { ...VALID_BODY, breakMinutes: -1 }],
+    ["invalid slot increment", { ...VALID_BODY, slotIncrementMinutes: 20 }],
+    [
+      "scheduling phase end before start",
+      {
+        ...VALID_BODY,
+        schedulingPhaseStart: "2026-09-01T00:00:00Z",
+        schedulingPhaseEnd: "2026-08-01T00:00:00Z",
+      },
+    ],
+  ])("rejects %s with 400", async (_label, body) => {
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    expect(await getRepositories().events.list()).toEqual([]);
+  });
+});

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -41,6 +41,10 @@ export function eventNameToSlug(name: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+// Top-level route segments served by this app (see app/); an event slug
+// matching one of these would shadow or be shadowed by that route.
+export const RESERVED_EVENT_SLUGS = new Set(["admin", "api", "login", "media"]);
+
 /**
  * URL for fetching a guest's votes. Encodes both values so reserved URL
  * characters (e.g. in legacy slugs stored before sanitization, like "&")


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [33c38ed](https://github.com/LWCW-Europe/schellingboard/pull/584/commits/33c38ede0e2726935995dd117fd6de8ad3633e30).

PRs:
* #588
* #587
* #586
* #585
* ➡️ #584 (this PR, base of the stack — can be merged first)

---

## Description

POST /api/admin/create-event lets external import scripts bootstrap an
event over plain HTTP (server actions are not callable by scripts). If
the derived slug already exists, returns that event instead of erroring.
Validation mirrors createEventAction; the reserved-slug set moves to
utils so both can share it (a "use server" file can only export actions).

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=33c38ede0e2726935995dd117fd6de8ad3633e30 -->