### PR TITLE
feat(api): admin route to create RSVPs

### DIFF
--- a/app/api/admin/create-rsvp/route.ts
+++ b/app/api/admin/create-rsvp/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
+
+export const dynamic = "force-dynamic";
+
+// Admin-only RSVP creation over plain HTTP, for external seeding scripts.
+// The middleware already enforces site auth for /api/*; here we additionally
+// require the admin cookie, matching the admin server actions.
+//
+// Unlike /api/toggle-rsvp there is no scheduling-phase gate, so an import
+// never depends on the event's current phase. rsvpCapacityHardLimit is still
+// enforced, same as toggle-rsvp: a full session is a 409, not a silent
+// overbook. The guest is auto-assigned to the session's event so the RSVP is
+// never orphaned from the UI's member lists. Idempotent per (session, guest)
+// via the repository's onConflictDoNothing.
+async function isAdminRequest(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value);
+}
+
+type Body = { sessionId?: string; guestId?: string };
+
+export async function POST(req: Request) {
+  if (!(await isAdminRequest())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Body;
+  try {
+    body = ((await req.json()) ?? {}) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    (body.sessionId !== undefined && typeof body.sessionId !== "string") ||
+    (body.guestId !== undefined && typeof body.guestId !== "string")
+  ) {
+    return NextResponse.json(
+      { error: "sessionId and guestId must be strings" },
+      { status: 400 }
+    );
+  }
+  const { sessionId, guestId } = body;
+  if (!sessionId || !guestId) {
+    return NextResponse.json(
+      { error: "sessionId and guestId are required" },
+      { status: 400 }
+    );
+  }
+
+  const repos = getRepositories();
+  const session = await repos.sessions.findById(sessionId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+  const guest = await repos.guests.findById(guestId);
+  if (!guest) {
+    return NextResponse.json({ error: "Guest not found" }, { status: 404 });
+  }
+  const event = await repos.events.findById(session.eventId);
+
+  const existing = (await repos.rsvps.listBySession(sessionId)).find(
+    (r) => r.guestId === guestId
+  );
+
+  let rsvp = existing;
+  if (!rsvp) {
+    const enforceCapacity =
+      event?.rsvpCapacityHardLimit && session.capacity > 0;
+    if (enforceCapacity) {
+      rsvp =
+        (await repos.rsvps.createIfUnderCapacity({
+          sessionId,
+          guestId,
+          capacity: session.capacity,
+        })) ?? undefined;
+      if (!rsvp) {
+        return NextResponse.json(
+          { error: "This session is full" },
+          { status: 409 }
+        );
+      }
+    } else {
+      rsvp = await repos.rsvps.create({ sessionId, guestId });
+    }
+  }
+
+  await repos.guests.assignToEvent(session.eventId, [guestId]);
+
+  return NextResponse.json(
+    { id: rsvp.id, created: !existing },
+    { status: existing ? 200 : 201 }
+  );
+}

--- a/tests/integration/admin-create-rsvp-route.test.ts
+++ b/tests/integration/admin-create-rsvp-route.test.ts
@@ -1,0 +1,195 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import type { Event, Guest, Session } from "@/db/repositories/interfaces";
+import { getRepositories } from "@/db/container";
+import { createAdminAuthCookie } from "@/utils/auth";
+import { POST } from "@/app/api/admin/create-rsvp/route";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/admin/create-rsvp", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function readJson(
+  res: Response
+): Promise<{ id: string; created: boolean }> {
+  return (await res.json()) as { id: string; created: boolean };
+}
+
+async function loginAsAdmin() {
+  const c = await createAdminAuthCookie();
+  cookieJar.set(c.name, c.value);
+}
+
+describe("POST /api/admin/create-rsvp", () => {
+  beforeAll(() => setupTestDb());
+
+  let event: Event;
+  let session: Session;
+  let guest: Guest;
+
+  beforeEach(async () => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    await loginAsAdmin();
+    // Proposal phase on purpose: unlike toggle-rsvp, this route must work
+    // in any phase.
+    event = await createEvent({ phase: "proposal" });
+    session = await createSession(event.id);
+    guest = await createGuest();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects the request without an admin cookie", async () => {
+    cookieJar.clear();
+    const res = await POST(
+      makeReq({ sessionId: session.id, guestId: guest.id })
+    );
+    expect(res.status).toBe(401);
+    expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
+  });
+
+  it("creates an RSVP regardless of phase and returns its id", async () => {
+    const res = await POST(
+      makeReq({ sessionId: session.id, guestId: guest.id })
+    );
+    expect(res.status).toBe(201);
+    const body = await readJson(res);
+    expect(body.created).toBe(true);
+
+    const rsvps = await getRepositories().rsvps.listBySession(session.id);
+    expect(rsvps).toHaveLength(1);
+    expect(rsvps[0].id).toBe(body.id);
+    expect(rsvps[0].guestId).toBe(guest.id);
+  });
+
+  it("assigns the guest to the session's event", async () => {
+    await POST(makeReq({ sessionId: session.id, guestId: guest.id }));
+    const members = await getRepositories().guests.listByEvent(event.id);
+    expect(members.map((g) => g.id)).toContain(guest.id);
+  });
+
+  it("is idempotent per session and guest", async () => {
+    const first = await readJson(
+      await POST(makeReq({ sessionId: session.id, guestId: guest.id }))
+    );
+    const res = await POST(
+      makeReq({ sessionId: session.id, guestId: guest.id })
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.created).toBe(false);
+    expect(body.id).toBe(first.id);
+    expect(
+      await getRepositories().rsvps.listBySession(session.id)
+    ).toHaveLength(1);
+  });
+
+  it("returns 404 for an unknown session", async () => {
+    const res = await POST(makeReq({ sessionId: "nope", guestId: guest.id }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown guest", async () => {
+    const res = await POST(makeReq({ sessionId: session.id, guestId: "nope" }));
+    expect(res.status).toBe(404);
+    expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
+  });
+
+  it("rejects a malformed JSON body with 400", async () => {
+    const res = await POST(
+      new Request("http://test/api/admin/create-rsvp", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects missing ids with 400", async () => {
+    expect((await POST(makeReq({ guestId: guest.id }))).status).toBe(400);
+    expect((await POST(makeReq({ sessionId: session.id }))).status).toBe(400);
+  });
+
+  it("rejects non-string ids with 400", async () => {
+    expect(
+      (await POST(makeReq({ sessionId: 1, guestId: guest.id }))).status
+    ).toBe(400);
+    expect(
+      (await POST(makeReq({ sessionId: session.id, guestId: 1 }))).status
+    ).toBe(400);
+  });
+
+  it("returns 409 when the session is full under a hard capacity limit", async () => {
+    const cappedEvent = await createEvent({
+      phase: "proposal",
+      rsvpCapacityHardLimit: true,
+    });
+    const cappedSession = await createSession(cappedEvent.id, {
+      capacity: 1,
+    });
+    const first = await createGuest();
+    const second = await createGuest();
+
+    const okRes = await POST(
+      makeReq({ sessionId: cappedSession.id, guestId: first.id })
+    );
+    expect(okRes.status).toBe(201);
+
+    const fullRes = await POST(
+      makeReq({ sessionId: cappedSession.id, guestId: second.id })
+    );
+    expect(fullRes.status).toBe(409);
+    expect(
+      await getRepositories().rsvps.listBySession(cappedSession.id)
+    ).toHaveLength(1);
+  });
+
+  it("re-adding an existing RSVP succeeds even at hard capacity", async () => {
+    const cappedEvent = await createEvent({
+      phase: "proposal",
+      rsvpCapacityHardLimit: true,
+    });
+    const cappedSession = await createSession(cappedEvent.id, {
+      capacity: 1,
+    });
+    const first = await createGuest();
+
+    await POST(makeReq({ sessionId: cappedSession.id, guestId: first.id }));
+    const res = await POST(
+      makeReq({ sessionId: cappedSession.id, guestId: first.id })
+    );
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body.created).toBe(false);
+  });
+});


### PR DESCRIPTION
POST /api/admin/create-rsvp completes the external-import flow: unlike
toggle-rsvp it has no scheduling-phase gate, so imports work in any
phase, but rsvpCapacityHardLimit is still enforced (409 when full). The
guest is auto-assigned to the session's event so the RSVP never dangles
outside the member list. Idempotent per session+guest.

<!-- jip:pushed-commit=7de1c72d79eb75223b79541773986dfecb6d076a -->