### PR TITLE
fix(api): return 201 on admin create-* route success

### DIFF
--- a/app/api/admin/create-day/route.ts
+++ b/app/api/admin/create-day/route.ts
@@ -122,5 +122,5 @@ export async function POST(req: Request) {
     );
   }
 
-  return NextResponse.json({ id: day.id });
+  return NextResponse.json({ id: day.id }, { status: 201 });
 }

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -178,5 +178,5 @@ export async function POST(req: Request) {
     throw e;
   }
 
-  return NextResponse.json({ id: event.id, slug: event.slug });
+  return NextResponse.json({ id: event.id, slug: event.slug }, { status: 201 });
 }

--- a/app/api/admin/create-guest/route.ts
+++ b/app/api/admin/create-guest/route.ts
@@ -70,5 +70,8 @@ export async function POST(req: Request) {
     await guests.assignToEvent(eventId, [guest.id]);
   }
 
-  return NextResponse.json({ id: guest.id, created });
+  return NextResponse.json(
+    { id: guest.id, created },
+    { status: created ? 201 : 200 }
+  );
 }

--- a/app/api/admin/create-location/route.ts
+++ b/app/api/admin/create-location/route.ts
@@ -99,5 +99,5 @@ export async function POST(req: Request) {
     await locations.assignToEvent(eventId, [location.id]);
   }
 
-  return NextResponse.json({ id: location.id });
+  return NextResponse.json({ id: location.id }, { status: 201 });
 }

--- a/app/api/admin/create-proposal/route.ts
+++ b/app/api/admin/create-proposal/route.ts
@@ -95,5 +95,5 @@ export async function POST(req: Request) {
     durationMinutes: duration ?? undefined,
   });
 
-  return NextResponse.json({ id: proposal.id });
+  return NextResponse.json({ id: proposal.id }, { status: 201 });
 }

--- a/app/api/admin/create-session/route.ts
+++ b/app/api/admin/create-session/route.ts
@@ -159,5 +159,5 @@ export async function POST(req: Request) {
     await repos.locations.assignToEvent(event.id, locationIds);
   }
 
-  return NextResponse.json({ id: session.id });
+  return NextResponse.json({ id: session.id }, { status: 201 });
 }

--- a/tests/integration/admin-create-day-route.test.ts
+++ b/tests/integration/admin-create-day-route.test.ts
@@ -80,7 +80,7 @@ describe("POST /api/admin/create-day", () => {
 
   it("creates a day and returns its id", async () => {
     const res = await POST(makeReq(validBody(event)));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await readJson(res);
 
     const days = await getRepositories().days.listByEvent(event.id);
@@ -103,7 +103,7 @@ describe("POST /api/admin/create-day", () => {
         endBookings: "2026-09-02T17:00:00Z",
       })
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(await getRepositories().days.listByEvent(event.id)).toHaveLength(2);
   });
 

--- a/tests/integration/admin-create-event-route.test.ts
+++ b/tests/integration/admin-create-event-route.test.ts
@@ -73,7 +73,7 @@ describe("POST /api/admin/create-event", () => {
 
   it("creates an event with defaults and returns id and slug", async () => {
     const res = await POST(makeReq(VALID_BODY));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = (await readJson(res)) as { id: string; slug: string };
     expect(body.slug).toBe("Summer-Camp");
 
@@ -103,7 +103,7 @@ describe("POST /api/admin/create-event", () => {
         schedulingPhaseEnd: "2026-09-03T00:00:00Z",
       })
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const { id } = (await readJson(res)) as { id: string; slug: string };
 
     const event = await getRepositories().events.findById(id);

--- a/tests/integration/admin-create-guest-route.test.ts
+++ b/tests/integration/admin-create-guest-route.test.ts
@@ -72,7 +72,7 @@ describe("POST /api/admin/create-guest", () => {
     const res = await POST(
       makeReq({ name: "Tom Tailor", email: "tom.tailor@foocorp.com" })
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await readJson(res);
     expect(body.created).toBe(true);
     expect(body.id).toBeTruthy();
@@ -91,6 +91,7 @@ describe("POST /api/admin/create-guest", () => {
     const res = await POST(
       makeReq({ name: "Tom Different", email: "tom@foocorp.com" })
     );
+    expect(res.status).toBe(200);
     const body = await readJson(res);
     expect(body.created).toBe(false);
     expect(body.id).toBe(first.id);

--- a/tests/integration/admin-create-location-route.test.ts
+++ b/tests/integration/admin-create-location-route.test.ts
@@ -67,7 +67,7 @@ describe("POST /api/admin/create-location", () => {
 
   it("creates a location with defaults and returns its id", async () => {
     const res = await POST(makeReq({ name: "Main Hall" }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await readJson(res);
 
     const location = await getRepositories().locations.findById(body.id);

--- a/tests/integration/admin-create-proposal-route.test.ts
+++ b/tests/integration/admin-create-proposal-route.test.ts
@@ -74,7 +74,7 @@ describe("POST /api/admin/create-proposal", () => {
         hostIds: [host.id],
       })
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const { id } = (await res.json()) as { id: string };
 
     const proposal = await getRepositories().sessionProposals.findById(id);

--- a/tests/integration/admin-create-session-route.test.ts
+++ b/tests/integration/admin-create-session-route.test.ts
@@ -91,7 +91,7 @@ describe("POST /api/admin/create-session", () => {
 
   it("creates a session and returns its id", async () => {
     const res = await POST(makeReq(validBody()));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await readJson(res);
 
     const session = await getRepositories().sessions.findById(body.id);
@@ -148,7 +148,7 @@ describe("POST /api/admin/create-session", () => {
     const res = await POST(
       makeReq({ ...validBody(), locationIds: [otherRoom.id] })
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const body = await readJson(res);
     expect(body.id).not.toBe(first.id);
     expect(await getRepositories().sessions.listByEvent(event.id)).toHaveLength(


### PR DESCRIPTION
Creating a resource conventionally returns 201, not 200; create-guest
keeps 200 for its dedup case (existing record reused, nothing created).

<!-- jip:pushed-commit=be2102175033625c59c5b6c8992494f23338ad1a -->