### PR TITLE
refactor: rename UPLOADS_DIR env var to SB_UPLOADS_DIR

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,7 +6,7 @@ SITE_PASSWORD=testtest
 ADMIN_PASSWORD=admintest
 AUTH_SECRET=test-only-do-not-use-in-production-7f4c8e2a1b9d6f3e
 DATABASE_URL=file:./data.test.db
-UPLOADS_DIR=./uploads-test/
+SB_UPLOADS_DIR=./uploads-test/
 
 # To skip tests that send emails, set these to blank in .env.test.local.
 MAILPIT_API_URL=http://localhost:8025

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ has its own layout and only requires the admin password (not `SITE_PASSWORD`).
 | `SITE_PASSWORD`  | Enables site-wide password protection. Omit to disable.                                                                                                   |
 | `ADMIN_PASSWORD` | Enables the admin UI at `/admin`. Omit to disable (admin routes return a diagnostic message).                                                             |
 | `AUTH_SECRET`    | HMAC secret used to sign auth cookies. Required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Use ≥32 random bytes.                                    |
-| `UPLOADS_DIR`    | Directory for admin-uploaded files (location images, avatars, the site map). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist. |
+| `SB_UPLOADS_DIR` | Directory for admin-uploaded files (location images, avatars, the site map). Defaults to `./uploads`; in Docker it is `/data/uploads` so uploads persist. |
 | `SMTP_*`         | See "email variables" below.                                                                                                                              |
 
 `NEXT_PUBLIC_` variables are exposed to the browser; all others are server-side only.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 ENV DATABASE_URL=file:/data/data.db
 # Uploaded files must live on the persistent /data volume
-ENV UPLOADS_DIR=/data/uploads
+ENV SB_UPLOADS_DIR=/data/uploads
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD node -e "fetch('http://localhost:3000/api/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"

--- a/README.md
+++ b/README.md
@@ -49,20 +49,21 @@ docker compose up -d
 
 ### Environment variables
 
-| Variable         | Required | Description                                                |
-| ---------------- | -------- | ---------------------------------------------------------- |
-| `SITE_PASSWORD`  | No       | Password gate for the whole site (leave unset to disable)  |
-| `ADMIN_PASSWORD` | No       | Password for the `/admin` UI (leave unset to disable)      |
-| `AUTH_SECRET`    | Yes      | Secret key for session signing (random 32-byte hex string) |
-| `DATABASE_URL`   | No       | SQLite path (default: `file:/data/data.db`)                |
-| `HOST_PORT`      | No       | Host port to bind (default: `3000`, compose only)          |
-| `SMTP_FROM`      | No       | Sender address for outgoing email                          |
-| `SMTP_URL`       | No       | SMTP connection URL (see below)                            |
-| `SMTP_HOST`      | No       | SMTP server hostname (see below)                           |
-| `SMTP_PORT`      | No       | SMTP server port                                           |
-| `SMTP_USER`      | No       | SMTP username                                              |
-| `SMTP_PASSWORD`  | No       | SMTP password                                              |
-| `SMTP_SECURE`    | No       | `true`, `false`, or `requireTLS` (default)                 |
+| Variable         | Required | Description                                                                    |
+| ---------------- | -------- | ------------------------------------------------------------------------------ |
+| `SITE_PASSWORD`  | No       | Password gate for the whole site (leave unset to disable)                      |
+| `ADMIN_PASSWORD` | No       | Password for the `/admin` UI (leave unset to disable)                          |
+| `AUTH_SECRET`    | Yes      | Secret key for session signing (random 32-byte hex string)                     |
+| `DATABASE_URL`   | No       | SQLite path (default: `file:/data/data.db`)                                    |
+| `SB_UPLOADS_DIR` | No       | Dir for admin-uploaded files (default: `./uploads`, `/data/uploads` in Docker) |
+| `HOST_PORT`      | No       | Host port to bind (default: `3000`, compose only)                              |
+| `SMTP_FROM`      | No       | Sender address for outgoing email                                              |
+| `SMTP_URL`       | No       | SMTP connection URL (see below)                                                |
+| `SMTP_HOST`      | No       | SMTP server hostname (see below)                                               |
+| `SMTP_PORT`      | No       | SMTP server port                                                               |
+| `SMTP_USER`      | No       | SMTP username                                                                  |
+| `SMTP_PASSWORD`  | No       | SMTP password                                                                  |
+| `SMTP_SECURE`    | No       | `true`, `false`, or `requireTLS` (default)                                     |
 
 Email is optional — leave the SMTP variables unset to disable it. To enable
 email, set `SMTP_FROM` plus either `SMTP_URL` (a single connection string,

--- a/app/media/avatars/[filename]/route.ts
+++ b/app/media/avatars/[filename]/route.ts
@@ -1,4 +1,4 @@
-// Serves user-uploaded location images from UPLOADS_DIR. URLs carry a
+// Serves user-uploaded location images from SB_UPLOADS_DIR. URLs carry a
 // ?v= cache-buster set on upload, so responses can be cached aggressively.
 import { NextRequest, NextResponse } from "next/server";
 import { getImageRepositories } from "@/utils/images";

--- a/app/media/locations/[filename]/route.ts
+++ b/app/media/locations/[filename]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getImageRepositories } from "@/utils/images";
 
-// Serves admin-uploaded location images from UPLOADS_DIR. URLs carry a
+// Serves admin-uploaded location images from SB_UPLOADS_DIR. URLs carry a
 // ?v= cache-buster set on upload, so responses can be cached aggressively.
 export async function GET(
   _request: NextRequest,

--- a/app/media/site/[filename]/route.ts
+++ b/app/media/site/[filename]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readMapImage } from "@/utils/map-image";
 
-// Serves the admin-uploaded site map from UPLOADS_DIR. URLs carry a ?v=
+// Serves the admin-uploaded site map from SB_UPLOADS_DIR. URLs carry a ?v=
 // cache-buster set on upload, so responses can be cached aggressively.
 export async function GET(
   _request: NextRequest,

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -155,14 +155,14 @@ function generateEventDates() {
 }
 
 // Committed CC0 avatar images (see scripts/seed-assets/avatars/README.md);
-// copied into UPLOADS_DIR at seed time like real uploads.
+// copied into SB_UPLOADS_DIR at seed time like real uploads.
 const seedAvatarsDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "seed-assets/avatars"
 );
 
 function uploadedAvatarsDir(): string {
-  return path.join(process.env.UPLOADS_DIR ?? "./uploads", "avatars");
+  return path.join(process.env.SB_UPLOADS_DIR ?? "./uploads", "avatars");
 }
 
 interface GuestConfig {
@@ -752,7 +752,7 @@ function clearAll() {
   // repeated seeding doesn't accumulate orphaned uploads. Likewise the map
   // upload belongs to the site-settings row just cleared.
   fs.rmSync(uploadedAvatarsDir(), { recursive: true, force: true });
-  fs.rmSync(path.join(process.env.UPLOADS_DIR ?? "./uploads", "site"), {
+  fs.rmSync(path.join(process.env.SB_UPLOADS_DIR ?? "./uploads", "site"), {
     recursive: true,
     force: true,
   });

--- a/tests/integration/admin-locations.test.ts
+++ b/tests/integration/admin-locations.test.ts
@@ -83,7 +83,7 @@ describe("admin location actions", () => {
     uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-test-"));
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    vi.stubEnv("UPLOADS_DIR", uploadsDir);
+    vi.stubEnv("SB_UPLOADS_DIR", uploadsDir);
     await loginAsAdmin();
   });
 

--- a/tests/integration/admin-settings.test.ts
+++ b/tests/integration/admin-settings.test.ts
@@ -64,7 +64,7 @@ describe("admin settings actions", () => {
     uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-test-"));
     vi.stubEnv("ADMIN_PASSWORD", "admin-pw");
     vi.stubEnv("AUTH_SECRET", VALID_SECRET);
-    vi.stubEnv("UPLOADS_DIR", uploadsDir);
+    vi.stubEnv("SB_UPLOADS_DIR", uploadsDir);
     await loginAsAdmin();
   });
 

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -43,7 +43,7 @@ describe("updateProfileAction", () => {
     resetTestDb();
     cookieJar.clear();
     uploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-test-"));
-    vi.stubEnv("UPLOADS_DIR", uploadsDir);
+    vi.stubEnv("SB_UPLOADS_DIR", uploadsDir);
   });
 
   afterEach(() => {

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -8,7 +8,7 @@ import {
   REQUIRED_ASPECT_RATIO,
 } from "@/utils/location-image-constraints";
 
-// Images are stored on the filesystem under UPLOADS_DIR
+// Images are stored on the filesystem under SB_UPLOADS_DIR
 // (a persistent volume in production), not in public/,
 // because public/ is baked into the build and lost on redeploy.
 
@@ -34,7 +34,7 @@ export abstract class BaseImageResourceRepository<
     // turbopackIgnore: paths point at a runtime uploads volume, not build
     // assets; without it Turbopack traces the whole project into the bundle.
     return path.join(
-      /*turbopackIgnore: true*/ process.env.UPLOADS_DIR ?? "./uploads",
+      /*turbopackIgnore: true*/ process.env.SB_UPLOADS_DIR ?? "./uploads",
       this.directory
     );
   }

--- a/utils/map-image.ts
+++ b/utils/map-image.ts
@@ -3,7 +3,7 @@ import path from "path";
 import sharp from "sharp";
 
 // The site map is uploaded through the admin UI and stored on the filesystem
-// under UPLOADS_DIR (a persistent volume in production), not in public/, because
+// under SB_UPLOADS_DIR (a persistent volume in production), not in public/, because
 // public/ is baked into the build and lost on redeploy. It is served by
 // app/media/site/[filename]/route.ts.
 //
@@ -19,7 +19,7 @@ const FORMAT_EXTENSIONS: Record<string, string> = {
 };
 
 function mapDir(): string {
-  return path.join(process.env.UPLOADS_DIR ?? "./uploads", "site");
+  return path.join(process.env.SB_UPLOADS_DIR ?? "./uploads", "site");
 }
 
 /**


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [d853f43](https://github.com/LWCW-Europe/schellingboard/pull/592/commits/d853f43d3fe53df8fc07242b4c807b9cb8fde117).

PRs:
* #599
* #594
* #593
* ➡️ #592 (this PR, base of the stack — can be merged first)

---

## Description

Project-specific prefix avoids collision with a generic UPLOADS_DIR
that another tool or shell profile might already export.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=d853f43d3fe53df8fc07242b4c807b9cb8fde117 -->