### PR TITLE
fix(rsvp): surface the 'session full' error instead of failing silently

### DIFF
--- a/app/(site)/[eventSlug]/session-block.tsx
+++ b/app/(site)/[eventSlug]/session-block.tsx
@@ -8,7 +8,7 @@ import { DateTime } from "luxon";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useContext, useState } from "react";
-import { CurrentUserModal, ConfirmationModal } from "../modals";
+import { CurrentUserModal, ConfirmationModal, AlertModal } from "../modals";
 import {
   UserContext,
   EventContext,
@@ -208,6 +208,7 @@ export function RealSessionCard(props: {
   const [userModalOpen, setUserModalOpen] = useState(false);
   const [clashingSession, setClashingSession] = useState<Session | null>(null);
   const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
+  const [rsvpError, setRsvpError] = useState<string | null>(null);
 
   const hostStatus =
     currentUser && session.hosts.some((h) => h.id === currentUser);
@@ -255,6 +256,7 @@ export function RealSessionCard(props: {
     if (!currentUser || isRsvping) return;
 
     setIsRsvping(true);
+    setRsvpError(null);
 
     const currentRsvpStatus = rsvpd;
 
@@ -264,8 +266,10 @@ export function RealSessionCard(props: {
         session.id,
         currentRsvpStatus
       );
-      if (!result) {
-        console.error("Failed to update RSVP");
+      if (!result.ok) {
+        setRsvpError(
+          result.error ?? "Failed to update RSVP. Please try again."
+        );
       }
     } finally {
       setIsRsvping(false);
@@ -379,6 +383,13 @@ export function RealSessionCard(props: {
             : "This session conflicts with another session you're attending. Do you want to RSVP anyway?"
         }
         confirm={handleConfirmRSVP}
+        portal={true}
+      />
+
+      <AlertModal
+        open={rsvpError !== null}
+        close={() => setRsvpError(null)}
+        message={rsvpError ?? ""}
         portal={true}
       />
     </Tooltip>

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -66,6 +66,7 @@ export function ViewSession(props: {
   const [userModalOpen, setUserModalOpen] = useState(false);
   const [clashingSession, setClashingSession] = useState<Session | null>(null);
   const [confirmRSVPModalOpen, setConfirmRSVPModalOpen] = useState(false);
+  const [rsvpError, setRsvpError] = useState<string | null>(null);
 
   const rsvpd = currentUser ? rsvpdForSession(session.id) : false;
   const isHost = currentUser && session.hosts.some((h) => h.id === currentUser);
@@ -114,13 +115,16 @@ export function ViewSession(props: {
     }
 
     setIsRsvping(true);
+    setRsvpError(null);
 
     const currentRsvpStatus = rsvpdForSession(session.id);
 
     void updateRsvp(currentUser, session.id, currentRsvpStatus)
       .then((result) => {
-        if (!result) {
-          console.error("Failed to update RSVP");
+        if (!result.ok) {
+          setRsvpError(
+            result.error ?? "Failed to update RSVP. Please try again."
+          );
         }
       })
       .finally(() => {
@@ -221,32 +225,39 @@ export function ViewSession(props: {
           </p>
         </div>
       )}
-      <div className="mt-2 mb-6 flex gap-2 flex-wrap">
-        {!isHost && (
-          <button
-            onClick={handleRsvp}
-            disabled={isRsvping || (!rsvpd && sessionFull)}
-            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors disabled:opacity-50"
-          >
-            {isRsvping
-              ? "..."
-              : rsvpd
-                ? "Un-RSVP"
-                : sessionFull
-                  ? "Session full"
-                  : "RSVP"}
-          </button>
-        )}
+      <div className="mt-2 mb-6">
+        <div className="flex gap-2 flex-wrap">
+          {!isHost && (
+            <button
+              onClick={handleRsvp}
+              disabled={isRsvping || (!rsvpd && sessionFull)}
+              className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors disabled:opacity-50"
+            >
+              {isRsvping
+                ? "..."
+                : rsvpd
+                  ? "Un-RSVP"
+                  : sessionFull
+                    ? "Session full"
+                    : "RSVP"}
+            </button>
+          )}
 
-        {isEditable && (
-          <Link
-            href={`/${eventSlug}/edit-session?sessionID=${session.id}`}
-            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
-            onClick={handleEditClick}
-          >
-            <PencilIcon className="h-3 w-3 mr-1" />
-            Edit
-          </Link>
+          {isEditable && (
+            <Link
+              href={`/${eventSlug}/edit-session?sessionID=${session.id}`}
+              className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+              onClick={handleEditClick}
+            >
+              <PencilIcon className="h-3 w-3 mr-1" />
+              Edit
+            </Link>
+          )}
+        </div>
+        {rsvpError && (
+          <p role="alert" className="mt-2 text-xs text-red-600">
+            {rsvpError}
+          </p>
         )}
       </div>
       <div className="space-y-2 mb-6 text-sm text-gray-700">

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -51,7 +51,7 @@ export interface EventContextType {
     guestId: string,
     sessionId: string,
     remove: boolean
-  ) => Promise<boolean>;
+  ) => Promise<{ ok: true } | { ok: false; error?: string }>;
 }
 
 export const EventContext = createContext<EventContextType>({
@@ -67,7 +67,7 @@ export const EventContext = createContext<EventContextType>({
   rsvpdForSession: () => false,
   updateRsvp: async () => {
     await Promise.resolve();
-    return false;
+    return { ok: false };
   },
 });
 
@@ -285,14 +285,18 @@ export function EventProvider({
         // Revert optimistic update on failure
         setRsvps(rsvpsBeforeUpdate);
         setRsvpCountDeltas(rsvpCountDeltasBeforeUpdate);
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        return { ok: false, error: body?.error };
       }
-      return response.ok;
+      return { ok: true };
     } catch (error: unknown) {
       // Revert optimistic update on error
       console.error("Error updating RSVP:", error);
       setRsvps(rsvpsBeforeUpdate);
       setRsvpCountDeltas(rsvpCountDeltasBeforeUpdate);
-      return false;
+      return { ok: false };
     }
   };
 

--- a/app/(site)/modals.tsx
+++ b/app/(site)/modals.tsx
@@ -192,6 +192,36 @@ export function ConfirmationModal(props: {
   );
 }
 
+export function AlertModal(props: {
+  open: boolean;
+  close: () => void;
+  message: string;
+  zIndex?: string;
+  portal?: boolean; // For nested modal contexts
+}) {
+  const { open, close, message, zIndex, portal } = props;
+  return (
+    <Modal
+      open={open}
+      setOpen={close}
+      hideClose={true}
+      zIndex={zIndex}
+      portal={portal}
+    >
+      <p role="alert">{message}</p>
+      <div className="mt-4">
+        <button
+          type="button"
+          className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-rose-400 font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400"
+          onClick={close}
+        >
+          OK
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
 export function Modal(props: {
   open: boolean;
   setOpen: (value: boolean) => void;

--- a/tests/integration/rsvp.test.ts
+++ b/tests/integration/rsvp.test.ts
@@ -128,6 +128,9 @@ describe("POST /api/toggle-rsvp", () => {
         makeToggleReq({ sessionId: session.id, guestId: bob.id })
       );
       expect(second.status).toBe(409);
+      // The client surfaces this message directly to the user, so its
+      // wording is part of the API contract, not just an implementation detail.
+      expect(await second.json()).toEqual({ error: "This session is full" });
       expect(await rsvpsForGuest(bob.id)).toHaveLength(0);
 
       // Removal must still work on a full session.


### PR DESCRIPTION
updateRsvp now returns {ok, error} so a rejected RSVP (e.g. a session that
filled up after the page loaded) shows a message instead of just reverting
the optimistic UI with a console.error. Both RSVP entry points (the session
dialog and the schedule-grid tile, the latter via a new AlertModal) surface
the error consistently.

<!-- jip:pushed-commit=3e7944df72b0a867c35a7482f165e9879880900d -->