### PR TITLE
feat(api): admin route to create days

### DIFF
--- a/app/actions/admin-days.ts
+++ b/app/actions/admin-days.ts
@@ -4,8 +4,11 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
-import { sessionContainedInWindow } from "@/utils/day-window";
-import { isSlotAligned } from "@/utils/slots";
+import {
+  dayAlignmentError,
+  daysOverlap,
+  sessionContainedInWindow,
+} from "@/utils/day-window";
 import type { AdminActionResult } from "./admin-guests";
 
 async function isAdminRequest(): Promise<boolean> {
@@ -73,30 +76,6 @@ function parseDayInput(
   return {
     data: { eventId: input.eventId, start, end, startBookings, endBookings },
   };
-}
-
-// The schedule grid anchors its slots at the day start, so the day end and
-// both booking boundaries must sit a whole number of slots from it.
-function dayAlignmentError(
-  day: ParsedDay,
-  incrementMinutes: number
-): string | null {
-  const aligned =
-    isSlotAligned(day.end, day.start, incrementMinutes) &&
-    isSlotAligned(day.startBookings, day.start, incrementMinutes) &&
-    isSlotAligned(day.endBookings, day.start, incrementMinutes);
-  return aligned
-    ? null
-    : `Day and bookings windows must be aligned to the event's ${incrementMinutes}-minute slots`;
-}
-
-function daysOverlap(
-  aStart: Date,
-  aEnd: Date,
-  bStart: Date,
-  bEnd: Date
-): boolean {
-  return aStart < bEnd && aEnd > bStart;
 }
 
 function revalidateDayPaths(eventId: string) {

--- a/app/api/admin/create-day/route.ts
+++ b/app/api/admin/create-day/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { dayAlignmentError, daysOverlap } from "@/utils/day-window";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only day creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+//
+// Behaves the same as createDayAction: a day overlapping an existing one
+// (including an exact duplicate) is a 409; otherwise multiple days can be
+// created freely, same as in the admin UI.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = {
+  eventSlug?: string;
+  start?: string;
+  end?: string;
+  startBookings?: string;
+  endBookings?: string;
+};
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function badRequest(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  for (const field of [
+    "eventSlug",
+    "start",
+    "end",
+    "startBookings",
+    "endBookings",
+  ] as const) {
+    if (body[field] !== undefined && typeof body[field] !== "string") {
+      return badRequest(`${field} must be a string`);
+    }
+  }
+
+  if (!body.eventSlug) return badRequest("eventSlug is required");
+
+  const start = parseDate(body.start);
+  if (!start) return badRequest("Invalid start date/time");
+
+  const end = parseDate(body.end);
+  if (!end) return badRequest("Invalid end date/time");
+
+  if (end <= start) return badRequest("Day end must be after start");
+
+  const startBookings = parseDate(body.startBookings);
+  if (!startBookings) return badRequest("Invalid bookings start date/time");
+
+  const endBookings = parseDate(body.endBookings);
+  if (!endBookings) return badRequest("Invalid bookings end date/time");
+
+  if (endBookings <= startBookings) {
+    return badRequest("Bookings end must be after bookings start");
+  }
+
+  if (startBookings < start || endBookings > end) {
+    return badRequest("Bookings window must be within the day window");
+  }
+
+  const repos = getRepositories();
+  const event = await repos.events.findBySlug(body.eventSlug);
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const alignmentError = dayAlignmentError(
+    { start, end, startBookings, endBookings },
+    event.slotIncrementMinutes
+  );
+  if (alignmentError) {
+    return badRequest(alignmentError);
+  }
+
+  const existingDays = await repos.days.listByEvent(event.id);
+  if (existingDays.some((d) => daysOverlap(start, end, d.start, d.end))) {
+    return NextResponse.json(
+      { error: "Day overlaps an existing day" },
+      { status: 409 }
+    );
+  }
+
+  let day;
+  try {
+    day = await repos.days.create({
+      eventId: event.id,
+      start,
+      end,
+      startBookings,
+      endBookings,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to create day" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ id: day.id });
+}

--- a/tests/integration/admin-create-day-route.test.ts
+++ b/tests/integration/admin-create-day-route.test.ts
@@ -1,0 +1,198 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent } from "../helpers/factories";
+import type { Event } from "@/db/repositories/interfaces";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-day/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-day", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response): Promise<{ id: string }> {
+  return (await res.json()) as { id: string };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+function validBody(event: Event) {
+  return {
+    eventSlug: event.slug,
+    start: "2026-09-01T08:00:00Z",
+    end: "2026-09-01T18:00:00Z",
+    startBookings: "2026-09-01T09:00:00Z",
+    endBookings: "2026-09-01T17:00:00Z",
+  };
+}
+
+describe("POST /api/admin/create-day", () => {
+  beforeAll(() => setupTestDb());
+
+  let event: Event;
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+    event = await createEvent();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(makeReq(validBody(event)));
+    expect(res.status).toBe(401);
+    expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
+  });
+
+  it("creates a day and returns its id", async () => {
+    const res = await POST(makeReq(validBody(event)));
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+
+    const days = await getRepositories().days.listByEvent(event.id);
+    expect(days).toHaveLength(1);
+    expect(days[0].id).toBe(body.id);
+    expect(days[0].start).toEqual(new Date("2026-09-01T08:00:00Z"));
+    expect(days[0].end).toEqual(new Date("2026-09-01T18:00:00Z"));
+    expect(days[0].startBookings).toEqual(new Date("2026-09-01T09:00:00Z"));
+    expect(days[0].endBookings).toEqual(new Date("2026-09-01T17:00:00Z"));
+  });
+
+  it("allows creating multiple non-overlapping days, same as the admin UI", async () => {
+    await POST(makeReq(validBody(event)));
+    const res = await POST(
+      makeReq({
+        ...validBody(event),
+        start: "2026-09-02T08:00:00Z",
+        end: "2026-09-02T18:00:00Z",
+        startBookings: "2026-09-02T09:00:00Z",
+        endBookings: "2026-09-02T17:00:00Z",
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(2);
+  });
+
+  it("rejects a day identical to an existing one with 409, same as the admin UI", async () => {
+    await POST(makeReq(validBody(event)));
+    const res = await POST(makeReq(validBody(event)));
+    expect(res.status).toBe(409);
+    expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(1);
+  });
+
+  it("rejects an overlapping non-identical day with 409", async () => {
+    await POST(makeReq(validBody(event)));
+    const res = await POST(
+      makeReq({
+        ...validBody(event),
+        start: "2026-09-01T09:00:00Z",
+        startBookings: "2026-09-01T09:00:00Z",
+      })
+    );
+    expect(res.status).toBe(409);
+    expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(1);
+  });
+
+  it("rejects a day misaligned to the event's slot increment with 400", async () => {
+    // The factory event uses 30-minute slots; 18:10 is not on a boundary.
+    const res = await POST(
+      makeReq({ ...validBody(event), end: "2026-09-01T18:10:00Z" })
+    );
+    expect(res.status).toBe(400);
+    expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
+  });
+
+  it("returns 404 for an unknown eventSlug", async () => {
+    const res = await POST(
+      makeReq({ ...validBody(event), eventSlug: "does-not-exist" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-day", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    [
+      "missing eventSlug",
+      (b: ReturnType<typeof validBody>) => ({ ...b, eventSlug: "" }),
+    ],
+    [
+      "invalid start",
+      (b: ReturnType<typeof validBody>) => ({ ...b, start: "nope" }),
+    ],
+    [
+      "end before start",
+      (b: ReturnType<typeof validBody>) => ({
+        ...b,
+        end: "2026-09-01T07:00:00Z",
+      }),
+    ],
+    [
+      "bookings end before bookings start",
+      (b: ReturnType<typeof validBody>) => ({
+        ...b,
+        endBookings: "2026-09-01T08:30:00Z",
+      }),
+    ],
+    [
+      "bookings outside the day window",
+      (b: ReturnType<typeof validBody>) => ({
+        ...b,
+        startBookings: "2026-09-01T07:00:00Z",
+      }),
+    ],
+    [
+      "a non-string start (e.g. epoch millis, bypassing date parsing)",
+      (b: ReturnType<typeof validBody>) => ({
+        ...b,
+        start: Date.parse(b.start) as unknown as string,
+      }),
+    ],
+  ])("rejects %s with 400", async (_label, mutate) => {
+    const res = await POST(makeReq(mutate(validBody(event))));
+    expect(res.status).toBe(400);
+    expect(await getRepositories().days.listByEvent(event.id)).toEqual([]);
+  });
+});

--- a/utils/day-window.ts
+++ b/utils/day-window.ts
@@ -1,6 +1,9 @@
-// Predicates relating a scheduled session to a day's time window. Shared so the
-// delete-cascade, the edit guard, and the admin UI warning all agree on which
-// sessions a day window affects.
+// Predicates relating a scheduled session to a day's time window, and rules
+// for validating a day's own window against its event and sibling days.
+// Shared so the delete-cascade, the edit guard, the admin UI warning, and the
+// day-creation entry points (admin action and admin API route) all agree.
+
+import { isSlotAligned } from "@/utils/slots";
 
 type ScheduledTimes = {
   startTime?: Date | null;
@@ -25,4 +28,36 @@ export function sessionContainedInWindow(
 ): boolean {
   if (!session.startTime || !session.endTime) return false;
   return session.startTime >= windowStart && session.endTime <= windowEnd;
+}
+
+/** True when [aStart, aEnd) and [bStart, bEnd) share any time. */
+export function daysOverlap(
+  aStart: Date,
+  aEnd: Date,
+  bStart: Date,
+  bEnd: Date
+): boolean {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+type DayWindow = {
+  start: Date;
+  end: Date;
+  startBookings: Date;
+  endBookings: Date;
+};
+
+// The schedule grid anchors its slots at the day start, so the day end and
+// both booking boundaries must sit a whole number of slots from it.
+export function dayAlignmentError(
+  day: DayWindow,
+  incrementMinutes: number
+): string | null {
+  const aligned =
+    isSlotAligned(day.end, day.start, incrementMinutes) &&
+    isSlotAligned(day.startBookings, day.start, incrementMinutes) &&
+    isSlotAligned(day.endBookings, day.start, incrementMinutes);
+  return aligned
+    ? null
+    : `Day and bookings windows must be aligned to the event's ${incrementMinutes}-minute slots`;
 }


### PR DESCRIPTION
POST /api/admin/create-day mirrors createDayAction's validation
(bookings inside the day window, slot alignment, no overlap) and
its overlap rule: an overlapping day (including an exact duplicate)
is a 409, same as the admin UI. Non-overlapping days can be created
freely, same as the admin UI.

Shares the alignment/overlap predicates with createDayAction via
utils/day-window.ts instead of duplicating them.

<!-- jip:pushed-commit=c4a990644bf2967e95983c51591ab220322a2078 -->