### PR TITLE
fix: guard against non-integer row-span from misaligned session times

### DIFF
--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -38,7 +38,12 @@ export function SessionBlock(props: {
   const startTime = session.startTime?.getTime() ?? 0;
   const endTime = session.endTime?.getTime() ?? 0;
   const sessionLength = endTime - startTime;
-  const numSlots = sessionLength / 1000 / 60 / slotIncrement;
+  // Ceil (not raw division) so a misaligned/legacy session still spans a
+  // whole number of grid rows instead of producing an invalid Tailwind class.
+  const numSlots = Math.max(
+    1,
+    Math.ceil(sessionLength / 1000 / 60 / slotIncrement)
+  );
 
   const isBlank = !session.title;
   const isBookable = isBookableSlot({


### PR DESCRIPTION
numSlots was raw division, producing invalid Tailwind classes for
legacy/malformed sessions not on the slot grid.

<!-- jip:pushed-commit=991ab3ef6e05c8655c28cf7f8b3a2a5a6439dd6f -->