### PR TITLE
feat(api): admin route to create sessions

### DIFF
--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -4,8 +4,7 @@ import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
-import { isSlotAligned } from "@/utils/slots";
-import { sessionOverlapsWindow } from "@/utils/day-window";
+import { sessionSlotAlignmentError } from "@/utils/day-window";
 import type { AdminActionResult } from "./admin-guests";
 
 async function isAdminRequest(): Promise<boolean> {
@@ -43,10 +42,6 @@ function parseTimeRange(
   return { start, end };
 }
 
-// Scheduled times must land on the slot grid of the day they fall in, anchored
-// to that day's start; the grid silently drops misaligned sessions. Sessions
-// overlapping no day window are exempt — there is no grid to align to. Mirrors
-// slotIncrementChangeError in admin-events.ts.
 async function slotAlignmentError(
   eventId: string,
   incrementMinutes: number,
@@ -55,17 +50,7 @@ async function slotAlignmentError(
 ): Promise<string | null> {
   if (!start || !end) return null;
   const days = await getRepositories().days.listByEvent(eventId);
-  const day = days.find((d) =>
-    sessionOverlapsWindow({ startTime: start, endTime: end }, d.start, d.end)
-  );
-  if (!day) return null;
-  if (
-    !isSlotAligned(start, day.start, incrementMinutes) ||
-    !isSlotAligned(end, day.start, incrementMinutes)
-  ) {
-    return `Session times must align to the event's ${incrementMinutes}-minute slots; misaligned sessions do not appear in the schedule grid`;
-  }
-  return null;
+  return sessionSlotAlignmentError(days, incrementMinutes, start, end);
 }
 
 // Mirrors the user-facing rule (validateSession in app/api/session-form-utils.ts):

--- a/app/api/admin/create-session/route.ts
+++ b/app/api/admin/create-session/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+import { sessionSlotAlignmentError } from "@/utils/day-window";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only session creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+//
+// Unlike /api/add-session this returns the created id (which the RSVP step
+// needs), takes absolute ISO times instead of the SessionParams shape, and —
+// like the other admin seeding routes — has no scheduling-phase or
+// future-time gate: an importer routinely seeds past/fixed dates.
+//
+// Always creates a new session, same as adminCreateSessionAction: sessions
+// aren't deduplicated, so a repeated request is a location conflict (409),
+// not a silent no-op. Hosts and locations are auto-assigned to the event so
+// imported sessions are fully visible without extra calls.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = {
+  eventSlug?: string;
+  title?: string;
+  description?: string;
+  startTime?: string;
+  endTime?: string;
+  hostIds?: string[];
+  locationIds?: string[];
+  capacity?: number;
+  adminManaged?: boolean;
+  closed?: boolean;
+};
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function badRequest(error: string) {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  for (const field of ["eventSlug", "title", "description"] as const) {
+    if (body[field] !== undefined && typeof body[field] !== "string") {
+      return badRequest(`${field} must be a string`);
+    }
+  }
+  if (body.hostIds !== undefined && !Array.isArray(body.hostIds)) {
+    return badRequest("hostIds must be an array");
+  }
+  if (body.locationIds !== undefined && !Array.isArray(body.locationIds)) {
+    return badRequest("locationIds must be an array");
+  }
+
+  if (!body.eventSlug) return badRequest("eventSlug is required");
+
+  const title = (body.title ?? "").trim();
+  if (!title) return badRequest("Title is required");
+
+  const startTime = parseDate(body.startTime);
+  if (!startTime) return badRequest("Invalid start time");
+
+  const endTime = parseDate(body.endTime);
+  if (!endTime) return badRequest("Invalid end time");
+
+  if (endTime <= startTime) {
+    return badRequest("End time must be after start time");
+  }
+
+  const hostIds = body.hostIds ?? [];
+  const locationIds = body.locationIds ?? [];
+
+  const repos = getRepositories();
+  const event = await repos.events.findBySlug(body.eventSlug);
+  if (!event) {
+    return NextResponse.json({ error: "Event not found" }, { status: 404 });
+  }
+
+  const knownHosts = await repos.guests.findExistingIds(hostIds);
+  if (knownHosts.length !== hostIds.length) {
+    return badRequest("Unknown host");
+  }
+  const knownLocations = await repos.locations.findExistingIds(locationIds);
+  if (knownLocations.length !== locationIds.length) {
+    return badRequest("Unknown location");
+  }
+
+  let capacity = body.capacity;
+  if (capacity === undefined) {
+    const firstLocation =
+      locationIds.length > 0
+        ? await repos.locations.findById(locationIds[0])
+        : undefined;
+    capacity = firstLocation?.capacity ?? 0;
+  }
+  if (!Number.isInteger(capacity) || capacity < 0) {
+    return badRequest("Capacity must be a non-negative whole number");
+  }
+
+  const days = await repos.days.listByEvent(event.id);
+  const alignmentError = sessionSlotAlignmentError(
+    days,
+    event.slotIncrementMinutes,
+    startTime,
+    endTime
+  );
+  if (alignmentError) return badRequest(alignmentError);
+
+  const conflict = await repos.sessions.findLocationConflict(
+    event.id,
+    startTime,
+    endTime,
+    locationIds
+  );
+  if (conflict) {
+    return NextResponse.json(
+      { error: `Overlaps "${conflict.title}" in the same location` },
+      { status: 409 }
+    );
+  }
+
+  const session = await repos.sessions.create({
+    title,
+    description: (body.description ?? "").trim(),
+    startTime,
+    endTime,
+    capacity,
+    adminManaged: body.adminManaged ?? false,
+    blocker: false,
+    closed: body.closed ?? false,
+    eventId: event.id,
+    hostIds,
+    locationIds,
+  });
+
+  if (hostIds.length > 0) {
+    await repos.guests.assignToEvent(event.id, hostIds);
+  }
+  if (locationIds.length > 0) {
+    await repos.locations.assignToEvent(event.id, locationIds);
+  }
+
+  return NextResponse.json({ id: session.id });
+}

--- a/tests/integration/admin-create-session-route.test.ts
+++ b/tests/integration/admin-create-session-route.test.ts
@@ -1,0 +1,270 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createDay,
+} from "../helpers/factories";
+import type { Event, Guest, Location } from "@/db/repositories/interfaces";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-session/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-session", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(res: Response): Promise<{ id: string }> {
+  return (await res.json()) as { id: string };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("POST /api/admin/create-session", () => {
+  beforeAll(() => setupTestDb());
+
+  let event: Event;
+  let host: Guest;
+  let room: Location;
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+    event = await createEvent();
+    host = await createGuest();
+    room = await createLocation({ capacity: 12 });
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  function validBody() {
+    return {
+      eventSlug: event.slug,
+      title: "Intro to Juggling",
+      description: "Bring three balls",
+      startTime: "2026-09-01T10:00:00Z",
+      endTime: "2026-09-01T11:00:00Z",
+      hostIds: [host.id],
+      locationIds: [room.id],
+    };
+  }
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(makeReq(validBody()));
+    expect(res.status).toBe(401);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
+  });
+
+  it("creates a session and returns its id", async () => {
+    const res = await POST(makeReq(validBody()));
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+
+    const session = await getRepositories().sessions.findById(body.id);
+    expect(session?.title).toBe("Intro to Juggling");
+    expect(session?.description).toBe("Bring three balls");
+    expect(session?.startTime).toEqual(new Date("2026-09-01T10:00:00Z"));
+    expect(session?.endTime).toEqual(new Date("2026-09-01T11:00:00Z"));
+    expect(session?.eventId).toBe(event.id);
+    expect(session?.hosts.map((h) => h.id)).toEqual([host.id]);
+    expect(session?.locations.map((l) => l.id)).toEqual([room.id]);
+    // adminManaged is opt-in via the request; omitting it defaults to false.
+    expect(session?.adminManaged).toBe(false);
+    expect(session?.blocker).toBe(false);
+    expect(session?.closed).toBe(false);
+    // Capacity defaults to the first location's capacity.
+    expect(session?.capacity).toBe(12);
+  });
+
+  it("assigns hosts and locations to the event", async () => {
+    await POST(makeReq(validBody()));
+    const repos = getRepositories();
+    const members = await repos.guests.listByEvent(event.id);
+    expect(members.map((g) => g.id)).toContain(host.id);
+    const rooms = await repos.locations.listLocationIdsByEvent(event.id);
+    expect(rooms).toContain(room.id);
+  });
+
+  it("accepts explicit capacity, adminManaged and closed", async () => {
+    const res = await POST(
+      makeReq({
+        ...validBody(),
+        capacity: 5,
+        adminManaged: true,
+        closed: true,
+      })
+    );
+    const { id } = await readJson(res);
+    const session = await getRepositories().sessions.findById(id);
+    expect(session?.capacity).toBe(5);
+    expect(session?.adminManaged).toBe(true);
+    expect(session?.closed).toBe(true);
+  });
+
+  it("defaults capacity to 0 without a location", async () => {
+    const res = await POST(makeReq({ ...validBody(), locationIds: [] }));
+    const { id } = await readJson(res);
+    const session = await getRepositories().sessions.findById(id);
+    expect(session?.capacity).toBe(0);
+  });
+
+  it("creates a new session even when title and start time match an existing one in a different location", async () => {
+    const first = await readJson(await POST(makeReq(validBody())));
+    const otherRoom = await createLocation({ capacity: 20 });
+    const res = await POST(
+      makeReq({ ...validBody(), locationIds: [otherRoom.id] })
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.id).not.toBe(first.id);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
+      2
+    );
+  });
+
+  it("rejects an overlapping session in the same location with 409", async () => {
+    await POST(makeReq(validBody()));
+    const res = await POST(
+      makeReq({
+        ...validBody(),
+        title: "Advanced Juggling",
+        startTime: "2026-09-01T10:30:00Z",
+        endTime: "2026-09-01T11:30:00Z",
+      })
+    );
+    expect(res.status).toBe(409);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
+      1
+    );
+  });
+
+  it("rejects a repeated identical request with 409 instead of silently reusing it", async () => {
+    await POST(makeReq(validBody()));
+    const res = await POST(makeReq(validBody()));
+    expect(res.status).toBe(409);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(
+      1
+    );
+  });
+
+  it("rejects times misaligned with the event's slot grid", async () => {
+    await createDay(event.id, {
+      start: new Date("2026-09-01T08:00:00Z"),
+      end: new Date("2026-09-01T18:00:00Z"),
+      startBookings: new Date("2026-09-01T09:00:00Z"),
+      endBookings: new Date("2026-09-01T17:00:00Z"),
+    });
+    const res = await POST(
+      makeReq({
+        ...validBody(),
+        startTime: "2026-09-01T10:07:00Z",
+        endTime: "2026-09-01T11:00:00Z",
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
+  });
+
+  it("returns 404 for an unknown eventSlug", async () => {
+    const res = await POST(
+      makeReq({ ...validBody(), eventSlug: "does-not-exist" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-session", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ["missing title", (b: Record<string, unknown>) => ({ ...b, title: " " })],
+    [
+      "invalid startTime",
+      (b: Record<string, unknown>) => ({ ...b, startTime: "nope" }),
+    ],
+    [
+      "missing endTime",
+      (b: Record<string, unknown>) => ({ ...b, endTime: undefined }),
+    ],
+    [
+      "end before start",
+      (b: Record<string, unknown>) => ({
+        ...b,
+        endTime: "2026-09-01T09:00:00Z",
+      }),
+    ],
+    [
+      "negative capacity",
+      (b: Record<string, unknown>) => ({ ...b, capacity: -1 }),
+    ],
+    [
+      "unknown hostId",
+      (b: Record<string, unknown>) => ({ ...b, hostIds: ["nope"] }),
+    ],
+    [
+      "unknown locationId",
+      (b: Record<string, unknown>) => ({ ...b, locationIds: ["nope"] }),
+    ],
+    ["non-string title", (b: Record<string, unknown>) => ({ ...b, title: 5 })],
+    [
+      "non-string description",
+      (b: Record<string, unknown>) => ({ ...b, description: 5 }),
+    ],
+    [
+      "non-string eventSlug",
+      (b: Record<string, unknown>) => ({ ...b, eventSlug: 5 }),
+    ],
+    [
+      "non-array hostIds",
+      (b: Record<string, unknown>) => ({ ...b, hostIds: "nope" }),
+    ],
+    [
+      "non-array locationIds",
+      (b: Record<string, unknown>) => ({ ...b, locationIds: "nope" }),
+    ],
+  ])("rejects %s with 400", async (_label, mutate) => {
+    const res = await POST(makeReq(mutate(validBody())));
+    expect(res.status).toBe(400);
+    expect(await getRepositories().sessions.listByEvent(event.id)).toEqual([]);
+  });
+});

--- a/utils/day-window.ts
+++ b/utils/day-window.ts
@@ -4,6 +4,7 @@
 // day-creation entry points (admin action and admin API route) all agree.
 
 import { isSlotAligned } from "@/utils/slots";
+import type { Day } from "@/db/repositories/interfaces";
 
 type ScheduledTimes = {
   startTime?: Date | null;
@@ -60,4 +61,28 @@ export function dayAlignmentError(
   return aligned
     ? null
     : `Day and bookings windows must be aligned to the event's ${incrementMinutes}-minute slots`;
+}
+
+// Scheduled times must land on the slot grid of the day they fall in, anchored
+// to that day's start; the grid silently drops misaligned sessions. Sessions
+// overlapping no day window are exempt — there is no grid to align to. Shared
+// by adminCreateSessionAction/adminUpdateSessionAction and the create-session
+// admin API route.
+export function sessionSlotAlignmentError(
+  days: Day[],
+  incrementMinutes: number,
+  start: Date,
+  end: Date
+): string | null {
+  const day = days.find((d) =>
+    sessionOverlapsWindow({ startTime: start, endTime: end }, d.start, d.end)
+  );
+  if (!day) return null;
+  if (
+    !isSlotAligned(start, day.start, incrementMinutes) ||
+    !isSlotAligned(end, day.start, incrementMinutes)
+  ) {
+    return `Session times must align to the event's ${incrementMinutes}-minute slots; misaligned sessions do not appear in the schedule grid`;
+  }
+  return null;
 }


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [1e02e5b](https://github.com/LWCW-Europe/schellingboard/pull/587/commits/1e02e5b281d4995c78f42f28a05288e5e62d6f62).

PRs:
* #604
* ➡️ #587 (this PR, base of the stack — can be merged first)

---

## Description

POST /api/admin/create-session returns the id the RSVP import step
needs; /api/add-session only logs it server-side. Takes absolute ISO
times and, unlike add-session, has no scheduling-phase or future-time
gate (importers seed past/fixed dates). Location overlap is a 409
mirroring the admin action; sessions are never deduplicated, same as
the admin UI. Enforces the same slot-alignment rule as
adminCreateSessionAction, now shared via sessionSlotAlignmentError in
utils/day-window.ts so the two entry points can't drift apart.
adminManaged defaults to false, same as the rest of the app.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=1e02e5b281d4995c78f42f28a05288e5e62d6f62 -->