### PR TITLE
fix(api): reject duplicate event slug with 409 instead of create-if-absent

### DIFF
--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -130,30 +130,46 @@ export async function POST(req: Request) {
   }
 
   const { events } = getRepositories();
-  // Best-effort: a concurrent request between this check and the create()
-  // below can still race and fail on the slug's unique constraint.
   const existing = await events.findBySlug(slug);
   if (existing) {
-    return NextResponse.json({
-      id: existing.id,
-      slug: existing.slug,
-      created: false,
-    });
+    return NextResponse.json(
+      {
+        error: `An event with the URL "${slug}" already exists ("${existing.name}")`,
+      },
+      { status: 409 }
+    );
   }
 
-  const event = await events.create({
-    name,
-    description: (body.description ?? "").trim(),
-    website: (body.website ?? "").trim(),
-    start,
-    end,
-    timezone,
-    maxSessionDuration,
-    breakMinutes,
-    slotIncrementMinutes,
-    schedulingPhaseStart,
-    schedulingPhaseEnd,
-  });
+  let event;
+  try {
+    event = await events.create({
+      name,
+      description: (body.description ?? "").trim(),
+      website: (body.website ?? "").trim(),
+      start,
+      end,
+      timezone,
+      maxSessionDuration,
+      breakMinutes,
+      slotIncrementMinutes,
+      schedulingPhaseStart,
+      schedulingPhaseEnd,
+    });
+  } catch (e) {
+    // A concurrent create can win the race between the findBySlug check
+    // above and this insert; translate the constraint violation into the
+    // same conflict response instead of surfacing a 500.
+    if (
+      e instanceof Error &&
+      e.message.includes("UNIQUE constraint failed: events.slug")
+    ) {
+      return NextResponse.json(
+        { error: `An event with the URL "${slug}" already exists` },
+        { status: 409 }
+      );
+    }
+    throw e;
+  }
 
-  return NextResponse.json({ id: event.id, slug: event.slug, created: true });
+  return NextResponse.json({ id: event.id, slug: event.slug });
 }

--- a/tests/integration/admin-create-event-route.test.ts
+++ b/tests/integration/admin-create-event-route.test.ts
@@ -36,8 +36,8 @@ function makeReq(body: unknown): Request {
 
 async function readJson(
   res: Response
-): Promise<{ id: string; slug: string; created: boolean }> {
-  return (await res.json()) as { id: string; slug: string; created: boolean };
+): Promise<{ id: string; slug: string } | { error: string }> {
+  return (await res.json()) as { id: string; slug: string } | { error: string };
 }
 
 async function loginAsAdmin() {
@@ -74,8 +74,7 @@ describe("POST /api/admin/create-event", () => {
   it("creates an event with defaults and returns id and slug", async () => {
     const res = await POST(makeReq(VALID_BODY));
     expect(res.status).toBe(200);
-    const body = await readJson(res);
-    expect(body.created).toBe(true);
+    const body = (await readJson(res)) as { id: string; slug: string };
     expect(body.slug).toBe("Summer-Camp");
 
     const event = await getRepositories().events.findBySlug("Summer-Camp");
@@ -105,7 +104,7 @@ describe("POST /api/admin/create-event", () => {
       })
     );
     expect(res.status).toBe(200);
-    const { id } = await readJson(res);
+    const { id } = (await readJson(res)) as { id: string; slug: string };
 
     const event = await getRepositories().events.findById(id);
     expect(event?.timezone).toBe("Europe/Berlin");
@@ -118,16 +117,18 @@ describe("POST /api/admin/create-event", () => {
     expect(event?.schedulingPhaseEnd).toEqual(new Date("2026-09-03T00:00:00Z"));
   });
 
-  it("returns the existing event with created=false when the slug already exists", async () => {
-    const first = await readJson(await POST(makeReq(VALID_BODY)));
+  it("rejects with 409 when the slug already exists", async () => {
+    const first = (await readJson(await POST(makeReq(VALID_BODY)))) as {
+      id: string;
+      slug: string;
+    };
     const res = await POST(
       makeReq({ ...VALID_BODY, name: "Summer Camp", breakMinutes: 42 })
     );
-    expect(res.status).toBe(200);
-    const body = await readJson(res);
-    expect(body.created).toBe(false);
-    expect(body.id).toBe(first.id);
-    // Create-if-absent: the existing event is not updated.
+    expect(res.status).toBe(409);
+    const body = (await readJson(res)) as { error: string };
+    expect(body.error).toMatch(/already exists/);
+    // The existing event is not updated.
     const event = await getRepositories().events.findById(first.id);
     expect(event?.breakMinutes).toBe(10);
   });


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [2f37839](https://github.com/LWCW-Europe/schellingboard/pull/601/commits/2f37839b610ca0109a99196cad85e885e89ed3ad).

PRs:
* #598
* ➡️ #601 (this PR, base of the stack — can be merged first)

---

## Description

The create-event API silently returned the existing event on a slug
clash (created:false, 200), diverging from the admin UI's server
action which treats it as an error. Align the two: return 409 with an
error message, and handle the insert-race case the same way.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=2f37839b610ca0109a99196cad85e885e89ed3ad -->