### PR TITLE
fix: remove nested <li> in guest list rows

### DIFF
--- a/app/(site)/guests/guest-list.tsx
+++ b/app/(site)/guests/guest-list.tsx
@@ -11,18 +11,16 @@ function GuestRow({
   guest: Guest;
 }) {
   return (
-    <li key={id}>
-      <Link
-        href={`/guests/${id}`}
-        className="flex items-center gap-4 py-3 hover:bg-gray-50 rounded-md px-2"
-      >
-        <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
-        <div className="flex flex-col gap-1">
-          <span className="font-medium text-gray-900">{name}</span>
-          <span className="text-sm text-gray-500 line-clamp-1">{aboutMe}</span>
-        </div>
-      </Link>
-    </li>
+    <Link
+      href={`/guests/${id}`}
+      className="flex items-center gap-4 hover:bg-gray-50 rounded-md px-2"
+    >
+      <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
+      <div className="flex flex-col gap-1">
+        <span className="font-medium text-gray-900">{name}</span>
+        <span className="text-sm text-gray-500 line-clamp-1">{aboutMe}</span>
+      </div>
+    </Link>
   );
 }
 


### PR DESCRIPTION
DataTable already wraps listItem rows in <li>; GuestRow's own <li>
caused invalid <li>-in-<li> nesting and a hydration error.

<!-- jip:pushed-commit=de007a2d0881ee341f7b43974d46d7f60a4b94ee -->