### PR TITLE
fix: Delete cohost RSVPs in-transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Host RSVPs cleared on edit**: adding an attendee as a session host now removes their RSVP to that session, including when an organizer edits the session from the admin panel
+
 ## [3.0.0] - 2026-07-13
 
 > **Breaking change**: the database backend has switched from Airtable to SQLite. There is no automated migration path — data must be re-entered manually or migrated via a custom script.

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -41,7 +41,6 @@ export async function POST(req: Request) {
     );
   }
   const existingSessions = allSessions.filter((ses) => ses.id !== params.id);
-  const newHostIds = input.hostIds;
   const sessionValid = validateSession(input, existingSessions);
   if (sessionValid) {
     try {
@@ -51,10 +50,6 @@ export async function POST(req: Request) {
       console.error(err);
       return Response.error();
     }
-
-    // Corner case: someone RSVPs to a session and is later added as a host
-    // In this case, remove their RSVP
-    void repos.rsvps.deleteBySessionAndGuests(params.id, newHostIds);
     return Response.json({ success: true });
   } else {
     return Response.error();

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -401,6 +401,10 @@ export interface SessionsRepository {
   ): Promise<SessionPage>;
   findById(id: string): Promise<Session | undefined>;
   create(data: SessionCreateInput): Promise<Session>;
+  /**
+   * When `hostIds` is given, any RSVPs by the new hosts are removed in the
+   * same transaction: hosts don't RSVP to their own session.
+   */
   update(id: string, patch: SessionUpdateInput): Promise<Session>;
   delete(id: string): Promise<void>;
   /**
@@ -445,10 +449,6 @@ export interface RsvpsRepository {
     capacity: number;
   }): Promise<Rsvp | null>;
   deleteBySessionAndGuest(sessionId: string, guestId: string): Promise<void>;
-  deleteBySessionAndGuests(
-    sessionId: string,
-    guestIds: string[]
-  ): Promise<void>;
 }
 
 // ── Session Proposals ─────────────────────────────────────────────────────────

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -402,8 +402,8 @@ export interface SessionsRepository {
   findById(id: string): Promise<Session | undefined>;
   create(data: SessionCreateInput): Promise<Session>;
   /**
-   * When `hostIds` is given, any RSVPs by the new hosts are removed in the
-   * same transaction: hosts don't RSVP to their own session.
+   * When `hostIds` is given, any RSVPs by the session's hosts are removed
+   * in the same transaction: hosts don't RSVP to their own session.
    */
   update(id: string, patch: SessionUpdateInput): Promise<Session>;
   delete(id: string): Promise<void>;

--- a/db/repositories/sqlite/rsvps.ts
+++ b/db/repositories/sqlite/rsvps.ts
@@ -107,20 +107,4 @@ export class SqliteRsvpsRepository implements RsvpsRepository {
       )
       .run();
   }
-
-  async deleteBySessionAndGuests(
-    sessionId: string,
-    guestIds: string[]
-  ): Promise<void> {
-    if (guestIds.length === 0) return;
-    this.db
-      .delete(schema.rsvps)
-      .where(
-        and(
-          eq(schema.rsvps.sessionId, sessionId),
-          inArray(schema.rsvps.guestId, guestIds)
-        )
-      )
-      .run();
-  }
 }

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -320,6 +320,18 @@ export class SqliteSessionsRepository implements SessionsRepository {
             .values({ sessionId: id, guestId })
             .run();
         }
+        // Hosts don't RSVP to their own session, so an RSVP'd guest who
+        // becomes a host loses their RSVP.
+        if (patch.hostIds.length > 0) {
+          tx.delete(schema.rsvps)
+            .where(
+              and(
+                eq(schema.rsvps.sessionId, id),
+                inArray(schema.rsvps.guestId, patch.hostIds)
+              )
+            )
+            .run();
+        }
       }
 
       if (patch.locationIds !== undefined) {

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -320,8 +320,8 @@ export class SqliteSessionsRepository implements SessionsRepository {
             .values({ sessionId: id, guestId })
             .run();
         }
-        // Hosts don't RSVP to their own session, so an RSVP'd guest who
-        // becomes a host loses their RSVP.
+        // Hosts don't RSVP to their own session, so any of the new hosts'
+        // existing RSVPs are removed here too.
         if (patch.hostIds.length > 0) {
           tx.delete(schema.rsvps)
             .where(

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -455,13 +455,18 @@ describe("adminUpdateSessionAction", () => {
 
   afterEach(() => vi.unstubAllEnvs());
 
-  it("removes a guest's RSVP when they are added as a host", async () => {
+  it("removes a guest's RSVP when they are added as a host, leaving other RSVPs untouched", async () => {
     const event = await createEvent();
     const rsvper = await createGuest();
+    const otherRsvper = await createGuest();
     const session = await createSession(event.id, { title: "Workshop" });
     await getRepositories().rsvps.create({
       sessionId: session.id,
       guestId: rsvper.id,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: otherRsvper.id,
     });
 
     const result = await adminUpdateSessionAction({
@@ -478,7 +483,8 @@ describe("adminUpdateSessionAction", () => {
       locationIds: [],
     });
     expect(result.ok).toBe(true);
-    expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
+    const remaining = await getRepositories().rsvps.listBySession(session.id);
+    expect(remaining.map((r) => r.guestId)).toEqual([otherRsvper.id]);
   });
 
   it("updates title, description, capacity, flags, time, host and location", async () => {

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -455,6 +455,32 @@ describe("adminUpdateSessionAction", () => {
 
   afterEach(() => vi.unstubAllEnvs());
 
+  it("removes a guest's RSVP when they are added as a host", async () => {
+    const event = await createEvent();
+    const rsvper = await createGuest();
+    const session = await createSession(event.id, { title: "Workshop" });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: rsvper.id,
+    });
+
+    const result = await adminUpdateSessionAction({
+      id: session.id,
+      title: "Workshop",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 30,
+      adminManaged: false,
+      blocker: false,
+      closed: false,
+      hostIds: [rsvper.id],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(await getRepositories().rsvps.listBySession(session.id)).toEqual([]);
+  });
+
   it("updates title, description, capacity, flags, time, host and location", async () => {
     const event = await createEvent();
     const h1 = await createGuest({ name: "Host One" });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -199,16 +199,21 @@ describe("POST /api/update-session", () => {
     expect(unchanged.hosts[0].id).toBe(guest.id);
   });
 
-  it("removes a guest's RSVP when they are added as a host", async () => {
+  it("removes a guest's RSVP when they are added as a host, leaving other RSVPs untouched", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     const rsvper = await createGuest({ eventId: event.id });
+    const otherRsvper = await createGuest({ eventId: event.id });
     const location = await createLocation();
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
     await getRepositories().rsvps.create({
       sessionId: id,
       guestId: rsvper.id,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: id,
+      guestId: otherRsvper.id,
     });
 
     const res = await POST(
@@ -218,7 +223,8 @@ describe("POST /api/update-session", () => {
       })
     );
     expect(res.ok).toBe(true);
-    expect(await getRepositories().rsvps.listBySession(id)).toEqual([]);
+    const remaining = await getRepositories().rsvps.listBySession(id);
+    expect(remaining.map((r) => r.guestId)).toEqual([otherRsvper.id]);
   });
 
   it("updates location, hosts, and capacity; re-fetched session reflects each", async () => {

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -199,6 +199,28 @@ describe("POST /api/update-session", () => {
     expect(unchanged.hosts[0].id).toBe(guest.id);
   });
 
+  it("removes a guest's RSVP when they are added as a host", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const rsvper = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+    await getRepositories().rsvps.create({
+      sessionId: id,
+      guestId: rsvper.id,
+    });
+
+    const res = await POST(
+      makeUpdateReq({
+        ...basePayload(host, location, day, { hosts: [host, rsvper] }),
+        id,
+      })
+    );
+    expect(res.ok).toBe(true);
+    expect(await getRepositories().rsvps.listBySession(id)).toEqual([]);
+  });
+
   it("updates location, hosts, and capacity; re-fetched session reflects each", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host1 = await createGuest({ name: "Host 1", eventId: event.id });


### PR DESCRIPTION
Minor, but means there's no risk of the app crashing in between "add cohosts" and "remove RSVPs"; and we now remove cohost RSVPs when an admin edits the session, too.