### PR TITLE
feat: markdown support for profiles and descriptions

### DIFF
--- a/app/(site)/[eventSlug]/event.tsx
+++ b/app/(site)/[eventSlug]/event.tsx
@@ -20,6 +20,7 @@ import { getDefaultFoldedDayIds } from "@/utils/schedule-fold";
 import { KioskController, useKioskMode } from "./kiosk";
 import { SessionModal } from "./session-modal";
 import type { DayWithSessions } from "../context";
+import { Markdown } from "@/app/(site)/markdown";
 
 export function EventDisplay() {
   const { event, days, locations, guests, rsvps, now } =
@@ -82,7 +83,9 @@ export function EventDisplay() {
             <span>{event.website}</span>
           </a>
         </div>
-        <p className="text-gray-900 mt-3 mb-5">{event.description}</p>
+        <div className="text-gray-900 mt-3 mb-5">
+          <Markdown>{event.description}</Markdown>
+        </div>
         {hasPhases(event) && (
           <div className="mb-5">
             <Link

--- a/app/(site)/[eventSlug]/proposal.tsx
+++ b/app/(site)/[eventSlug]/proposal.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import type { SessionProposal } from "@/db/repositories/interfaces";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 import { useBreakMinutes } from "@/app/(site)/context";
+import { Markdown } from "@/app/(site)/markdown";
 
 export function Proposal(props: { proposal: SessionProposal }) {
   const { proposal } = props;
@@ -24,7 +25,9 @@ export function Proposal(props: { proposal: SessionProposal }) {
           </span>
         ))}
       </p>
-      <p className="mb-3 whitespace-pre-line">{proposal.description}</p>
+      <div className="mb-3">
+        <Markdown>{proposal.description}</Markdown>
+      </div>
       {proposal.durationMinutes && (
         <p className="text-sm text-gray-600 mb-4">
           Duration:{" "}

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -28,6 +28,7 @@ import { formatDuration, durationMinusBreak } from "@/utils/utils";
 import { VotingButtons } from "./voting-buttons";
 import { VoteChoice } from "@/app/(site)/votes";
 import { viewProposalLinkFromOwner } from "../modal-nav";
+import { stripMarkdown } from "@/utils/markdown";
 
 const ITEMS_PER_PAGE = 1000;
 
@@ -484,235 +485,76 @@ export function ProposalTable({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
-            {currentPageProposals.map((proposal) => (
-              <tr key={proposal.id} className="hover:bg-gray-200">
-                <td className="px-4 lg:px-6 py-4" title={proposal.title}>
-                  <Link
-                    {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
-                    className="block w-full"
-                  >
-                    <div className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors line-clamp-2 leading-tight">
-                      {proposal.title}
-                    </div>
-                  </Link>
-                </td>
-                <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  <div className="truncate">
-                    {proposal.hosts.length === 0
-                      ? "-"
-                      : proposal.hosts.map((h, i) => (
-                          <span key={h.id}>
-                            {i > 0 && ", "}
-                            <Link
-                              href={`/guests/${h.id}`}
-                              className="hover:text-blue-600 transition-colors"
-                            >
-                              {h.name}
-                            </Link>
-                          </span>
-                        ))}
-                  </div>
-                </td>
-                <td className="px-4 lg:px-6 py-4" title={proposal.description}>
-                  <div className="text-sm text-gray-500 line-clamp-2 leading-tight">
-                    {proposal.description || "-"}
-                  </div>
-                </td>
-                <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                  <div className="flex items-center">
-                    {proposal.durationMinutes ? (
-                      <>
-                        <ClockIcon className="h-4 w-4 mr-1 text-gray-400 flex-shrink-0" />
-                        <span className="text-sm text-gray-500 truncate">
-                          {formatDuration(
-                            durationMinusBreak(
-                              proposal.durationMinutes,
-                              event.breakMinutes
-                            )
-                          )}
-                        </span>
-                      </>
-                    ) : (
-                      <span className="text-sm text-gray-500">-</span>
-                    )}
-                  </div>
-                </td>
-                {!schedEnabled && (
-                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                    {currentUserId &&
-                      !proposal.hosts.some((h) => h.id === currentUserId) && (
-                        <VotingButtons
-                          proposalId={proposal.id}
-                          votingEnabled={votingEnabled}
-                          votingDisabledText={votingDisabledText}
-                        />
-                      )}
+            {currentPageProposals.map((proposal) => {
+              const plainDescription = stripMarkdown(proposal.description);
+              return (
+                <tr key={proposal.id} className="hover:bg-gray-200">
+                  <td className="px-4 lg:px-6 py-4" title={proposal.title}>
+                    <Link
+                      {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
+                      className="block w-full"
+                    >
+                      <div className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors line-clamp-2 leading-tight">
+                        {proposal.title}
+                      </div>
+                    </Link>
                   </td>
-                )}
-                {schedEnabled && (
-                  <>
-                    <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                      <span
-                        title={(() => {
-                          const vote = votes.find(
-                            (v) =>
-                              v.proposalId === proposal.id &&
-                              v.guestId === currentUserId
-                          );
-                          if (!vote) return "No vote";
-                          switch (vote.choice) {
-                            case VoteChoice.interested:
-                              return "Interested";
-                            case VoteChoice.maybe:
-                              return "Maybe";
-                            case VoteChoice.skip:
-                              return "Skip";
-                            default:
-                              return "No vote";
-                          }
-                        })()}
-                      >
-                        {proposalVoteEmoji(proposal.id)}
-                      </span>
-                    </td>
-                    <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center gap-2">
-                        <span
-                          title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-gray-500"
-                        >
-                          ❤️&nbsp;{proposal.interestedVotesCount}
-                        </span>
-                        <span
-                          title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-gray-500"
-                        >
-                          ⭐&nbsp;{proposal.maybeVotesCount}
-                        </span>
-                      </div>
-                    </td>
-                  </>
-                )}
-                <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                  <div className="flex gap-1 flex-col sm:flex-row">
-                    {canEdit(proposal.hosts) && (
-                      <div className="relative inline-block group">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            router.push(
-                              `/${eventSlug}/proposals/${proposal.id}/edit`
-                            );
-                          }}
-                          className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
-                        >
-                          <PencilIcon className="h-3 w-3 mr-1" />
-                          Edit
-                        </button>
-                      </div>
-                    )}
-                    {canEdit(proposal.hosts) && (
-                      <HoverTooltip
-                        text={schedDisabledText}
-                        visible={!schedEnabled}
-                      >
-                        <button
-                          onClick={() =>
-                            router.push(
-                              `/${eventSlug}/add-session?proposalID=${proposal.id}`
-                            )
-                          }
-                          className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
-                            schedEnabled ? "" : "opacity-50 cursor-not-allowed"
-                          }`}
-                          disabled={!schedEnabled}
-                        >
-                          <CalendarIcon className="h-3 w-3 mr-1" />
-                          Schedule
-                        </button>
-                      </HoverTooltip>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ))}
-            {searchResults.length === 0 && (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="px-4 lg:px-6 py-4 text-center text-sm text-gray-500"
-                >
-                  No proposals found
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Mobile Card View */}
-      <div className="block md:hidden space-y-4">
-        {currentPageProposals.map((proposal) => (
-          <div
-            key={proposal.id}
-            className="bg-white border border-gray-200 rounded-lg p-4 hover:bg-gray-50 relative"
-          >
-            <div className="space-y-3">
-              <div>
-                <h3 className="text-base font-medium text-gray-900">
-                  <Link
-                    {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
-                    className="hover:text-blue-600 transition-colors after:absolute after:inset-0"
-                  >
-                    {proposal.title}
-                  </Link>
-                </h3>
-                <p className="text-sm text-gray-500 mt-1">
-                  Host(s): {proposal.hosts.map((h) => h.name).join(", ") || "-"}
-                </p>
-              </div>
-
-              {proposal.description ? (
-                <p className="text-sm text-gray-600 line-clamp-3">
-                  {proposal.description}
-                </p>
-              ) : (
-                <p className="text-sm text-gray-500">-</p>
-              )}
-
-              {proposal.durationMinutes ? (
-                <div className="flex items-center">
-                  <ClockIcon className="h-4 w-4 mr-1 text-gray-400" />
-                  <span className="text-sm text-gray-500">
-                    {formatDuration(
-                      durationMinusBreak(
-                        proposal.durationMinutes,
-                        event.breakMinutes
-                      )
-                    )}
-                  </span>
-                </div>
-              ) : (
-                <div className="text-sm text-gray-500">-</div>
-              )}
-
-              <div className="pt-2 border-t border-gray-100 space-y-3">
-                {currentUserId &&
-                  !proposal.hosts.some((h) => h.id === currentUserId) &&
-                  !schedEnabled && (
-                    <div className="relative z-10">
-                      <VotingButtons
-                        proposalId={proposal.id}
-                        votingEnabled={votingEnabled}
-                        votingDisabledText={votingDisabledText}
-                      />
+                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <div className="truncate">
+                      {proposal.hosts.length === 0
+                        ? "-"
+                        : proposal.hosts.map((h, i) => (
+                            <span key={h.id}>
+                              {i > 0 && ", "}
+                              <Link
+                                href={`/guests/${h.id}`}
+                                className="hover:text-blue-600 transition-colors"
+                              >
+                                {h.name}
+                              </Link>
+                            </span>
+                          ))}
                     </div>
+                  </td>
+                  <td className="px-4 lg:px-6 py-4" title={plainDescription}>
+                    <div className="text-sm text-gray-500 line-clamp-2 leading-tight">
+                      {plainDescription || "-"}
+                    </div>
+                  </td>
+                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                    <div className="flex items-center">
+                      {proposal.durationMinutes ? (
+                        <>
+                          <ClockIcon className="h-4 w-4 mr-1 text-gray-400 flex-shrink-0" />
+                          <span className="text-sm text-gray-500 truncate">
+                            {formatDuration(
+                              durationMinusBreak(
+                                proposal.durationMinutes,
+                                event.breakMinutes
+                              )
+                            )}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="text-sm text-gray-500">-</span>
+                      )}
+                    </div>
+                  </td>
+                  {!schedEnabled && (
+                    <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                      {currentUserId &&
+                        !proposal.hosts.some((h) => h.id === currentUserId) && (
+                          <VotingButtons
+                            proposalId={proposal.id}
+                            votingEnabled={votingEnabled}
+                            votingDisabledText={votingDisabledText}
+                          />
+                        )}
+                    </td>
                   )}
-                {schedEnabled && (
-                  <>
-                    {!canEdit(proposal.hosts) && (
-                      <div>
-                        Your vote:
+                  {schedEnabled && (
+                    <>
+                      <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
                         <span
                           title={(() => {
                             const vote = votes.find(
@@ -732,74 +574,242 @@ export function ProposalTable({
                                 return "No vote";
                             }
                           })()}
-                          className="ml-1"
                         >
                           {proposalVoteEmoji(proposal.id)}
                         </span>
-                      </div>
-                    )}
-                    <div className="flex items-center gap-2">
-                      Total votes:
-                      <span
-                        title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                        className="flex items-center gap-1 text-sm text-gray-500"
-                      >
-                        ❤️&nbsp;{proposal.interestedVotesCount}
-                      </span>
-                      <span
-                        title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                        className="flex items-center gap-1 text-sm text-gray-500"
-                      >
-                        ⭐&nbsp;{proposal.maybeVotesCount}
-                      </span>
+                      </td>
+                      <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center gap-2">
+                          <span
+                            title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
+                            className="flex items-center gap-1 text-sm text-gray-500"
+                          >
+                            ❤️&nbsp;{proposal.interestedVotesCount}
+                          </span>
+                          <span
+                            title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
+                            className="flex items-center gap-1 text-sm text-gray-500"
+                          >
+                            ⭐&nbsp;{proposal.maybeVotesCount}
+                          </span>
+                        </div>
+                      </td>
+                    </>
+                  )}
+                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
+                    <div className="flex gap-1 flex-col sm:flex-row">
+                      {canEdit(proposal.hosts) && (
+                        <div className="relative inline-block group">
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              router.push(
+                                `/${eventSlug}/proposals/${proposal.id}/edit`
+                              );
+                            }}
+                            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+                          >
+                            <PencilIcon className="h-3 w-3 mr-1" />
+                            Edit
+                          </button>
+                        </div>
+                      )}
+                      {canEdit(proposal.hosts) && (
+                        <HoverTooltip
+                          text={schedDisabledText}
+                          visible={!schedEnabled}
+                        >
+                          <button
+                            onClick={() =>
+                              router.push(
+                                `/${eventSlug}/add-session?proposalID=${proposal.id}`
+                              )
+                            }
+                            className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
+                              schedEnabled
+                                ? ""
+                                : "opacity-50 cursor-not-allowed"
+                            }`}
+                            disabled={!schedEnabled}
+                          >
+                            <CalendarIcon className="h-3 w-3 mr-1" />
+                            Schedule
+                          </button>
+                        </HoverTooltip>
+                      )}
                     </div>
-                  </>
+                  </td>
+                </tr>
+              );
+            })}
+            {searchResults.length === 0 && (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 lg:px-6 py-4 text-center text-sm text-gray-500"
+                >
+                  No proposals found
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile Card View */}
+      <div className="block md:hidden space-y-4">
+        {currentPageProposals.map((proposal) => {
+          const plainDescription = stripMarkdown(proposal.description);
+          return (
+            <div
+              key={proposal.id}
+              className="bg-white border border-gray-200 rounded-lg p-4 hover:bg-gray-50 relative"
+            >
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-base font-medium text-gray-900">
+                    <Link
+                      {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
+                      className="hover:text-blue-600 transition-colors after:absolute after:inset-0"
+                    >
+                      {proposal.title}
+                    </Link>
+                  </h3>
+                  <p className="text-sm text-gray-500 mt-1">
+                    Host(s):{" "}
+                    {proposal.hosts.map((h) => h.name).join(", ") || "-"}
+                  </p>
+                </div>
+
+                {plainDescription ? (
+                  <p className="text-sm text-gray-600 line-clamp-3">
+                    {plainDescription}
+                  </p>
+                ) : (
+                  <p className="text-sm text-gray-500">-</p>
                 )}
 
-                <div className="flex gap-2 relative z-10">
-                  {canEdit(proposal.hosts) && (
-                    <div className="relative inline-block group">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          router.push(
-                            `/${eventSlug}/proposals/${proposal.id}/edit`
-                          );
-                        }}
-                        className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
-                      >
-                        <PencilIcon className="h-4 w-4 mr-1" />
-                        Edit
-                      </button>
-                    </div>
+                {proposal.durationMinutes ? (
+                  <div className="flex items-center">
+                    <ClockIcon className="h-4 w-4 mr-1 text-gray-400" />
+                    <span className="text-sm text-gray-500">
+                      {formatDuration(
+                        durationMinusBreak(
+                          proposal.durationMinutes,
+                          event.breakMinutes
+                        )
+                      )}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="text-sm text-gray-500">-</div>
+                )}
+
+                <div className="pt-2 border-t border-gray-100 space-y-3">
+                  {currentUserId &&
+                    !proposal.hosts.some((h) => h.id === currentUserId) &&
+                    !schedEnabled && (
+                      <div className="relative z-10">
+                        <VotingButtons
+                          proposalId={proposal.id}
+                          votingEnabled={votingEnabled}
+                          votingDisabledText={votingDisabledText}
+                        />
+                      </div>
+                    )}
+                  {schedEnabled && (
+                    <>
+                      {!canEdit(proposal.hosts) && (
+                        <div>
+                          Your vote:
+                          <span
+                            title={(() => {
+                              const vote = votes.find(
+                                (v) =>
+                                  v.proposalId === proposal.id &&
+                                  v.guestId === currentUserId
+                              );
+                              if (!vote) return "No vote";
+                              switch (vote.choice) {
+                                case VoteChoice.interested:
+                                  return "Interested";
+                                case VoteChoice.maybe:
+                                  return "Maybe";
+                                case VoteChoice.skip:
+                                  return "Skip";
+                                default:
+                                  return "No vote";
+                              }
+                            })()}
+                            className="ml-1"
+                          >
+                            {proposalVoteEmoji(proposal.id)}
+                          </span>
+                        </div>
+                      )}
+                      <div className="flex items-center gap-2">
+                        Total votes:
+                        <span
+                          title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
+                          className="flex items-center gap-1 text-sm text-gray-500"
+                        >
+                          ❤️&nbsp;{proposal.interestedVotesCount}
+                        </span>
+                        <span
+                          title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
+                          className="flex items-center gap-1 text-sm text-gray-500"
+                        >
+                          ⭐&nbsp;{proposal.maybeVotesCount}
+                        </span>
+                      </div>
+                    </>
                   )}
-                  {canEdit(proposal.hosts) && (
-                    <HoverTooltip
-                      text={schedDisabledText}
-                      visible={!schedEnabled}
-                    >
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          router.push(
-                            `/${eventSlug}/add-session?proposalID=${proposal.id}`
-                          );
-                        }}
-                        className={`inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
-                          schedEnabled ? "" : "opacity-50 cursor-not-allowed"
-                        }`}
-                        disabled={!schedEnabled}
+
+                  <div className="flex gap-2 relative z-10">
+                    {canEdit(proposal.hosts) && (
+                      <div className="relative inline-block group">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(
+                              `/${eventSlug}/proposals/${proposal.id}/edit`
+                            );
+                          }}
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+                        >
+                          <PencilIcon className="h-4 w-4 mr-1" />
+                          Edit
+                        </button>
+                      </div>
+                    )}
+                    {canEdit(proposal.hosts) && (
+                      <HoverTooltip
+                        text={schedDisabledText}
+                        visible={!schedEnabled}
                       >
-                        <CalendarIcon className="h-4 w-4 mr-1" />
-                        Schedule
-                      </button>
-                    </HoverTooltip>
-                  )}
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(
+                              `/${eventSlug}/add-session?proposalID=${proposal.id}`
+                            );
+                          }}
+                          className={`inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
+                            schedEnabled ? "" : "opacity-50 cursor-not-allowed"
+                          }`}
+                          disabled={!schedEnabled}
+                        >
+                          <CalendarIcon className="h-4 w-4 mr-1" />
+                          Schedule
+                        </button>
+                      </HoverTooltip>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
         {searchResults.length === 0 && (
           <div className="text-center py-8 text-sm text-gray-500">
             No proposals found

--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -20,6 +20,7 @@ import { getStartTimePlusBreak, TIME_FORMAT } from "@/utils/utils";
 import { isBookableSlot } from "@/utils/session-bookable";
 import { LockIcon } from "../lock-icon";
 import { viewSessionLinkFromOwner } from "./modal-nav";
+import { stripMarkdown } from "@/utils/markdown";
 
 export function SessionBlock(props: {
   session: Session;
@@ -148,6 +149,7 @@ function SessionInfoDisplay({
   timezone: string;
 }) {
   const breakMinutes = useBreakMinutes();
+  const plainDescription = stripMarkdown(session.description);
   return (
     <>
       <h1 className="text-lg font-bold leading-tight flex items-center gap-1">
@@ -160,9 +162,9 @@ function SessionInfoDisplay({
         Hosted by {formattedHostNames}
       </p>
       <p className="text-sm whitespace-pre-line">
-        {session.description?.length > 210
-          ? session.description.substring(0, 200) + "..."
-          : session.description}
+        {plainDescription.length > 210
+          ? plainDescription.substring(0, 200) + "..."
+          : plainDescription}
       </p>
       <div className="flex justify-between mt-2 gap-4 text-xs text-gray-500">
         <div className="flex gap-1">

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -32,6 +32,7 @@ import { UserContext } from "../context";
 import { sessionsOverlap, newEmptySession } from "../session_utils";
 import { buildSessionInterval } from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 interface ErrorResponse {
   message: string;
@@ -405,6 +406,7 @@ export function SessionForm(props: {
           className="rounded-md text-sm resize-none h-24 border bg-white px-4 shadow-sm transition-colors invalid:border-red-500 invalid:text-red-900 invalid:placeholder-red-300 focus:outline-none disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500 border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none"
           onChange={(e) => setDescription(e.target.value)}
         />
+        <MarkdownHint />
       </div>
 
       {/* Closed session checkbox */}

--- a/app/(site)/[eventSlug]/session-proposal-form.tsx
+++ b/app/(site)/[eventSlug]/session-proposal-form.tsx
@@ -16,6 +16,7 @@ import { SelectHosts } from "@/app/select-hosts";
 import { ConfirmDeletionModal } from "../modals";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 import { slotDurationOptions } from "@/utils/slots";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 export function SessionProposalForm(props: {
   eventID: string;
@@ -155,6 +156,7 @@ export function SessionProposalForm(props: {
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Describe what your session will cover"
           />
+          <MarkdownHint />
         </div>
 
         <div className="flex flex-col gap-1">

--- a/app/(site)/[eventSlug]/session-text.tsx
+++ b/app/(site)/[eventSlug]/session-text.tsx
@@ -9,6 +9,8 @@ import { UserContext, EventContext, useBreakMinutes } from "../context";
 import { CheckCircleIcon, AcademicCapIcon } from "@heroicons/react/24/solid";
 import { LockIcon } from "../lock-icon";
 import { viewSessionLinkFromOwner } from "./modal-nav";
+import { Markdown } from "@/app/(site)/markdown";
+import { stripMarkdown } from "@/utils/markdown";
 
 export function SessionText(props: {
   session: Session;
@@ -27,11 +29,8 @@ export function SessionText(props: {
   const isHost = currentUser && session.hosts.some((h) => h.id === currentUser);
 
   const description = session.description || "";
-  const isLongDescription = description.length > 200;
-  const displayDescription =
-    isLongDescription && !showFullDescription
-      ? description.substring(0, 200) + "..."
-      : description;
+  const plainDescription = stripMarkdown(description);
+  const isLongDescription = plainDescription.length > 200;
 
   const linkProps = viewSessionLinkFromOwner(
     searchParams,
@@ -114,17 +113,23 @@ export function SessionText(props: {
           ))}
         </div>
       </div>
-      <p className="text-sm whitespace-pre-line mt-2">
-        {displayDescription}
+      <div className="text-sm mt-2">
+        {isLongDescription && !showFullDescription ? (
+          <p className="whitespace-pre-line">
+            {plainDescription.substring(0, 200) + "..."}
+          </p>
+        ) : (
+          <Markdown>{description}</Markdown>
+        )}
         {isLongDescription && (
           <button
             onClick={() => setShowFullDescription(!showFullDescription)}
-            className="ml-2 text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
+            className="text-blue-600 hover:text-blue-800 font-medium cursor-pointer"
           >
             {showFullDescription ? "Show less" : "Show more"}
           </button>
         )}
-      </p>
+      </div>
     </div>
   );
 }

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -15,6 +15,7 @@ import { sessionsOverlap } from "../../session_utils";
 import { LockIcon } from "../../lock-icon";
 import { LocationTag } from "../session-text";
 import { viewProposalLinkFromElsewhere } from "../modal-nav";
+import { Markdown } from "@/app/(site)/markdown";
 
 export function ViewSession(props: {
   session: Session;
@@ -299,7 +300,7 @@ export function ViewSession(props: {
       </div>
       <div className="mb-6">
         <h3 className="font-semibold mb-2">Description</h3>
-        <p className="whitespace-pre-line">{session.description}</p>
+        <Markdown>{session.description}</Markdown>
       </div>
       {session.proposalId && (
         <p className="text-sm text-gray-600">

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -4,6 +4,7 @@ import { getRepositories } from "@/db/container";
 import { eventNameToSlug } from "@/utils/utils";
 import { sanitizeGuest } from "@/utils/guests";
 import { Avatar } from "../avatar";
+import { Markdown } from "@/app/(site)/markdown";
 import { JSX, PropsWithChildren } from "react";
 import {
   ProfileItem,
@@ -81,7 +82,9 @@ export default async function GuestProfilePage(props: {
       {guest.aboutMe && (
         <section>
           <h2 className="text-lg font-semibold mb-2">About me</h2>
-          <p className="whitespace-pre-line text-gray-800">{guest.aboutMe}</p>
+          <div className="text-gray-800">
+            <Markdown>{guest.aboutMe}</Markdown>
+          </div>
         </section>
       )}
 

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -28,6 +28,7 @@ import {
   ComboboxOptions,
 } from "@headlessui/react";
 import { ChevronUpDownIcon } from "@heroicons/react/16/solid";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 const profileFormSchema = profileSchema.extend({
   avatar: z.instanceof(FileList).nullable().optional(),
@@ -256,6 +257,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
               form.formState.errors.aboutMe ? "invalid" : ""
             )}
           />
+          <MarkdownHint />
           <span className="text-rose-400 text-sm">
             {form.formState.errors.aboutMe?.message}
           </span>

--- a/app/(site)/guests/guest-list.tsx
+++ b/app/(site)/guests/guest-list.tsx
@@ -4,6 +4,7 @@ import { Guest } from "@/db/repositories/interfaces";
 import { DataTable } from "@/app/admin/data-table";
 import Link from "next/link";
 import { Avatar } from "@/app/(site)/guests/avatar";
+import { stripMarkdown } from "@/utils/markdown";
 
 function GuestRow({
   guest: { id, avatarUrl, name, aboutMe },
@@ -18,7 +19,9 @@ function GuestRow({
       <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
       <div className="flex flex-col gap-1">
         <span className="font-medium text-gray-900">{name}</span>
-        <span className="text-sm text-gray-500 line-clamp-1">{aboutMe}</span>
+        <span className="text-sm text-gray-500 line-clamp-1">
+          {stripMarkdown(aboutMe)}
+        </span>
       </div>
     </Link>
   );

--- a/app/(site)/markdown.tsx
+++ b/app/(site)/markdown.tsx
@@ -1,0 +1,90 @@
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+
+// User-provided content: raw HTML is never parsed (react-markdown default)
+// and unsafe URL schemes like javascript: are stripped by the default URL
+// transform. Images stay disabled so viewers' IPs never hit arbitrary URLs.
+const DISALLOWED = [
+  "img",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "input",
+];
+
+// Headings render as bold paragraphs sized relative to the surrounding text
+// (em units), so user content can never out-shout the page's own headings,
+// and repeated h1s in descriptions don't pollute the document outline.
+const heading = (weight: string, size: string) =>
+  function Heading({ children }: { children?: React.ReactNode }) {
+    return (
+      <p className={`${weight} ${size} mt-3 mb-1 first:mt-0`}>{children}</p>
+    );
+  };
+
+const components: Components = {
+  h1: heading("font-bold", "text-[1.1em]"),
+  h2: heading("font-bold", "text-[1.05em]"),
+  h3: heading("font-semibold", "text-[1em]"),
+  h4: heading("font-semibold", "text-[1em]"),
+  h5: heading("font-semibold", "text-[1em]"),
+  h6: heading("font-semibold", "text-[1em]"),
+  p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0">{children}</p>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      className="text-rose-500 underline hover:text-rose-600"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc pl-5 my-2 first:mt-0 last:mb-0">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal pl-5 my-2 first:mt-0 last:mb-0">{children}</ol>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-4 border-gray-300 pl-3 text-gray-600 my-2">
+      {children}
+    </blockquote>
+  ),
+  code: ({ children }) => (
+    <code className="bg-gray-100 rounded px-1 font-mono text-[0.9em]">
+      {children}
+    </code>
+  ),
+  pre: ({ children }) => (
+    <pre className="bg-gray-100 rounded p-2 my-2 overflow-x-auto">
+      {children}
+    </pre>
+  ),
+  hr: () => <hr className="my-3 border-gray-200" />,
+};
+
+export function MarkdownHint() {
+  return <p className="text-xs text-gray-500">Markdown supported</p>;
+}
+
+export function Markdown({
+  children,
+}: {
+  children: string | null | undefined;
+}) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      disallowedElements={DISALLOWED}
+      unwrapDisallowed
+      components={components}
+    >
+      {children ?? ""}
+    </ReactMarkdown>
+  );
+}

--- a/app/(site)/summary-page.tsx
+++ b/app/(site)/summary-page.tsx
@@ -7,6 +7,7 @@ import {
 import { DateTime } from "luxon";
 import Link from "next/link";
 import type { Event } from "@/db/repositories/interfaces";
+import { Markdown } from "@/app/(site)/markdown";
 
 export default function SummaryPage(props: {
   events: Event[];
@@ -21,7 +22,9 @@ export default function SummaryPage(props: {
     <Suspense fallback={<div>Loading...</div>}>
       <div className="mx-auto max-w-2xl">
         <h1 className="text-4xl font-bold mt-5">{title}</h1>
-        <p className="mt-3">{description}</p>
+        <div className="mt-3">
+          <Markdown>{description}</Markdown>
+        </div>
         <div className="flex flex-col gap-8 sm:pl-5 mt-10">
           {sortedEvents.map((event) => (
             <div key={event.name}>
@@ -47,7 +50,9 @@ export default function SummaryPage(props: {
                   <span>{event.website}</span>
                 </a>
               </div>
-              <p className="text-gray-900 mt-2">{event.description}</p>
+              <div className="text-gray-900 mt-2">
+                <Markdown>{event.description}</Markdown>
+              </div>
               <Link
                 href={`/${event.slug}`}
                 className="font-semibold text-rose-400 hover:text-rose-500 flex gap-1 items-center text-sm justify-end mt-2"

--- a/app/admin/events/[id]/event-detail-form.tsx
+++ b/app/admin/events/[id]/event-detail-form.tsx
@@ -18,6 +18,7 @@ import { TimezoneSelect } from "@/app/admin/timezone-select";
 import { IconPicker } from "@/app/admin/icon-picker";
 import { normalizeEventIconName } from "@/app/event-icons";
 import { SLOT_INCREMENT_OPTIONS } from "@/utils/slots";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 function toDateInputValue(date: Date): string {
   return date.toISOString().split("T")[0];
@@ -95,12 +96,14 @@ export function EventDetailForm({ event }: { event: Event }) {
           <label htmlFor="ev-description" className="text-sm text-gray-600">
             Description
           </label>
-          <Input
+          <textarea
             id="ev-description"
             value={form.description}
             onChange={(e) => set("description", e.target.value)}
-            className="w-full h-10"
+            rows={3}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y focus:outline-none focus:ring-2 focus:ring-gray-400"
           />
+          <MarkdownHint />
         </div>
         <div className="flex flex-col gap-1">
           <label htmlFor="ev-website" className="text-sm text-gray-600">

--- a/app/admin/events/[id]/event-proposals-manager.tsx
+++ b/app/admin/events/[id]/event-proposals-manager.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/app/admin/buttons";
 import { DataTable } from "../../data-table";
 import { SelectHosts } from "@/app/select-hosts";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 export type ProposalRow = {
   id: string;
@@ -237,6 +238,7 @@ function ProposalItem({
           onChange={(e) => setDescription(e.target.value)}
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
         />
+        <MarkdownHint />
       </div>
       <div className="flex flex-col gap-1">
         <label

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -17,6 +17,7 @@ import {
 import { DataTable } from "../../data-table";
 import { SelectHosts } from "@/app/select-hosts";
 import { utcToZonedInput, zonedInputToUtc } from "@/utils/admin-datetime";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 export type SessionRow = {
   id: string;
@@ -265,6 +266,7 @@ function SessionForm({
           onChange={(e) => setDescription(e.target.value)}
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
         />
+        <MarkdownHint />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1">

--- a/app/admin/events/events-manager.tsx
+++ b/app/admin/events/events-manager.tsx
@@ -7,6 +7,7 @@ import type { Event } from "@/db/repositories/interfaces";
 import { createEventAction, type EventInput } from "@/app/actions/admin-events";
 import { PRIMARY_BUTTON, SECONDARY_BUTTON } from "@/app/admin/buttons";
 import { TimezoneSelect } from "@/app/admin/timezone-select";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 // Event start/end are date-only values stored as UTC midnight; format them in
 // UTC so browsers west of Greenwich don't show the previous day.
@@ -82,12 +83,14 @@ function AddEventForm({
         <label htmlFor="ev-description" className="text-sm text-gray-600">
           Description
         </label>
-        <Input
+        <textarea
           id="ev-description"
           value={form.description}
           onChange={(e) => set("description", e.target.value)}
-          className="w-full h-10"
+          rows={3}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y focus:outline-none focus:ring-2 focus:ring-gray-400"
         />
+        <MarkdownHint />
       </div>
       <div className="flex flex-col gap-1">
         <label htmlFor="ev-website" className="text-sm text-gray-600">

--- a/app/admin/settings-manager.tsx
+++ b/app/admin/settings-manager.tsx
@@ -7,6 +7,7 @@ import type { SiteSettings } from "@/db/repositories/interfaces";
 import { MAP_REQUIREMENTS_HINT } from "@/utils/map-image-constraints";
 import { updateSettingsAction } from "../actions/admin-settings";
 import { PRIMARY_BUTTON } from "./buttons";
+import { MarkdownHint } from "@/app/(site)/markdown";
 
 export function SettingsManager({ settings }: { settings: SiteSettings }) {
   const [error, setError] = useState<string | null>(null);
@@ -65,6 +66,7 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
           rows={3}
           className="rounded-md border border-gray-300 bg-white px-4 py-2 shadow-sm focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none"
         />
+        <MarkdownHint />
       </div>
 
       <div className="flex flex-col gap-1">

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "manifest-schedule",
@@ -27,8 +26,13 @@
         "react": "^19",
         "react-dom": "^19",
         "react-hook-form": "^7.80.0",
+        "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
         "sharp": "^0.35.3",
         "turndown": "^7.2.4",
+        "unified": "^11.0.5",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -38,6 +42,7 @@
         "@types/js-cookie": "^3.0.6",
         "@types/lodash": "^4.17.24",
         "@types/luxon": "^3.7.2",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^26",
         "@types/nodemailer": "^8.0.1",
         "@types/react": "^19",
@@ -421,9 +426,15 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "@types/js-cookie": ["@types/js-cookie@3.0.6", "", {}, "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="],
 
@@ -435,6 +446,10 @@
 
     "@types/luxon": ["@types/luxon@3.7.2", "", {}, "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q=="],
 
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
     "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
@@ -444,6 +459,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/type-utils": "8.62.1", "@typescript-eslint/utils": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA=="],
 
@@ -464,6 +481,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.62.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/types": "8.62.1", "@typescript-eslint/typescript-estree": "8.62.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.1", "", { "dependencies": { "@typescript-eslint/types": "8.62.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
 
@@ -565,6 +584,8 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
@@ -597,9 +618,19 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
@@ -610,6 +641,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -631,6 +664,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
@@ -643,7 +678,11 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -727,6 +766,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
@@ -734,6 +775,8 @@
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -813,6 +856,10 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
@@ -820,6 +867,8 @@
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
@@ -835,7 +884,13 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -855,6 +910,8 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
@@ -863,6 +920,8 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
@@ -870,6 +929,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -961,6 +1022,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -973,9 +1036,99 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -1045,6 +1198,8 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -1077,6 +1232,8 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -1095,6 +1252,8 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-stately": ["react-stately@3.46.0", "", { "dependencies": { "@internationalized/date": "^3.12.1", "@internationalized/number": "^3.6.6", "@internationalized/string": "^3.2.8", "@react-types/shared": "^3.34.0", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -1102,6 +1261,16 @@
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
@@ -1163,6 +1332,8 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -1185,9 +1356,15 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
@@ -1216,6 +1393,10 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
@@ -1247,6 +1428,18 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1256,6 +1449,10 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
@@ -1284,6 +1481,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1353,6 +1552,8 @@
 
     "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
@@ -1362,6 +1563,8 @@
     "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,13 @@
     "react": "^19",
     "react-dom": "^19",
     "react-hook-form": "^7.80.0",
+    "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "sharp": "^0.35.3",
     "turndown": "^7.2.4",
+    "unified": "^11.0.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -37,6 +42,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.24",
     "@types/luxon": "^3.7.2",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^26",
     "@types/nodemailer": "^8.0.1",
     "@types/react": "^19",

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -123,6 +123,46 @@ test.describe("Edit profile", () => {
     ).toBeVisible();
   });
 
+  test("renders markdown in About me, safely", async ({ page }) => {
+    await login(page);
+    await page.goto("/Conference-Alpha/proposals");
+
+    await selectCurrentUser(page);
+    await page.getByRole("link", { name: /Participants/i }).click();
+    await page.getByRole("link", { name: /Edit profile/i }).click();
+
+    await page
+      .getByLabel("About me")
+      .fill(
+        "# Big header\n\n**Bold statement** and [my site](https://example.com)\n\n<script>alert(1)</script>"
+      );
+    await page.getByRole("button", { name: /^Save$/ }).click();
+    await expect(page).toHaveURL(/\/guests\/[^/]+$/);
+
+    // Markdown renders: bold text and a real link.
+    await expect(
+      page.locator("strong", { hasText: "Bold statement" })
+    ).toBeVisible();
+    const link = page.getByRole("link", { name: "my site" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "https://example.com");
+
+    // Headings are capped: text shows but not as a heading element.
+    await expect(page.getByText("Big header")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Big header" })).toHaveCount(
+      0
+    );
+
+    // Raw HTML is escaped and displayed as literal text, not executed.
+    await expect(page.getByText("<script>alert(1)</script>")).toBeVisible();
+
+    // The attendees list preview shows plain text, not raw markdown syntax.
+    await page.getByRole("link", { name: /Participants/i }).click();
+    await expect(page).toHaveURL(/\/guests$/);
+    await expect(page.getByText("Big header Bold statement")).toBeVisible();
+    await expect(page.getByText("**Bold statement**")).toHaveCount(0);
+  });
+
   test("shows no image when the user avatar is reset", async ({ page }) => {
     await login(page);
     await page.goto("/Conference-Alpha/proposals");

--- a/tests/unit/markdown.test.tsx
+++ b/tests/unit/markdown.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Markdown } from "@/app/(site)/markdown";
+import { stripMarkdown } from "@/utils/markdown";
+
+function render(markdown: string): string {
+  return renderToStaticMarkup(<Markdown>{markdown}</Markdown>);
+}
+
+describe("Markdown component", () => {
+  it("renders emphasis, strong and inline code", () => {
+    const html = render("Some *italic*, **bold** and `code`.");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toMatch(/<code[^>]*>code<\/code>/);
+  });
+
+  it("renders lists", () => {
+    const html = render("- one\n- two");
+    expect(html).toMatch(/<ul[^>]*>/);
+    expect(html).toMatch(/<li[^>]*>one<\/li>/);
+  });
+
+  it("preserves single newlines as line breaks (legacy plain text)", () => {
+    const html = render("first line\nsecond line");
+    expect(html).toContain("<br/>");
+  });
+
+  it("escapes raw HTML instead of rendering it", () => {
+    const html = render('<script>alert("x")</script>');
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("does not render event-handler attributes from raw HTML", () => {
+    const html = render('<img src="x" onerror="alert(1)">');
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img"); // escaped, shown as literal text
+  });
+
+  it("drops javascript: URLs", () => {
+    const html = render("[click](javascript:alert(1))");
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("opens links in a new tab with safe rel", () => {
+    const html = render("[site](https://example.com)");
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toMatch(/rel="[^"]*noopener[^"]*"/);
+    expect(html).toMatch(/rel="[^"]*nofollow[^"]*"/);
+  });
+
+  it("autolinks bare URLs", () => {
+    const html = render("see https://example.com/page");
+    expect(html).toContain('href="https://example.com/page"');
+  });
+
+  it("does not render markdown images", () => {
+    const html = render("![tracking pixel](https://evil.example/p.gif)");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("evil.example");
+  });
+
+  it("never renders native heading elements, but keeps heading text", () => {
+    const html = render("# Huge title\n\nbody");
+    expect(html).not.toMatch(/<h[1-6]/);
+    expect(html).toContain("Huge title");
+  });
+
+  it("does not render tables but keeps their text", () => {
+    const html = render("| a | b |\n| - | - |\n| c | d |");
+    expect(html).not.toContain("<table");
+  });
+});
+
+describe("stripMarkdown", () => {
+  it("strips formatting down to plain text", () => {
+    expect(stripMarkdown("Some **bold** and [a link](https://x.com).")).toBe(
+      "Some bold and a link."
+    );
+  });
+
+  it("strips headings and separates blocks with newlines", () => {
+    expect(stripMarkdown("# Title\n\nBody text")).toBe("Title\nBody text");
+  });
+
+  it("keeps literal special characters unescaped", () => {
+    expect(stripMarkdown("2 * 3 = 6 and snake_case")).toBe(
+      "2 * 3 = 6 and snake_case"
+    );
+  });
+
+  it("keeps inline code content", () => {
+    expect(stripMarkdown("run `make test` now")).toBe("run make test now");
+  });
+
+  it("drops images but keeps alt text", () => {
+    expect(stripMarkdown("![alt text](https://x.com/i.png)")).toBe("alt text");
+  });
+
+  it("flattens list items onto separate lines", () => {
+    expect(stripMarkdown("- one\n- two")).toBe("one\ntwo");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripMarkdown("")).toBe("");
+  });
+
+  it("returns empty string for null or undefined input", () => {
+    expect(stripMarkdown(null)).toBe("");
+    expect(stripMarkdown(undefined)).toBe("");
+  });
+
+  it("drops raw HTML tags instead of showing their literal text", () => {
+    expect(stripMarkdown("Some <div>text</div> here")).toBe("Some text here");
+  });
+});

--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -1,0 +1,49 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import type { Nodes, Parent } from "mdast";
+
+// unified + remark-parse (not the remark package): react-markdown already
+// pulls both in for its own parsing, so this reuses that pipeline instead of
+// adding a separate one.
+const parser = unified().use(remarkParse).use(remarkGfm);
+
+// Own mdast walker instead of strip-markdown + remark-stringify: stringify
+// backslash-escapes literal markdown characters ("2 * 3" → "2 \* 3"), which
+// is unacceptable in plain-text previews.
+function nodeToText(node: Nodes): string {
+  switch (node.type) {
+    case "text":
+    case "inlineCode":
+    case "code":
+      return node.value;
+    case "break":
+      return "\n";
+    case "image":
+      return node.alt ?? "";
+    case "list":
+    case "blockquote":
+      return childrenToText(node, "\n");
+    // Raw HTML tags in user content aren't meaningful plain text.
+    case "html":
+      return "";
+    default:
+      return "children" in node ? childrenToText(node, "") : "";
+  }
+}
+
+function childrenToText(node: Parent, separator: string): string {
+  return node.children
+    .map(nodeToText)
+    .filter((t) => t !== "")
+    .join(separator);
+}
+
+/**
+ * Reduce markdown to plain text for truncated previews (board cards, table
+ * cells, title attributes). Block-level nodes become separate lines.
+ */
+export function stripMarkdown(markdown: string | null | undefined): string {
+  const tree = parser.parse(markdown ?? "");
+  return childrenToText(tree, "\n").trim();
+}


### PR DESCRIPTION
Render aboutMe, session, proposal, event and site descriptions as
markdown via a shared component (react-markdown). Raw HTML is never
parsed, javascript: URLs and images are dropped, and headings render
capped at roughly body-text size so user content can't out-shout the
page. Truncated previews (board cards, proposal table) strip markdown
to plain text instead of rendering it. remark-breaks keeps existing
plain-text descriptions rendering unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=d3430fd2700c51d24b3370df78e0970fef726b54 -->