### PR TITLE
feat(api): admin route to create locations

### DIFF
--- a/app/api/admin/create-location/route.ts
+++ b/app/api/admin/create-location/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { normalizeLocationColor } from "@/utils/location-colors";
+
+export const dynamic = "force-dynamic";
+
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = {
+  name?: string;
+  description?: string;
+  areaDescription?: string;
+  capacity?: number;
+  color?: string;
+  hidden?: boolean;
+  bookable?: boolean;
+  eventSlug?: string;
+};
+
+function badRequest(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+// Admin-only location creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+//
+// Always creates a new location, same as the admin UI action: locations
+// aren't unique by name, so a name matching an existing location is not
+// treated as a duplicate to reuse. Image upload stays exclusive to the
+// admin UI action.
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  for (const field of [
+    "name",
+    "description",
+    "areaDescription",
+    "color",
+    "eventSlug",
+  ] as const) {
+    if (body[field] !== undefined && typeof body[field] !== "string") {
+      return badRequest(`${field} must be a string`);
+    }
+  }
+
+  const name = (body.name ?? "").trim();
+  if (!name) {
+    return badRequest("Name is required");
+  }
+
+  const capacity = body.capacity ?? 0;
+  if (!Number.isInteger(capacity) || capacity < 0) {
+    return badRequest("Capacity must be a non-negative whole number");
+  }
+
+  const { locations, events } = getRepositories();
+
+  let eventId: string | undefined;
+  if (body.eventSlug) {
+    const event = await events.findBySlug(body.eventSlug);
+    if (!event) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+    eventId = event.id;
+  }
+
+  const all = await locations.list();
+  // sortIndex is auto-assigned exactly as in createLocationAction.
+  const sortIndex =
+    all.length === 0 ? 0 : Math.max(...all.map((l) => l.sortIndex)) + 1;
+  const location = await locations.create({
+    name,
+    imageUrl: "",
+    description: (body.description ?? "").trim(),
+    areaDescription: (body.areaDescription ?? "").trim() || undefined,
+    capacity,
+    color: normalizeLocationColor(body.color ?? ""),
+    hidden: body.hidden ?? false,
+    bookable: body.bookable ?? false,
+    sortIndex,
+  });
+
+  if (eventId) {
+    await locations.assignToEvent(eventId, [location.id]);
+  }
+
+  return NextResponse.json({ id: location.id });
+}

--- a/tests/integration/admin-create-location-route.test.ts
+++ b/tests/integration/admin-create-location-route.test.ts
@@ -1,0 +1,180 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { DEFAULT_LOCATION_COLOR } from "@/utils/location-colors";
+import { POST } from "@/app/api/admin/create-location/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-location", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response): Promise<{ id: string }> {
+  return (await res.json()) as { id: string };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("POST /api/admin/create-location", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(makeReq({ name: "Main Hall" }));
+    expect(res.status).toBe(401);
+    expect(await getRepositories().locations.list()).toEqual([]);
+  });
+
+  it("creates a location with defaults and returns its id", async () => {
+    const res = await POST(makeReq({ name: "Main Hall" }));
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+
+    const location = await getRepositories().locations.findById(body.id);
+    expect(location?.name).toBe("Main Hall");
+    expect(location?.capacity).toBe(0);
+    expect(location?.color).toBe(DEFAULT_LOCATION_COLOR);
+    expect(location?.hidden).toBe(false);
+    expect(location?.bookable).toBe(false);
+    expect(location?.sortIndex).toBe(0);
+  });
+
+  it("accepts explicit fields and auto-increments sortIndex", async () => {
+    await POST(makeReq({ name: "Main Hall" }));
+    const res = await POST(
+      makeReq({
+        name: "Workshop Room",
+        description: "First floor",
+        areaDescription: "North wing",
+        capacity: 25,
+        color: "blue",
+        hidden: true,
+        bookable: true,
+      })
+    );
+    const { id } = await readJson(res);
+
+    const location = await getRepositories().locations.findById(id);
+    expect(location?.description).toBe("First floor");
+    expect(location?.areaDescription).toBe("North wing");
+    expect(location?.capacity).toBe(25);
+    expect(location?.color).toBe("blue");
+    expect(location?.hidden).toBe(true);
+    expect(location?.bookable).toBe(true);
+    expect(location?.sortIndex).toBe(1);
+  });
+
+  it("creates a new location even when the name matches an existing one", async () => {
+    const first = await readJson(
+      await POST(makeReq({ name: "Main Hall", capacity: 100 }))
+    );
+    const res = await POST(makeReq({ name: "main hall", capacity: 5 }));
+    const body = await readJson(res);
+    expect(body.id).not.toBe(first.id);
+
+    const all = await getRepositories().locations.list();
+    expect(all.map((l) => l.name)).toEqual(["Main Hall", "main hall"]);
+    expect(all.map((l) => l.capacity)).toEqual([100, 5]);
+  });
+
+  it("assigns the location to the event when eventSlug is given", async () => {
+    const event = await createEvent();
+    const res = await POST(
+      makeReq({ name: "Main Hall", eventSlug: event.slug })
+    );
+    const { id } = await readJson(res);
+
+    const assigned = await getRepositories().locations.listLocationIdsByEvent(
+      event.id
+    );
+    expect(assigned).toContain(id);
+  });
+
+  it("creates a new location and assigns it to the event, even when the name matches an existing location", async () => {
+    const first = await readJson(await POST(makeReq({ name: "Main Hall" })));
+    const event = await createEvent();
+    const res = await POST(
+      makeReq({ name: "Main Hall", eventSlug: event.slug })
+    );
+    const body = await readJson(res);
+    expect(body.id).not.toBe(first.id);
+
+    const assigned = await getRepositories().locations.listLocationIdsByEvent(
+      event.id
+    );
+    expect(assigned).toEqual([body.id]);
+  });
+
+  it("returns 404 for an unknown eventSlug", async () => {
+    const res = await POST(
+      makeReq({ name: "Main Hall", eventSlug: "does-not-exist" })
+    );
+    expect(res.status).toBe(404);
+    expect(await getRepositories().locations.list()).toEqual([]);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-location", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ["missing name", { name: "  " }],
+    ["negative capacity", { name: "Main Hall", capacity: -1 }],
+    ["non-integer capacity", { name: "Main Hall", capacity: 1.5 }],
+    ["non-string name", { name: 123 }],
+    ["non-string description", { name: "Main Hall", description: 123 }],
+    ["non-string areaDescription", { name: "Main Hall", areaDescription: 123 }],
+    ["non-string color", { name: "Main Hall", color: 123 }],
+    ["non-string eventSlug", { name: "Main Hall", eventSlug: 123 }],
+  ])("rejects %s with 400", async (_label, body) => {
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(400);
+    expect(await getRepositories().locations.list()).toEqual([]);
+  });
+});


### PR DESCRIPTION
POST /api/admin/create-location accepts JSON (no image; that stays in
the admin UI action) and always creates a new location, matching the
admin UI action's behavior of not treating a matching name as a
duplicate. Locations can optionally be assigned to an event by slug.

Field types are validated (mirroring create-event) so a malformed
seeding request gets a 400 instead of an unhandled 500.

<!-- jip:pushed-commit=91cf1bbae9af9d6a7fa485b52d30db44042b645b -->