### PR TITLE
Actually send some emails

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -19,6 +19,10 @@ HOST_PORT=3000
 # See CONTRIBUTING.md#email-variables for details.
 SMTP_FROM=
 
+# The site's public base URL, e.g. https://sessions.example.org — used so
+# emails can link back to the site. Required when email is configured.
+SITE_URL=
+
 # Option A: a single connection URL, e.g. smtp://user:pass@localhost:1025
 SMTP_URL=
 

--- a/.env.test
+++ b/.env.test
@@ -12,3 +12,4 @@ SB_UPLOADS_DIR=./uploads-test/
 MAILPIT_API_URL=http://localhost:8025
 SMTP_URL=smtp://localhost:1025
 SMTP_FROM='Test <mailer-test@test.example>'
+SITE_URL=http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,20 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
 
+    services:
+      # e2e tests send real email to mailpit (see CONTRIBUTING.md § Running
+      # tests). Same pinned image as docker-compose.yml.
+      mailpit:
+        image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd "/mailpit readyz"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Email notifications**: attendees are emailed when a session they've RSVP'd to changes time or location, hosts are emailed when a session they're hosting changes time or location, and guests are emailed when they're added as a co-host of a session. Each notification can be turned on or off individually from the profile page (requires SMTP and `SITE_URL` to be configured)
+
 ### Fixed
 
 - **Host RSVPs cleared on edit**: adding an attendee as a session host now removes their RSVP to that session, including when an organizer edits the session from the admin panel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,8 @@ make test-e2e-headed     # Run E2E tests (headed, for local dev)
 
 By default, `make test` tests that we can successfully send email to a local [mailpit](https://mailpit.axllent.org/) (start it with `docker compose up mailpit`). You can skip that test by setting `MAILPIT_API_URL` to blank in `.env.test.local`.
 
+Some e2e tests (`make test-e2e`) also require mailpit. These ones fail if it's unreachable.
+
 Install Playwright browsers before first use:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,9 @@ format: install
 format-check: install
 	bun x prettier --check .
 
-precommit: format lint typecheck test-coverage test-e2e
+# We don't run test-e2e here, because it fails if mailpit isn't running and we
+# don't want to require devs to run it.
+precommit: format lint typecheck test-coverage
 
 clean:
 	rm -rf .next

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -34,6 +34,14 @@ export default async function EditProfilePage() {
     );
   }
 
-  // Strip private info (email) before handing the guest to a client component.
-  return <ProfileForm guest={sanitizeGuest(guest)} />;
+  // Strip private info (email) before handing the guest to a client
+  // component. The email settings are stripped, so we pass them separately.
+  // This page is only ever the current user's own profile, so they may see
+  // them.
+  return (
+    <ProfileForm
+      guest={sanitizeGuest(guest)}
+      emailSettings={guest.info.emailSettings}
+    />
+  );
 }

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/navigation";
 import { Input } from "@/app/input";
 import { updateProfileAction } from "@/app/actions/profile";
 import { Avatar } from "../avatar";
-import type { Guest } from "@/db/repositories/interfaces";
+import type { EmailSettings, Guest } from "@/db/repositories/interfaces";
 import { resizeImage } from "@/utils/images-client";
 import clsx from "clsx";
 import { Path, useController, useForm, useWatch } from "react-hook-form";
@@ -34,13 +34,20 @@ const profileFormSchema = profileSchema.extend({
   avatar: z.instanceof(FileList).nullable().optional(),
 });
 
-export function ProfileForm({ guest }: { guest: Guest }) {
+export function ProfileForm({
+  guest,
+  emailSettings,
+}: {
+  guest: Guest;
+  emailSettings: EmailSettings;
+}) {
   const router = useRouter();
   const form = useForm({
     defaultValues: {
       name: guest.name,
       aboutMe: guest.aboutMe,
       pronouns: guest.pronouns,
+      emailSettings,
     },
     resolver: zodResolver(profileFormSchema),
   });
@@ -262,6 +269,31 @@ export function ProfileForm({ guest }: { guest: Guest }) {
             {form.formState.errors.aboutMe?.message}
           </span>
         </div>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="font-medium mb-1">Email me when…</legend>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              {...form.register("emailSettings.rsvpChange")}
+            />
+            a session I&rsquo;ve RSVP&rsquo;d to changes time or location
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              {...form.register("emailSettings.hostChange")}
+            />
+            a session I&rsquo;m hosting changes time or location
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              {...form.register("emailSettings.cohostAdd")}
+            />
+            someone adds me as a session co-host
+          </label>
+        </fieldset>
 
         {form.formState.errors.root && (
           <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">

--- a/app/(site)/markdown.tsx
+++ b/app/(site)/markdown.tsx
@@ -1,20 +1,11 @@
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
+import { MARKDOWN_DISALLOWED_ELEMENTS } from "@/utils/markdown";
 
 // User-provided content: raw HTML is never parsed (react-markdown default)
 // and unsafe URL schemes like javascript: are stripped by the default URL
-// transform. Images stay disabled so viewers' IPs never hit arbitrary URLs.
-const DISALLOWED = [
-  "img",
-  "table",
-  "thead",
-  "tbody",
-  "tr",
-  "th",
-  "td",
-  "input",
-];
+// transform.
 
 // Headings render as bold paragraphs sized relative to the surrounding text
 // (em units), so user content can never out-shout the page's own headings,
@@ -80,7 +71,7 @@ export function Markdown({
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkBreaks]}
-      disallowedElements={DISALLOWED}
+      disallowedElements={MARKDOWN_DISALLOWED_ELEMENTS}
       unwrapDisallowed
       components={components}
     >

--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -5,7 +5,10 @@ import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import { sessionSlotAlignmentError } from "@/utils/day-window";
-import { notifySessionChanged } from "@/utils/notifications";
+import {
+  notifyCohostsAdded,
+  notifySessionChanged,
+} from "@/utils/notifications";
 import type { AdminActionResult } from "./admin-guests";
 
 async function isAdminRequest(): Promise<boolean> {
@@ -123,8 +126,9 @@ export async function adminCreateSessionAction(
   );
   if (conflict) return { ok: false, error: conflict };
 
+  let created;
   try {
-    await sessions.create({
+    created = await sessions.create({
       title,
       description: input.description.trim(),
       startTime: range.start,
@@ -142,6 +146,12 @@ export async function adminCreateSessionAction(
   }
 
   await revalidateEventPaths(input.eventId);
+
+  await notifyCohostsAdded({
+    session: created,
+    previousHostIds: [],
+    changedById: null,
+  });
   return { ok: true };
 }
 
@@ -201,7 +211,12 @@ export async function adminUpdateSessionAction(
   }
 
   await revalidateEventPaths(session.eventId);
-  // Admins aren't guests, so there is no editor to exclude.
+
+  await notifyCohostsAdded({
+    session: updated,
+    previousHostIds: session.hosts.map((h) => h.id),
+    changedById: null,
+  });
   await notifySessionChanged({
     before: session,
     after: updated,

--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import { sessionSlotAlignmentError } from "@/utils/day-window";
+import { notifySessionChanged } from "@/utils/notifications";
 import type { AdminActionResult } from "./admin-guests";
 
 async function isAdminRequest(): Promise<boolean> {
@@ -181,8 +182,9 @@ export async function adminUpdateSessionAction(
   );
   if (conflict) return { ok: false, error: conflict };
 
+  let updated;
   try {
-    await sessions.update(input.id, {
+    updated = await sessions.update(input.id, {
       title,
       description: input.description.trim(),
       startTime: range.start,
@@ -199,6 +201,12 @@ export async function adminUpdateSessionAction(
   }
 
   await revalidateEventPaths(session.eventId);
+  // Admins aren't guests, so there is no editor to exclude.
+  await notifySessionChanged({
+    before: session,
+    after: updated,
+    changedById: null,
+  });
   return { ok: true };
 }
 

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -1,11 +1,13 @@
+import type { NextRequest } from "next/server";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
+import { notifyCohostsAdded } from "@/utils/notifications";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const params = (await req.json()) as SessionParams;
   const repos = getRepositories();
   const input = prepareToInsert(params);
@@ -30,13 +32,20 @@ export async function POST(req: Request) {
   );
   const sessionValid = validateSession(input, existingSessions);
   if (sessionValid) {
+    let session;
     try {
-      const session = await repos.sessions.create(input);
+      session = await repos.sessions.create(input);
       console.log(session.id);
     } catch (err) {
       console.error(err);
       return Response.error();
     }
+
+    await notifyCohostsAdded({
+      session,
+      previousHostIds: [],
+      changedById: req.cookies.get("user")?.value ?? null,
+    });
     return Response.json({ success: true });
   } else {
     return Response.error();

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -1,11 +1,13 @@
+import type { NextRequest } from "next/server";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
+import { notifySessionChanged } from "@/utils/notifications";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const params = (await req.json()) as SessionParams;
   if (!params.id) {
     console.error("Session ID is required for update.");
@@ -43,13 +45,20 @@ export async function POST(req: Request) {
   const existingSessions = allSessions.filter((ses) => ses.id !== params.id);
   const sessionValid = validateSession(input, existingSessions);
   if (sessionValid) {
+    let updated;
     try {
-      const updated = await repos.sessions.update(params.id, input);
+      updated = await repos.sessions.update(params.id, input);
       console.log(updated.id);
     } catch (err) {
       console.error(err);
       return Response.error();
     }
+
+    await notifySessionChanged({
+      before: prevSession,
+      after: updated,
+      changedById: req.cookies.get("user")?.value ?? null,
+    });
     return Response.json({ success: true });
   } else {
     return Response.error();

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -1,7 +1,10 @@
 import type { NextRequest } from "next/server";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
-import { notifySessionChanged } from "@/utils/notifications";
+import {
+  notifyCohostsAdded,
+  notifySessionChanged,
+} from "@/utils/notifications";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
@@ -54,10 +57,16 @@ export async function POST(req: NextRequest) {
       return Response.error();
     }
 
+    const changedById = req.cookies.get("user")?.value ?? null;
+    await notifyCohostsAdded({
+      session: updated,
+      previousHostIds: prevSession.hosts.map((h) => h.id),
+      changedById,
+    });
     await notifySessionChanged({
       before: prevSession,
       after: updated,
-      changedById: req.cookies.get("user")?.value ?? null,
+      changedById,
     });
     return Response.json({ success: true });
   } else {

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -101,8 +101,28 @@ export interface EventsRepository {
 
 // ── Guests ────────────────────────────────────────────────────────────────────
 
+// When the guest wants to be emailed. Not consulted anywhere yet: the emails
+// themselves are not implemented.
+export type EmailSettings = {
+  /** A session the guest RSVP'd to changed time or location. */
+  rsvpChange: boolean;
+  /** A session the guest is hosting changed time or location. */
+  hostChange: boolean;
+  /** The guest was added as a co-host of a session. */
+  cohostAdd: boolean;
+};
+
+export const DEFAULT_EMAIL_SETTINGS: EmailSettings = {
+  rsvpChange: true,
+  hostChange: true,
+  cohostAdd: true,
+};
+
 type GuestPrivateInfo = {
   email: string;
+  // These aren't very private, but still no reason to expose them to other
+  // guests.
+  emailSettings: EmailSettings;
 };
 
 export type Guest<PI extends GuestPrivateInfo | void = void> = {
@@ -116,6 +136,12 @@ export type Guest<PI extends GuestPrivateInfo | void = void> = {
 };
 
 export type CompleteGuest = Guest<GuestPrivateInfo>;
+
+/** Input for creating a guest. Everything else is filled in after creation. */
+export type NewGuest = {
+  name: string;
+  info: { email: string };
+};
 
 /** A guest paired with their email and whether they are assigned to a given event. */
 export type EventGuestRow = {
@@ -202,24 +228,32 @@ export interface GuestsRepository {
   findByEmail(email: string): Promise<CompleteGuest | undefined>;
   /** Guests whose email matches any of `emails`, compared case-insensitively. */
   findByEmails(emails: string[]): Promise<CompleteGuest[]>;
-  create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest>;
+  create(data: NewGuest): Promise<CompleteGuest>;
   /**
    * Atomically creates a guest, or returns the existing one if a guest with
    * the same email (case-insensitive) already exists. Safe under concurrent
    * calls with the same email (backed by a DB-level unique index).
    */
   findOrCreateByEmail(
-    data: Omit<CompleteGuest, "id">
+    data: NewGuest
   ): Promise<{ guest: CompleteGuest; created: boolean }>;
-  // Usage: an admin updates a user (name and private info such as email).
+  // Usage: an admin updates a user (name and email). Email settings are not
+  // touched: those belong to the guest, via updateProfile.
   update(
     id: string,
-    data: Pick<CompleteGuest, "name" | "info">
+    data: { name: string; info: { email: string } }
   ): Promise<CompleteGuest | undefined>;
-  // Usage: a user updates their own profile (name and public aboutMe).
+  // Usage: a user updates their own profile (name, public aboutMe, and their
+  // email notification settings).
   updateProfile(
     id: string,
-    data: Pick<Guest, "name" | "avatarUrl" | "aboutMe" | "pronouns">
+    data: {
+      name: string;
+      aboutMe: string | null;
+      avatarUrl: string | null;
+      pronouns: string | null;
+      emailSettings: EmailSettings;
+    }
   ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -101,8 +101,7 @@ export interface EventsRepository {
 
 // ── Guests ────────────────────────────────────────────────────────────────────
 
-// When the guest wants to be emailed. Not consulted anywhere yet: the emails
-// themselves are not implemented.
+// When the guest wants to be emailed.
 export type EmailSettings = {
   /** A session the guest RSVP'd to changed time or location. */
   rsvpChange: boolean;

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -11,12 +11,15 @@ import {
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
-import type {
-  CompleteGuest,
-  EventGuestPage,
-  Guest,
-  GuestsRepository,
-  GuestPage,
+import {
+  DEFAULT_EMAIL_SETTINGS,
+  type CompleteGuest,
+  type EmailSettings,
+  type EventGuestPage,
+  type Guest,
+  type GuestsRepository,
+  type GuestPage,
+  type NewGuest,
   AttendeePage,
   Attendee,
 } from "../interfaces";
@@ -37,7 +40,14 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
     aboutMe: row.aboutMe,
     avatarUrl: row.avatarUrl,
     pronouns: row.pronouns,
-    info: { email: row.email },
+    info: {
+      email: row.email,
+      emailSettings: {
+        rsvpChange: row.emailOnRsvpChange,
+        hostChange: row.emailOnHostChange,
+        cohostAdd: row.emailOnCohostAdd,
+      },
+    },
   };
 }
 
@@ -277,19 +287,24 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .map(rowToGuest);
   }
 
-  async create(data: Omit<CompleteGuest, "id">): Promise<CompleteGuest> {
+  async create(data: NewGuest): Promise<CompleteGuest> {
     const id = nanoid();
     const {
       name,
       info: { email },
     } = data;
 
+    // Email settings are left to their column defaults.
     this.db.insert(schema.guests).values({ id, name, email }).run();
-    return { id, ...data };
+    return {
+      id,
+      name,
+      info: { email, emailSettings: { ...DEFAULT_EMAIL_SETTINGS } },
+    };
   }
 
   async findOrCreateByEmail(
-    data: Omit<CompleteGuest, "id">
+    data: NewGuest
   ): Promise<{ guest: CompleteGuest; created: boolean }> {
     const id = nanoid();
     const {
@@ -320,7 +335,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
 
   async update(
     id: string,
-    data: Pick<CompleteGuest, "name" | "info">
+    data: { name: string; info: { email: string } }
   ): Promise<CompleteGuest | undefined> {
     const {
       name,
@@ -338,7 +353,13 @@ export class SqliteGuestsRepository implements GuestsRepository {
 
   async updateProfile(
     id: string,
-    data: Pick<Guest, "name" | "aboutMe" | "avatarUrl" | "pronouns">
+    data: {
+      name: string;
+      aboutMe: string | null;
+      avatarUrl: string | null;
+      pronouns: string | null;
+      emailSettings: EmailSettings;
+    }
   ): Promise<CompleteGuest | undefined> {
     const result = this.db
       .update(schema.guests)
@@ -347,6 +368,9 @@ export class SqliteGuestsRepository implements GuestsRepository {
         aboutMe: data.aboutMe,
         avatarUrl: data.avatarUrl,
         pronouns: data.pronouns,
+        emailOnRsvpChange: data.emailSettings.rsvpChange,
+        emailOnHostChange: data.emailSettings.hostChange,
+        emailOnCohostAdd: data.emailSettings.cohostAdd,
       })
       .where(eq(schema.guests.id, id))
       .run();

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -26,6 +26,17 @@ export const guests = sqliteTable(
     email: text("email").notNull(),
     aboutMe: text("about_me"),
     pronouns: text("pronouns"),
+    // Email notification settings; see EmailSettings in
+    // repositories/interfaces.ts.
+    emailOnRsvpChange: integer("email_on_rsvp_change", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    emailOnHostChange: integer("email_on_host_change", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    emailOnCohostAdd: integer("email_on_cohost_add", { mode: "boolean" })
+      .notNull()
+      .default(true),
     avatarUrl: text("avatar_url"),
   },
   (table) => [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,8 @@ services:
   # [1]: https://mailpit.axllent.org/
   # [2]: https://docs.docker.com/compose/how-tos/profiles/
   mailpit:
-    # If you update this pin, update it in .github/workflows/ci.yml too.
+    # If you update this pin, update it in .github/workflows/ci.yml too, for
+    # both `test` and `test-e2e`.
     image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
     profiles:
       - dev

--- a/docs/hosting/README.md
+++ b/docs/hosting/README.md
@@ -50,12 +50,16 @@ docker compose up -d
 | `SMTP_USER`      | No       | SMTP username                                                                  |
 | `SMTP_PASSWORD`  | No       | SMTP password                                                                  |
 | `SMTP_SECURE`    | No       | `true`, `false`, or `requireTLS` (default)                                     |
+| `SITE_URL`       | No\*     | Public base URL of the site, e.g. `https://sessions.example.org`               |
 
 Email is optional — leave the SMTP variables unset to disable it. To enable
 email, set `SMTP_FROM` plus either `SMTP_URL` (a single connection string,
 e.g. `smtp://user:pass@localhost:1025`, which already includes the host,
 port, user, password, and security settings) **or** `SMTP_HOST` together
 with `SMTP_PORT`/`SMTP_USER`/`SMTP_PASSWORD`/`SMTP_SECURE` — not both.
+
+\* `SITE_URL` is required when email is enabled, so that emails can link back
+to the site.
 
 ## Administration
 

--- a/drizzle/0018_guest-email-settings.sql
+++ b/drizzle/0018_guest-email-settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `guests` ADD `email_on_rsvp_change` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_host_change` integer DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `email_on_cohost_add` integer DEFAULT true NOT NULL;

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,986 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8bd668f2-5c42-468c-82cb-efafd0799428",
+  "prevId": "d36ada2b-4938-4da9-afa9-6fb4159b690a",
+  "tables": {
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1783841298927,
       "tag": "0017_rsvp_capacity_hard_limit",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1784110051953,
+      "tag": "0018_guest-email-settings",
+      "breakpoints": true
     }
   ]
 }

--- a/emails/cohost-added.tsx
+++ b/emails/cohost-added.tsx
@@ -1,0 +1,34 @@
+import type { EmailMessage } from "@/utils/mailer";
+import { EmailMarkdown } from "@/emails/markdown";
+
+// Sent to a guest when someone adds them as a co-host of a session (or
+// creates a session listing them). Time and location come preformatted.
+export function cohostAddedEmail(props: {
+  title: string;
+  description: string;
+  time: string;
+  location: string;
+  sessionUrl: string;
+}): EmailMessage {
+  return {
+    subject: `You are now a co-host of: ${props.title}`,
+    body: (
+      <>
+        <h1>{props.title}</h1>
+        <p>You&rsquo;ve been added as a co-host of this session.</p>
+        <p>
+          <strong>Time:</strong> {props.time}
+        </p>
+        <p>
+          <strong>Location:</strong> {props.location}
+        </p>
+        {props.description && (
+          <EmailMarkdown>{props.description}</EmailMarkdown>
+        )}
+        <p>
+          <a href={props.sessionUrl}>View the session</a>
+        </p>
+      </>
+    ),
+  };
+}

--- a/emails/markdown.tsx
+++ b/emails/markdown.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import { MARKDOWN_DISALLOWED_ELEMENTS } from "@/utils/markdown";
+
+// User-provided markdown in email bodies. The same parser and safety
+// settings as the site's Markdown component (raw HTML never parsed, unsafe
+// URL schemes stripped, images disallowed), but unlike the site version it
+// keeps plain HTML tags: mail clients apply their default styles, and CSS
+// classes would do nothing without the site's stylesheet.
+//
+// Headings are the exception, as on the site: they render as bold paragraphs
+// so user content can't out-shout the email's own headings.
+function Heading({ children }: { children?: ReactNode }) {
+  return <p style={{ fontWeight: "bold" }}>{children}</p>;
+}
+
+export function EmailMarkdown({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      disallowedElements={MARKDOWN_DISALLOWED_ELEMENTS}
+      unwrapDisallowed
+      components={{
+        h1: Heading,
+        h2: Heading,
+        h3: Heading,
+        h4: Heading,
+        h5: Heading,
+        h6: Heading,
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/emails/session-changed.tsx
+++ b/emails/session-changed.tsx
@@ -11,6 +11,7 @@ export function sessionChangedEmail(props: {
   oldTime?: string;
   newLocation: string;
   oldLocation?: string;
+  sessionUrl: string;
 }): EmailMessage {
   const changed =
     props.oldTime && props.oldLocation
@@ -40,6 +41,9 @@ export function sessionChangedEmail(props: {
           {props.oldLocation && <> (was {props.oldLocation})</>}
         </p>
         {props.description && <p>{props.description}</p>}
+        <p>
+          <a href={props.sessionUrl}>View the session</a>
+        </p>
       </>
     ),
   };

--- a/emails/session-changed.tsx
+++ b/emails/session-changed.tsx
@@ -1,4 +1,5 @@
 import type { EmailMessage } from "@/utils/mailer";
+import { EmailMarkdown } from "@/emails/markdown";
 
 // Sent to hosts and RSVP'd guests when a session changes time and/or
 // location. Times and locations come preformatted; the old value is given
@@ -40,7 +41,9 @@ export function sessionChangedEmail(props: {
           <strong>Location:</strong> {props.newLocation}
           {props.oldLocation && <> (was {props.oldLocation})</>}
         </p>
-        {props.description && <p>{props.description}</p>}
+        {props.description && (
+          <EmailMarkdown>{props.description}</EmailMarkdown>
+        )}
         <p>
           <a href={props.sessionUrl}>View the session</a>
         </p>

--- a/emails/session-changed.tsx
+++ b/emails/session-changed.tsx
@@ -1,0 +1,46 @@
+import type { EmailMessage } from "@/utils/mailer";
+
+// Sent to hosts and RSVP'd guests when a session changes time and/or
+// location. Times and locations come preformatted; the old value is given
+// only for what actually changed.
+export function sessionChangedEmail(props: {
+  recipient: "host" | "attendee";
+  title: string;
+  description: string;
+  newTime: string;
+  oldTime?: string;
+  newLocation: string;
+  oldLocation?: string;
+}): EmailMessage {
+  const changed =
+    props.oldTime && props.oldLocation
+      ? "time and location"
+      : props.oldTime
+        ? "time"
+        : "location";
+  return {
+    subject: `Session ${changed} changed: ${props.title}`,
+    body: (
+      <>
+        <h1>{props.title}</h1>
+        <p>
+          {props.recipient === "host" ? (
+            <>A session you&rsquo;re hosting</>
+          ) : (
+            <>A session you RSVP&rsquo;d to</>
+          )}{" "}
+          has changed {changed}.
+        </p>
+        <p>
+          <strong>Time:</strong> {props.newTime}
+          {props.oldTime && <> (was {props.oldTime})</>}
+        </p>
+        <p>
+          <strong>Location:</strong> {props.newLocation}
+          {props.oldLocation && <> (was {props.oldLocation})</>}
+        </p>
+        {props.description && <p>{props.description}</p>}
+      </>
+    ),
+  };
+}

--- a/model/guest.ts
+++ b/model/guest.ts
@@ -1,8 +1,16 @@
 import { z } from "zod";
 
+// Matches EmailSettings in db/repositories/interfaces.ts.
+export const emailSettingsSchema = z.object({
+  rsvpChange: z.boolean(),
+  hostChange: z.boolean(),
+  cohostAdd: z.boolean(),
+});
+
 export const profileSchema = z.object({
   name: z.string().trim().min(1, { message: "Name is required" }),
   aboutMe: z.string().trim().nullable().optional().default(null),
   avatar: z.instanceof(Blob).nullable().optional(),
   pronouns: z.string().trim().nullable().optional().default(null),
+  emailSettings: emailSettingsSchema,
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,12 @@ const port = process.env.E2E_PORT
 process.env.E2E_PORT = String(port);
 const baseURL = `http://localhost:${port}`;
 
+// Emails link back to the site via SITE_URL. Point it at this run's server —
+// the web server command inherits this process's environment, and real
+// environment variables beat the .env.test value in set-env.ts — so
+// emails.spec.ts can follow the links it finds in sent emails.
+process.env.SITE_URL = baseURL;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/tests/e2e/update-session.spec.ts
+++ b/tests/e2e/update-session.spec.ts
@@ -1,0 +1,143 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import {
+  MAILPIT_API_URL,
+  getMessage,
+  searchBySubject,
+} from "../helpers/mailpit";
+
+// Form idioms shared with scheduling.spec.ts: the form's labels are not wired
+// to their inputs, so locate each listbox through its labelled section.
+async function selectUser(page: Page, name: RegExp) {
+  await page.getByLabel("My name is:").click();
+  await page.getByRole("option", { name }).click();
+}
+
+function listboxButton(page: Page, section: RegExp) {
+  return page
+    .locator("div")
+    .filter({ hasText: section })
+    .first()
+    .getByRole("button")
+    .first();
+}
+
+const dayRadios = (page: Page) =>
+  page.getByRole("radio", {
+    name: /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/,
+  });
+
+test("updating a session emails the RSVP'd guest and the added co-host", async ({
+  page,
+}) => {
+  expect(
+    MAILPIT_API_URL,
+    "MAILPIT_API_URL must be set: this test needs Mailpit (docker compose up mailpit) and fails rather than skips without it"
+  ).toBeTruthy();
+
+  await login(page);
+  // The title doubles as the unique token for finding this test's emails
+  // (both notification emails carry it in the subject), so leftover
+  // mailbox contents from other tests or runs never match.
+  const title = `E2E Email Session ${Date.now()}`;
+
+  // Charlie creates a session on the last event day (Garden Terrace 15:10 —
+  // a slot no other spec claims; see the note in scheduling.spec.ts).
+  await page.goto("/Conference-Gamma");
+  await selectUser(page, /Charlie Test/i);
+  await page.getByRole("link", { name: "Add session" }).first().click();
+  await expect(
+    page.getByRole("heading", { name: /Add a session/i })
+  ).toBeVisible();
+  await page.getByRole("textbox").first().fill(title);
+  // Hosts are prefilled with the selected user (Charlie).
+  await dayRadios(page).last().check();
+  await listboxButton(page, /^Location/).click();
+  await page.getByRole("option", { name: /Garden Terrace/ }).click();
+  await listboxButton(page, /^Start Time/).click();
+  await page.getByRole("option", { name: "15:10" }).click();
+  const submit = page.getByRole("button", { name: "Submit" });
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(
+    page.getByRole("heading", { name: /Session added/i })
+  ).toBeVisible();
+  await page.getByRole("link", { name: /Back to schedule/i }).click();
+
+  // Bob RSVPs to it.
+  await selectUser(page, /Bob Test/i);
+  await page.getByRole("link", { name: title }).click();
+  const dialog = page.getByRole("dialog", { name: "Session details" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "RSVP", exact: true }).click();
+  await expect(dialog.getByRole("button", { name: "Un-RSVP" })).toBeVisible();
+
+  // Charlie moves the session and adds Alice as a co-host.
+  await page.goto("/Conference-Gamma");
+  await selectUser(page, /Charlie Test/i);
+  await page.getByRole("link", { name: title }).click();
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("link", { name: "Edit" }).click();
+  await expect(
+    page.getByRole("heading", { name: /Edit session/i })
+  ).toBeVisible();
+  await listboxButton(page, /^Start Time/).click();
+  await page.getByRole("option", { name: "14:40" }).click();
+  const hostsSection = page
+    .locator("div")
+    .filter({ hasText: /^Hosts/ })
+    .first();
+  // Don't click the section's first button, as add-session.spec.ts does:
+  // with a host already present that's the host chip's "Remove" button, not
+  // the dropdown opener. Type into the combobox itself instead.
+  const hostsCombobox = hostsSection.getByRole("combobox");
+  await hostsCombobox.click();
+  await hostsCombobox.pressSequentially("Alice Test");
+  await page.getByRole("option", { name: /Alice Test/i }).click();
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Submit" }).click();
+  await expect(
+    page.getByRole("heading", { name: /Session updated/i })
+  ).toBeVisible();
+
+  // Three emails arrive: Bob is told as an attendee, Alice both that she is
+  // a co-host now and, as a host, that the session changed. Charlie made the
+  // change, so he hears nothing.
+  await expect
+    .poll(() => searchBySubject(title), { timeout: 1000 /* milliseconds */ })
+    .toHaveLength(3);
+  const messages = await searchBySubject(title);
+  const to = (address: string) =>
+    messages.filter((m) => m.To.some((t) => t.Address === address));
+  expect(to("bob@test.com")).toHaveLength(1);
+  expect(to("alice@test.com")).toHaveLength(2);
+  expect(to("charlie@test.com")).toHaveLength(0);
+
+  // Every link in every email resolves on the site. The browser parses the
+  // email html for us, so hrefs come out entity-decoded. page.request shares
+  // the browser's cookies, so the site-password gate doesn't redirect to
+  // /login.
+  for (const summary of messages) {
+    const message = await getMessage(summary.ID);
+    await page.setContent(message.HTML);
+    const links = await page
+      .locator("a[href]")
+      .evaluateAll((anchors) => anchors.map((a) => a.getAttribute("href")!));
+    expect(
+      links.length,
+      `email "${summary.Subject}" should link to the session`
+    ).toBeGreaterThan(0);
+    for (const link of links) {
+      // Mail clients have no base URL, so a relative link is always broken.
+      expect(link, `relative link in "${summary.Subject}"`).toMatch(
+        /^https?:\/\//
+      );
+      const response = await page.request.get(link);
+      expect(response.ok(), `broken link ${link} in "${summary.Subject}"`).toBe(
+        true
+      );
+      expect(response.url()).not.toContain("/login");
+    }
+  }
+});

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -1,5 +1,6 @@
 import { getRepositories } from "@/db/container";
 import type {
+  EmailSettings,
   Event,
   Guest,
   Location,
@@ -88,6 +89,7 @@ export async function createEvent(opts?: {
 export async function createGuest(opts?: {
   name?: string;
   email?: string;
+  emailSettings?: EmailSettings;
   /** When set, the guest is also assigned to this event. */
   eventId?: string;
 }): Promise<Guest> {
@@ -99,6 +101,17 @@ export async function createGuest(opts?: {
       info: { email: opts?.email ?? `guest-${unique}@test.example` },
     })
     .then((g) => g && sanitizeGuest(g));
+  if (opts?.emailSettings) {
+    // Guests are created with default settings; non-default settings are
+    // applied the way a real guest would, via their profile.
+    await guests.updateProfile(guest.id, {
+      name: guest.name,
+      aboutMe: guest.aboutMe ?? null,
+      avatarUrl: guest.avatarUrl ?? null,
+      pronouns: guest.pronouns ?? null,
+      emailSettings: opts.emailSettings,
+    });
+  }
   if (opts?.eventId) {
     await guests.assignToEvent(opts.eventId, [guest.id]);
   }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -178,6 +178,7 @@ export async function createSession(
   eventId: string,
   opts?: {
     title?: string;
+    description?: string;
     locationIds?: string[];
     hostIds?: string[];
     startTime?: Date;
@@ -188,7 +189,7 @@ export async function createSession(
   const { sessions } = getRepositories();
   return sessions.create({
     title: opts?.title ?? `Test Session ${Date.now()}`,
-    description: "",
+    description: opts?.description ?? "",
     startTime: opts?.startTime,
     endTime: opts?.endTime,
     capacity: opts?.capacity ?? 30,

--- a/tests/helpers/mailpit.ts
+++ b/tests/helpers/mailpit.ts
@@ -1,0 +1,37 @@
+// Talking to Mailpit's API (docker compose up mailpit), for tests that check
+// real email delivery.
+export const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
+
+export type MessageSummary = {
+  ID: string;
+  From: { Name: string; Address: string };
+  To: { Address: string }[];
+  Subject: string;
+};
+
+async function mailpitGet(path: string): Promise<unknown> {
+  const res = await fetch(new URL(path, MAILPIT_API_URL));
+  if (!res.ok) {
+    throw new Error(`Mailpit API ${path} returned ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function searchBySubject(
+  subject: string
+): Promise<MessageSummary[]> {
+  const query = encodeURIComponent(`subject:"${subject}"`);
+  const result = (await mailpitGet(`/api/v1/search?query=${query}`)) as {
+    messages: MessageSummary[];
+  };
+  return result.messages;
+}
+
+export async function getMessage(
+  id: string
+): Promise<{ Text: string; HTML: string }> {
+  return (await mailpitGet(`/api/v1/message/${id}`)) as {
+    Text: string;
+    HTML: string;
+  };
+}

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+import { sendMail } from "@/utils/mailer";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -11,10 +18,17 @@ import { POST } from "@/app/api/add-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
 
-function makeReq(payload: unknown): Request {
-  return new Request("http://test/api/add-session", {
+function makeReq(
+  payload: unknown,
+  opts?: { editorGuestId?: string }
+): NextRequest {
+  return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
+    // The `user` cookie identifies the acting guest, like the site sets it.
+    headers: opts?.editorGuestId
+      ? { cookie: `user=${opts.editorGuestId}` }
+      : undefined,
   });
 }
 
@@ -40,7 +54,32 @@ function buildPayload(
 
 describe("POST /api/add-session", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+  });
+
+  it("emails co-hosts of the new session, but not its creator", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const creator = await createGuest({ eventId: event.id });
+    const cohost = await createGuest({
+      email: "cohost@test.example",
+      eventId: event.id,
+    });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(
+        buildPayload(creator, location, day, { hosts: [creator, cohost] }),
+        { editorGuestId: creator.id }
+      )
+    );
+
+    expect(res.ok).toBe(true);
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("cohost@test.example");
+  });
 
   it("creates a session and returns success", async () => {
     const event = await createEvent({ phase: "scheduling" });
@@ -178,7 +217,7 @@ describe("POST /api/add-session", () => {
 
   // Route does not guard req.json() — parse errors surface as a thrown SyntaxError
   it("malformed JSON causes a SyntaxError", async () => {
-    const req = new Request("http://test/api/add-session", {
+    const req = new NextRequest("http://test/api/add-session", {
       method: "POST",
       body: "not json",
       headers: { "content-type": "application/json" },

--- a/tests/integration/admin-guests.test.ts
+++ b/tests/integration/admin-guests.test.ts
@@ -215,6 +215,23 @@ describe("admin guest actions", () => {
     });
   });
 
+  describe("email settings", () => {
+    it("defaults email settings to on for new guests", async () => {
+      const result = await createGuestAction({
+        name: "Alice",
+        email: "alice@test.example",
+      });
+      expect(result).toEqual({ ok: true });
+      const guest =
+        await getRepositories().guests.findByEmail("alice@test.example");
+      expect(guest?.info.emailSettings).toEqual({
+        rsvpChange: true,
+        hostChange: true,
+        cohostAdd: true,
+      });
+    });
+  });
+
   describe("deleteGuestAction", () => {
     it("deletes a guest", async () => {
       const guest = await createGuest();

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -24,6 +24,11 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+import { sendMail } from "@/utils/mailer";
 import { revalidatePath } from "next/cache";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
@@ -523,6 +528,40 @@ describe("adminUpdateSessionAction", () => {
     expect(updated?.endTime?.toISOString()).toBe("2030-01-01T11:00:00.000Z");
     expect(updated?.hosts.map((h) => h.id)).toEqual([h2.id]);
     expect(updated?.locations.map((l) => l.id)).toEqual([loc.id]);
+  });
+
+  it("emails RSVP'd guests when the session time changes", async () => {
+    vi.mocked(sendMail).mockReset();
+    const event = await createEvent();
+    const rsvper = await createGuest({ email: "rsvper@test.example" });
+    const loc = await createLocation();
+    const session = await createSession(event.id, {
+      title: "Workshop",
+      locationIds: [loc.id],
+      startTime: new Date("2030-01-01T10:00:00.000Z"),
+      endTime: new Date("2030-01-01T11:00:00.000Z"),
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: rsvper.id,
+    });
+
+    const result = await adminUpdateSessionAction({
+      id: session.id,
+      title: "Workshop",
+      description: "",
+      startTime: "2030-01-01T12:00:00.000Z",
+      endTime: "2030-01-01T13:00:00.000Z",
+      capacity: 30,
+      adminManaged: false,
+      blocker: false,
+      closed: false,
+      hostIds: [],
+      locationIds: [loc.id],
+    });
+    expect(result.ok).toBe(true);
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("rsvper@test.example");
   });
 
   it("clears the time when startTime and endTime are null", async () => {

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -101,6 +101,29 @@ describe("adminCreateSessionAction", () => {
     expect(created.locations.map((l) => l.id)).toEqual([loc.id]);
   });
 
+  it("emails the hosts of a newly created session", async () => {
+    vi.mocked(sendMail).mockReset();
+    const event = await createEvent();
+    const cohost = await createGuest({ email: "cohost@test.example" });
+
+    const result = await adminCreateSessionAction({
+      eventId: event.id,
+      title: "Workshop",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 30,
+      adminManaged: false,
+      blocker: false,
+      closed: false,
+      hostIds: [cohost.id],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("cohost@test.example");
+  });
+
   it("creates an unscheduled session without hosts or locations", async () => {
     const event = await createEvent();
 
@@ -528,6 +551,30 @@ describe("adminUpdateSessionAction", () => {
     expect(updated?.endTime?.toISOString()).toBe("2030-01-01T11:00:00.000Z");
     expect(updated?.hosts.map((h) => h.id)).toEqual([h2.id]);
     expect(updated?.locations.map((l) => l.id)).toEqual([loc.id]);
+  });
+
+  it("emails newly added co-hosts", async () => {
+    vi.mocked(sendMail).mockReset();
+    const event = await createEvent();
+    const cohost = await createGuest({ email: "cohost@test.example" });
+    const session = await createSession(event.id, { title: "Workshop" });
+
+    const result = await adminUpdateSessionAction({
+      id: session.id,
+      title: "Workshop",
+      description: "",
+      startTime: null,
+      endTime: null,
+      capacity: 30,
+      adminManaged: false,
+      blocker: false,
+      closed: false,
+      hostIds: [cohost.id],
+      locationIds: [],
+    });
+    expect(result.ok).toBe(true);
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("cohost@test.example");
   });
 
   it("emails RSVP'd guests when the session time changes", async () => {

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -12,8 +18,8 @@ import { POST } from "@/app/api/delete-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
 
-function makeAddReq(payload: unknown): Request {
-  return new Request("http://test/api/add-session", {
+function makeAddReq(payload: unknown): NextRequest {
+  return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
   });

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -8,6 +8,7 @@ import {
   createSession,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 
 describe("guest profile repositories", () => {
   beforeAll(() => setupTestDb());
@@ -53,7 +54,10 @@ describe("guest profile repositories", () => {
       const { guests } = getRepositories();
       await createGuest({ name: "A", email: "case@test.example" });
       await expect(
-        guests.create({ name: "B", info: { email: "Case@Test.Example" } })
+        guests.create({
+          name: "B",
+          info: { email: "Case@Test.Example" },
+        })
       ).rejects.toThrow(/UNIQUE constraint failed/i);
     });
   });
@@ -67,6 +71,8 @@ describe("guest profile repositories", () => {
         name: "New Name",
         aboutMe: "I love unconferences.",
         avatarUrl: "/media/uploads/avatar.png",
+        pronouns: "they/them",
+        emailSettings: DEFAULT_EMAIL_SETTINGS,
       });
 
       expect(updated).toMatchObject({

--- a/tests/integration/mailer.test.tsx
+++ b/tests/integration/mailer.test.tsx
@@ -1,35 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
+import {
+  MAILPIT_API_URL,
+  getMessage,
+  searchBySubject,
+} from "../helpers/mailpit";
 
 // This suite runs only when MAILPIT_API_URL points at a mailpit instance (e.g.
 // http://localhost:8025 via `docker compose up mailpit`). Skips when
 // MAILPIT_API_URL is unset or empty; fails when it's set but mailpit is
 // unreachable.
-const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
-
-type MessageSummary = {
-  ID: string;
-  From: { Name: string; Address: string };
-  To: { Address: string }[];
-  Subject: string;
-};
-
-async function mailpitGet(path: string): Promise<unknown> {
-  const res = await fetch(new URL(path, MAILPIT_API_URL));
-  if (!res.ok) {
-    throw new Error(`Mailpit API ${path} returned ${res.status}`);
-  }
-  return res.json();
-}
-
-async function searchBySubject(subject: string): Promise<MessageSummary[]> {
-  const query = encodeURIComponent(`subject:"${subject}"`);
-  const result = (await mailpitGet(`/api/v1/search?query=${query}`)) as {
-    messages: MessageSummary[];
-  };
-  return result.messages;
-}
-
 describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
   beforeEach(() => {
     // Fix the sender rather than using the environment's SMTP_FROM, whose
@@ -76,10 +56,7 @@ describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
       expect.objectContaining({ Address: "recipient@test.example" }),
     ]);
 
-    const message = (await mailpitGet(`/api/v1/message/${summary.ID}`)) as {
-      Text: string;
-      HTML: string;
-    };
+    const message = await getMessage(summary.ID);
 
     // Check that both the html and the derived text parts arrive. This assumes
     // the HTML isn't formatted too much. For text, note that SMTP encodes

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import type { ReactElement } from "react";
 
 vi.mock("@/utils/mailer", () => ({
@@ -76,7 +84,10 @@ describe("notifySessionChanged", () => {
   beforeEach(() => {
     resetTestDb();
     vi.mocked(sendMail).mockReset();
+    vi.stubEnv("SITE_URL", "https://site.example");
   });
+
+  afterEach(() => vi.unstubAllEnvs());
 
   // React separates adjacent text nodes with `<!-- -->` comments in the
   // rendered html, which would break substring assertions.
@@ -106,7 +117,7 @@ describe("notifySessionChanged", () => {
   }
 
   it("emails RSVP'd guests the new and old time when the time changes", async () => {
-    const { session } = await setup();
+    const { event, session } = await setup();
     const after = await getRepositories().sessions.update(session.id, {
       startTime: new Date("2026-08-01T15:00:00Z"),
       endTime: new Date("2026-08-01T16:00:00Z"),
@@ -127,6 +138,38 @@ describe("notifySessionChanged", () => {
     expect(html).toContain("Room A");
     // The location did not change, so no old location is given.
     expect(html.match(/\(was /g)).toHaveLength(1);
+    // Links to the session, prefixed with SITE_URL.
+    expect(html).toContain(
+      `href="https://site.example/${event.slug}?viewSession=${session.id}"`
+    );
+  });
+
+  it("sends nothing when SITE_URL is not set (email is disabled then too)", async () => {
+    vi.stubEnv("SITE_URL", "");
+    const { session } = await setup();
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("does not throw, and sends nothing, when SITE_URL is invalid", async () => {
+    vi.stubEnv("SITE_URL", "not-a-valid-url");
+    const { session } = await setup();
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await expect(
+      notifySessionChanged({ before: session, after, changedById: null })
+    ).resolves.toBeUndefined();
+
+    expect(sendMail).not.toHaveBeenCalled();
   });
 
   it("emails hosts, addressing them as hosts", async () => {

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -23,7 +23,11 @@ import {
 import { getRepositories } from "@/db/container";
 import { render } from "@react-email/render";
 import { sendMail } from "@/utils/mailer";
-import { notifyGuest, notifySessionChanged } from "@/utils/notifications";
+import {
+  notifyCohostsAdded,
+  notifyGuest,
+  notifySessionChanged,
+} from "@/utils/notifications";
 
 const MESSAGE = {
   subject: "Session moved",
@@ -310,5 +314,139 @@ describe("notifySessionChanged", () => {
 
     expect(sendMail).toHaveBeenCalledOnce();
     expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("rsvper@test.example");
+  });
+
+  it("sends the change email to hosts added by the same change too", async () => {
+    const { session } = await setup();
+    const newHost = await createGuest({ email: "new-host@test.example" });
+    const after = await getRepositories().sessions.update(session.id, {
+      hostIds: [newHost.id],
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    const recipients = vi.mocked(sendMail).mock.calls.map((c) => c[0].to);
+    expect(recipients.sort()).toEqual([
+      "new-host@test.example",
+      "rsvper@test.example",
+    ]);
+  });
+});
+
+describe("notifyCohostsAdded", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+    vi.stubEnv("SITE_URL", "https://site.example");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function renderWithoutComments(body: ReactElement): Promise<string> {
+    return (await render(body)).replace(/<!--.*?-->/g, "");
+  }
+
+  // Same shape as the notifySessionChanged setup: a scheduled session in
+  // "Room A" with one RSVP'd guest, plus a guest just added as co-host.
+  async function setupWithCohost() {
+    const event = await createEvent({ phase: "scheduling" });
+    const roomA = await createLocation({ name: "Room A" });
+    const rsvper = await createGuest({ email: "rsvper@test.example" });
+    const cohost = await createGuest({ email: "cohost@test.example" });
+    const session = await createSession(event.id, {
+      title: "Fun Workshop",
+      description: "A *hands-on* session.",
+      locationIds: [roomA.id],
+      startTime: new Date("2026-08-01T10:00:00Z"),
+      endTime: new Date("2026-08-01T11:00:00Z"),
+      hostIds: [cohost.id],
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: rsvper.id,
+    });
+    return { event, cohost, session };
+  }
+
+  it("does not throw, and sends nothing, when SITE_URL is invalid", async () => {
+    vi.stubEnv("SITE_URL", "not-a-valid-url");
+    const { session } = await setupWithCohost();
+
+    await expect(
+      notifyCohostsAdded({ session, previousHostIds: [], changedById: null })
+    ).resolves.toBeUndefined();
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("emails newly added co-hosts the session details", async () => {
+    const { event, session } = await setupWithCohost();
+
+    await notifyCohostsAdded({
+      session,
+      previousHostIds: [],
+      changedById: null,
+    });
+
+    // Only the new co-host; RSVP'd guests are not involved.
+    expect(sendMail).toHaveBeenCalledOnce();
+    const message = vi.mocked(sendMail).mock.calls[0][0];
+    expect(message.to).toBe("cohost@test.example");
+    expect(message.subject).toContain("Fun Workshop");
+    const html = await renderWithoutComments(message.body);
+    expect(html).toContain("co-host");
+    expect(html).toContain("A <em>hands-on</em> session.");
+    expect(html).toContain("Saturday 1 August, 10:00–11:00");
+    expect(html).toContain("Room A");
+    expect(html).toContain(
+      `href="https://site.example/${event.slug}?viewSession=${session.id}"`
+    );
+  });
+
+  it("does not email guests who were hosts already", async () => {
+    const { cohost, session } = await setupWithCohost();
+
+    await notifyCohostsAdded({
+      session,
+      previousHostIds: [cohost.id],
+      changedById: null,
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("does not email a guest who added themselves", async () => {
+    const { cohost, session } = await setupWithCohost();
+
+    await notifyCohostsAdded({
+      session,
+      previousHostIds: [],
+      changedById: cohost.id,
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("skips guests who opted out of co-host emails", async () => {
+    const { session } = await setupWithCohost();
+    const optedOut = await createGuest({
+      email: "opted-out@test.example",
+      emailSettings: { rsvpChange: true, hostChange: true, cohostAdd: false },
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      hostIds: [optedOut.id],
+    });
+
+    await notifyCohostsAdded({
+      session: after,
+      previousHostIds: [],
+      changedById: null,
+    });
+
+    expect(sendMail).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -1,13 +1,21 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import type { ReactElement } from "react";
 
 vi.mock("@/utils/mailer", () => ({
   sendMail: vi.fn(),
 }));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
-import { createGuest } from "../helpers/factories";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { render } from "@react-email/render";
 import { sendMail } from "@/utils/mailer";
-import { notifyGuest } from "@/utils/notifications";
+import { notifyGuest, notifySessionChanged } from "@/utils/notifications";
 
 const MESSAGE = {
   subject: "Session moved",
@@ -59,5 +67,204 @@ describe("notifyGuest", () => {
       notifyGuest("does-not-exist", "rsvpChange", MESSAGE)
     ).resolves.toBeUndefined();
     expect(sendMail).not.toHaveBeenCalled();
+  });
+});
+
+describe("notifySessionChanged", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+  });
+
+  // React separates adjacent text nodes with `<!-- -->` comments in the
+  // rendered html, which would break substring assertions.
+  async function renderWithoutComments(body: ReactElement): Promise<string> {
+    return (await render(body)).replace(/<!--.*?-->/g, "");
+  }
+
+  // A scheduled session in "Room A", Saturday 1 August 10:00–11:00 UTC, with
+  // one RSVP'd guest.
+  async function setup() {
+    const event = await createEvent({ phase: "scheduling" });
+    const roomA = await createLocation({ name: "Room A" });
+    const roomB = await createLocation({ name: "Room B" });
+    const guest = await createGuest({ email: "rsvper@test.example" });
+    const session = await createSession(event.id, {
+      title: "Fun Workshop",
+      description: "A hands-on session.",
+      locationIds: [roomA.id],
+      startTime: new Date("2026-08-01T10:00:00Z"),
+      endTime: new Date("2026-08-01T11:00:00Z"),
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+    return { event, roomA, roomB, guest, session };
+  }
+
+  it("emails RSVP'd guests the new and old time when the time changes", async () => {
+    const { session } = await setup();
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    const message = vi.mocked(sendMail).mock.calls[0][0];
+    expect(message.to).toBe("rsvper@test.example");
+    expect(message.subject).toContain("Fun Workshop");
+    const html = await renderWithoutComments(message.body);
+    expect(html).toContain("Fun Workshop");
+    expect(html).toContain("A session you RSVP’d to");
+    expect(html).toContain("A hands-on session.");
+    expect(html).toContain("Saturday 1 August, 15:00–16:00");
+    expect(html).toContain("(was Saturday 1 August, 10:00–11:00)");
+    expect(html).toContain("Room A");
+    // The location did not change, so no old location is given.
+    expect(html.match(/\(was /g)).toHaveLength(1);
+  });
+
+  it("emails hosts, addressing them as hosts", async () => {
+    const { session } = await setup();
+    const host = await createGuest({ email: "host@test.example" });
+    const withHost = await getRepositories().sessions.update(session.id, {
+      hostIds: [host.id],
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: withHost, after, changedById: null });
+
+    expect(sendMail).toHaveBeenCalledTimes(2);
+    const messages = vi.mocked(sendMail).mock.calls.map((call) => call[0]);
+    const hostMessage = messages.find((m) => m.to === "host@test.example");
+    const rsvperMessage = messages.find((m) => m.to === "rsvper@test.example");
+    expect(hostMessage).toBeDefined();
+    expect(rsvperMessage).toBeDefined();
+    expect(await renderWithoutComments(hostMessage!.body)).toContain(
+      "A session you’re hosting"
+    );
+    expect(await renderWithoutComments(rsvperMessage!.body)).toContain(
+      "A session you RSVP’d to"
+    );
+  });
+
+  it("gates host emails on hostChange, not rsvpChange", async () => {
+    const { session } = await setup();
+    const host = await createGuest({
+      email: "host@test.example",
+      emailSettings: { rsvpChange: false, cohostAdd: true, hostChange: true },
+    });
+    const withHost = await getRepositories().sessions.update(session.id, {
+      hostIds: [host.id],
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: withHost, after, changedById: null });
+
+    // Host has rsvpChange off but hostChange on: they're still emailed.
+    const recipients = vi.mocked(sendMail).mock.calls.map((c) => c[0].to);
+    expect(recipients).toContain("host@test.example");
+  });
+
+  it("does not email a host who opted out of hostChange", async () => {
+    const { session } = await setup();
+    const host = await createGuest({
+      email: "host@test.example",
+      emailSettings: { rsvpChange: true, cohostAdd: true, hostChange: false },
+    });
+    const withHost = await getRepositories().sessions.update(session.id, {
+      hostIds: [host.id],
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: withHost, after, changedById: null });
+
+    const recipients = vi.mocked(sendMail).mock.calls.map((c) => c[0].to);
+    expect(recipients).not.toContain("host@test.example");
+  });
+
+  it("does not email the guest who made the change", async () => {
+    const { session } = await setup();
+    const host = await createGuest({ email: "host@test.example" });
+    const withHost = await getRepositories().sessions.update(session.id, {
+      hostIds: [host.id],
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({
+      before: withHost,
+      after,
+      changedById: host.id,
+    });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("rsvper@test.example");
+  });
+
+  it("emails the new and old location when only the location changes", async () => {
+    const { roomB, session } = await setup();
+    const after = await getRepositories().sessions.update(session.id, {
+      locationIds: [roomB.id],
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    const html = await renderWithoutComments(
+      vi.mocked(sendMail).mock.calls[0][0].body
+    );
+    expect(html).toContain("Room B");
+    expect(html).toContain("(was Room A)");
+    // The time did not change, so no old time is given.
+    expect(html.match(/\(was /g)).toHaveLength(1);
+  });
+
+  it("does not email when neither time nor location changed", async () => {
+    const { session } = await setup();
+    const after = await getRepositories().sessions.update(session.id, {
+      title: "Renamed Workshop",
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("skips guests who opted out of session change emails", async () => {
+    const { session } = await setup();
+    const optedOut = await createGuest({
+      email: "opted-out@test.example",
+      emailSettings: { rsvpChange: false, hostChange: true, cohostAdd: true },
+    });
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: optedOut.id,
+    });
+    const after = await getRepositories().sessions.update(session.id, {
+      startTime: new Date("2026-08-01T15:00:00Z"),
+      endTime: new Date("2026-08-01T16:00:00Z"),
+    });
+
+    await notifySessionChanged({ before: session, after, changedById: null });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("rsvper@test.example");
   });
 });

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { sendMail } from "@/utils/mailer";
+import { notifyGuest } from "@/utils/notifications";
+
+const MESSAGE = {
+  subject: "Session moved",
+  body: <p>Your session moved.</p>,
+};
+
+describe("notifyGuest", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+  });
+
+  it("sends the email when the guest has the setting on", async () => {
+    const guest = await createGuest({
+      email: "on@test.example",
+      emailSettings: { rsvpChange: true, hostChange: false, cohostAdd: false },
+    });
+    await notifyGuest(guest.id, "rsvpChange", MESSAGE);
+    expect(sendMail).toHaveBeenCalledExactlyOnceWith({
+      to: "on@test.example",
+      ...MESSAGE,
+    });
+  });
+
+  it("does not send when the guest has the setting off", async () => {
+    const guest = await createGuest({
+      emailSettings: { rsvpChange: false, hostChange: true, cohostAdd: true },
+    });
+    await notifyGuest(guest.id, "rsvpChange", MESSAGE);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("consults the specific setting, not the others", async () => {
+    const guest = await createGuest({
+      email: "cohost@test.example",
+      emailSettings: { rsvpChange: false, hostChange: false, cohostAdd: true },
+    });
+    await notifyGuest(guest.id, "cohostAdd", MESSAGE);
+    expect(sendMail).toHaveBeenCalledExactlyOnceWith({
+      to: "cohost@test.example",
+      ...MESSAGE,
+    });
+  });
+
+  it("does nothing for an unknown guest id", async () => {
+    await expect(
+      notifyGuest("does-not-exist", "rsvpChange", MESSAGE)
+    ).resolves.toBeUndefined();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -104,7 +104,7 @@ describe("notifySessionChanged", () => {
     const guest = await createGuest({ email: "rsvper@test.example" });
     const session = await createSession(event.id, {
       title: "Fun Workshop",
-      description: "A hands-on session.",
+      description: "A *hands-on* session.",
       locationIds: [roomA.id],
       startTime: new Date("2026-08-01T10:00:00Z"),
       endTime: new Date("2026-08-01T11:00:00Z"),
@@ -132,7 +132,8 @@ describe("notifySessionChanged", () => {
     const html = await renderWithoutComments(message.body);
     expect(html).toContain("Fun Workshop");
     expect(html).toContain("A session you RSVP’d to");
-    expect(html).toContain("A hands-on session.");
+    // The description is markdown, rendered to html.
+    expect(html).toContain("A <em>hands-on</em> session.");
     expect(html).toContain("Saturday 1 August, 15:00–16:00");
     expect(html).toContain("(was Saturday 1 August, 10:00–11:00)");
     expect(html).toContain("Room A");

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
 }));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
@@ -26,8 +31,11 @@ import { createProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
 // creation during the proposal *and* voting phases (the UI's "Add Proposal"
 // button is disabled only once scheduling starts).
 
-function makeReq(url: string, payload: unknown): Request {
-  return new Request(url, { method: "POST", body: JSON.stringify(payload) });
+function makeReq(url: string, payload: unknown): NextRequest {
+  return new NextRequest(url, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }
 
 async function voteOnProposalIn(phase: "proposal" | "voting" | "scheduling") {

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -27,6 +27,7 @@ vi.mock("next/cache", () => ({
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 import { updateProfileAction } from "@/app/actions/profile";
 import { createImageFile } from "@/tests/helpers/utils";
 import fs from "fs";
@@ -51,6 +52,23 @@ describe("updateProfileAction", () => {
     fs.rmSync(uploadsDir, { recursive: true, force: true });
   });
 
+  it("updates email settings for the current user", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set("user", guest.id);
+    const result = await updateProfileAction({
+      name: "Guest",
+      aboutMe: null,
+      emailSettings: { rsvpChange: false, hostChange: false, cohostAdd: true },
+    });
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated?.info.emailSettings).toEqual({
+      rsvpChange: false,
+      hostChange: false,
+      cohostAdd: true,
+    });
+  });
+
   it("updates name, pronouns and aboutMe for the current user", async () => {
     const guest = await createGuest({ name: "Old" });
     cookieJar.set("user", guest.id);
@@ -58,6 +76,7 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       pronouns: "they/them",
+      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -76,6 +95,7 @@ describe("updateProfileAction", () => {
       aboutMe: "Hello there",
       avatar: await createImageFile(256, 256, "avatar.png"),
       pronouns: "they/them",
+      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -98,6 +118,7 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       avatar: await createImageFile(512, 512, "avatar.png"),
+      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -118,6 +139,7 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       avatar: await createImageFile(128, 128, "avatar.png"),
+      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toMatchObject({ ok: false });
   });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+import { render } from "@react-email/render";
+import { sendMail } from "@/utils/mailer";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import {
   createEvent,
@@ -19,10 +27,17 @@ function makeAddReq(payload: unknown): Request {
   });
 }
 
-function makeUpdateReq(payload: unknown): Request {
-  return new Request("http://test/api/update-session", {
+function makeUpdateReq(
+  payload: unknown,
+  opts?: { editorGuestId?: string }
+): NextRequest {
+  return new NextRequest("http://test/api/update-session", {
     method: "POST",
     body: JSON.stringify(payload),
+    // The `user` cookie identifies the acting guest, like the site sets it.
+    headers: opts?.editorGuestId
+      ? { cookie: `user=${opts.editorGuestId}` }
+      : undefined,
   });
 }
 
@@ -65,7 +80,82 @@ async function createScheduledSession(
 
 describe("POST /api/update-session", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+  });
+
+  it("emails RSVP'd guests when the session time changes", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const rsvper = await createGuest({
+      email: "rsvper@test.example",
+      eventId: event.id,
+    });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day, {
+      startTimeMinutes: 10 * 60,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: id,
+      guestId: rsvper.id,
+    });
+
+    const res = await POST(
+      makeUpdateReq(
+        {
+          ...basePayload(host, location, day, { startTimeMinutes: 12 * 60 }),
+          id,
+        },
+        // The host makes the change, so only the RSVP'd guest is emailed.
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.ok).toBe(true);
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe("rsvper@test.example");
+  });
+
+  it("emails a guest promoted to host as a host, not as an attendee", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const rsvper = await createGuest({
+      email: "promoted@test.example",
+      eventId: event.id,
+    });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day, {
+      startTimeMinutes: 10 * 60,
+    });
+    await getRepositories().rsvps.create({
+      sessionId: id,
+      guestId: rsvper.id,
+    });
+
+    const res = await POST(
+      makeUpdateReq(
+        {
+          ...basePayload(host, location, day, {
+            startTimeMinutes: 12 * 60,
+            hosts: [host, rsvper],
+          }),
+          id,
+        },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.ok).toBe(true);
+    // Their RSVP was removed with the promotion, so the one email they get
+    // is the hosts' variant.
+    expect(sendMail).toHaveBeenCalledOnce();
+    const message = vi.mocked(sendMail).mock.calls[0][0];
+    expect(message.to).toBe("promoted@test.example");
+    const html = await render(message.body);
+    expect(html).toContain("hosting");
+    expect(html).not.toContain("RSVP’d to");
+  });
 
   it("changes time without conflict; re-fetched session reflects new time", async () => {
     const event = await createEvent({ phase: "scheduling" });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -20,8 +20,8 @@ import { POST } from "@/app/api/update-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
 
-function makeAddReq(payload: unknown): Request {
-  return new Request("http://test/api/add-session", {
+function makeAddReq(payload: unknown): NextRequest {
+  return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -101,6 +101,8 @@ describe("POST /api/update-session", () => {
       sessionId: id,
       guestId: rsvper.id,
     });
+    // Creating the event might have sent email, which we don't want to test.
+    vi.mocked(sendMail).mockClear();
 
     const res = await POST(
       makeUpdateReq(
@@ -133,6 +135,8 @@ describe("POST /api/update-session", () => {
       sessionId: id,
       guestId: rsvper.id,
     });
+    // Creating the event might have sent email, which we don't want to test.
+    vi.mocked(sendMail).mockClear();
 
     const res = await POST(
       makeUpdateReq(
@@ -147,14 +151,14 @@ describe("POST /api/update-session", () => {
       )
     );
     expect(res.ok).toBe(true);
-    // Their RSVP was removed with the promotion, so the one email they get
-    // is the hosts' variant.
-    expect(sendMail).toHaveBeenCalledOnce();
-    const message = vi.mocked(sendMail).mock.calls[0][0];
-    expect(message.to).toBe("promoted@test.example");
-    const html = await render(message.body);
-    expect(html).toContain("hosting");
-    expect(html).not.toContain("RSVP’d to");
+    // Their RSVP was removed with the promotion, so they are told as a
+    // co-host and as a host of a changed session — never as an attendee.
+    const messages = vi.mocked(sendMail).mock.calls.map((c) => c[0]);
+    expect(messages).toHaveLength(2);
+    for (const message of messages) {
+      expect(message.to).toBe("promoted@test.example");
+      expect(await render(message.body)).not.toContain("RSVP’d to");
+    }
   });
 
   it("changes time without conflict; re-fetched session reflects new time", async () => {

--- a/tests/unit/mailer.test.tsx
+++ b/tests/unit/mailer.test.tsx
@@ -138,6 +138,7 @@ describe("mailer", () => {
     resetMailer();
     vi.stubEnv("SMTP_URL", "smtp://localhost:1025");
     vi.stubEnv("SMTP_FROM", "SchellingBoard <noreply@test.example>");
+    vi.stubEnv("SITE_URL", "https://site.example");
     // Ensure individual SMTP_* variables from the developer's environment
     // don't leak into these tests.
     vi.stubEnv("SMTP_HOST", "");
@@ -158,6 +159,23 @@ describe("mailer", () => {
     it("throws when SMTP_FROM is set but SMTP_URL is not", () => {
       vi.stubEnv("SMTP_URL", "");
       expect(() => initMailer()).toThrow("must be set");
+    });
+
+    it("throws when SMTP is configured but SITE_URL is not", () => {
+      vi.stubEnv("SITE_URL", "");
+      expect(() => initMailer()).toThrow("SITE_URL");
+    });
+
+    it("throws on an invalid SITE_URL", () => {
+      vi.stubEnv("SITE_URL", "site.example");
+      expect(() => initMailer()).toThrow("SITE_URL");
+    });
+
+    it("does not require SITE_URL when SMTP is not configured", () => {
+      vi.stubEnv("SMTP_URL", "");
+      vi.stubEnv("SMTP_FROM", "");
+      vi.stubEnv("SITE_URL", "");
+      expect(() => initMailer()).not.toThrow();
     });
 
     it("creates the transport using SMTP_URL", () => {

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -3,6 +3,7 @@ import type SMTPTransport from "nodemailer/lib/smtp-transport";
 import TurndownService from "turndown";
 import { render } from "@react-email/render";
 import type { ReactElement } from "react";
+import { siteUrl } from "@/utils/site-url";
 
 const turndown = new TurndownService();
 
@@ -109,6 +110,12 @@ export function initMailer(): void {
   }
   if (!transportConfig) {
     throw new Error("SMTP_URL or SMTP_HOST must be set when SMTP_FROM is set");
+  }
+  // siteUrl() also throws here when SITE_URL is set but not a valid URL.
+  if (!siteUrl()) {
+    throw new Error(
+      "SITE_URL must be set when SMTP is configured, so emails can link back to the site"
+    );
   }
   g.__mailerState = {
     configured: true,

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -136,6 +136,13 @@ function getMailer(): Mailer | null {
   return state.configured ? state.mailer : null;
 }
 
+// What the factories in `emails/` return: everything an email needs except
+// the recipient.
+export type EmailMessage = {
+  subject: string;
+  body: ReactElement;
+};
+
 // Send an email. Requires `initMailer` to have been called first. If email
 // sending is disabled, logs a warning, with no way for the caller to tell.
 //
@@ -144,11 +151,9 @@ function getMailer(): Mailer | null {
 // rendered to html, and a plain-text version (markdown) is derived from that
 // and sent alongside. Links must be absolute; relative links are passed
 // through as-is, which mail clients can't resolve.
-export async function sendMail(options: {
-  to: string;
-  subject: string;
-  body: ReactElement;
-}): Promise<void> {
+export async function sendMail(
+  options: { to: string } & EmailMessage
+): Promise<void> {
   const mailer = getMailer();
   if (!mailer) {
     // Don't include details of the email, to avoid putting PII in logs.

--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -3,6 +3,21 @@ import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import type { Nodes, Parent } from "mdast";
 
+// Elements never rendered from user-provided markdown, shared by every
+// renderer (see app/(site)/markdown.tsx and emails/markdown.tsx). Images stay
+// disabled so viewers' IPs never hit arbitrary URLs; the table elements
+// don't degrade gracefully in the places descriptions appear.
+export const MARKDOWN_DISALLOWED_ELEMENTS = [
+  "img",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "input",
+];
+
 // unified + remark-parse (not the remark package): react-markdown already
 // pulls both in for its own parsing, so this reuses that pipeline instead of
 // adding a separate one.

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,6 +1,8 @@
+import { DateTime } from "luxon";
 import { getRepositories } from "@/db/container";
-import type { EmailSettings } from "@/db/repositories/interfaces";
+import type { EmailSettings, Session } from "@/db/repositories/interfaces";
 import { sendMail, type EmailMessage } from "@/utils/mailer";
+import { sessionChangedEmail } from "@/emails/session-changed";
 
 // Send `message` to the guest, iff they have opted in to emails for
 // `setting` (see EmailSettings).
@@ -16,4 +18,98 @@ export async function notifyGuest(
   const guest = await getRepositories().guests.findById(guestId);
   if (!guest || !guest.info.emailSettings[setting]) return;
   await sendMail({ to: guest.info.email, ...message });
+}
+
+async function tryNotifyGuest(
+  guestId: string,
+  setting: keyof EmailSettings,
+  message: EmailMessage
+): Promise<void> {
+  try {
+    await notifyGuest(guestId, setting, message);
+  } catch (err) {
+    console.error(`Failed to email guest ${guestId}:`, err);
+  }
+}
+
+// Email the session's hosts and RSVP'd guests (who have opted in) about the
+// session's time and/or location change, telling them the old value of
+// whatever changed. A no-op when neither changed. The guest who made the
+// change (`changedById`; null when unknown or not a guest, e.g. an admin) is
+// not told about their own edit.
+//
+// Never throws: a failed send is logged and must not break the session
+// update it trails, nor the sends to the other guests.
+export async function notifySessionChanged({
+  before,
+  after,
+  changedById,
+}: {
+  before: Session;
+  after: Session;
+  changedById: string | null;
+}): Promise<void> {
+  const timeChanged =
+    before.startTime?.getTime() !== after.startTime?.getTime() ||
+    before.endTime?.getTime() !== after.endTime?.getTime();
+  const locationChanged = !sameLocations(before.locations, after.locations);
+  if (!timeChanged && !locationChanged) return;
+
+  const { events, rsvps } = getRepositories();
+  const event = await events.findById(after.eventId);
+  if (!event) return;
+
+  const messageProps = {
+    title: after.title,
+    description: after.description,
+    newTime: formatSessionTime(after, event.timezone),
+    oldTime: timeChanged
+      ? formatSessionTime(before, event.timezone)
+      : undefined,
+    newLocation: formatLocations(after),
+    oldLocation: locationChanged ? formatLocations(before) : undefined,
+  };
+  const hostMessage = sessionChangedEmail({
+    ...messageProps,
+    recipient: "host",
+  });
+  const attendeeMessage = sessionChangedEmail({
+    ...messageProps,
+    recipient: "attendee",
+  });
+
+  // Guards against telling anyone twice (or the editor at all), should a
+  // guest ever be both host and RSVP'd.
+  const done = new Set(changedById === null ? [] : [changedById]);
+
+  for (const host of after.hosts) {
+    if (done.has(host.id)) continue;
+    done.add(host.id);
+    await tryNotifyGuest(host.id, "hostChange", hostMessage);
+  }
+  for (const rsvp of await rsvps.listBySession(after.id)) {
+    if (done.has(rsvp.guestId)) continue;
+    done.add(rsvp.guestId);
+    await tryNotifyGuest(rsvp.guestId, "rsvpChange", attendeeMessage);
+  }
+}
+
+function sameLocations(a: { id: string }[], b: { id: string }[]): boolean {
+  const aIds = new Set(a.map((l) => l.id));
+  const bIds = new Set(b.map((l) => l.id));
+  return aIds.symmetricDifference(bIds).size === 0;
+}
+
+function formatSessionTime(
+  session: { startTime?: Date; endTime?: Date },
+  timezone: string
+): string {
+  if (!session.startTime || !session.endTime) return "Unscheduled";
+  const start = DateTime.fromJSDate(session.startTime).setZone(timezone);
+  const end = DateTime.fromJSDate(session.endTime).setZone(timezone);
+  return `${start.toFormat("cccc d LLLL, HH:mm")}–${end.toFormat("HH:mm")}`;
+}
+
+function formatLocations(session: { locations: { name: string }[] }): string {
+  return session.locations.map((l) => l.name).join(", ") || "No location";
 }

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -2,6 +2,7 @@ import { DateTime } from "luxon";
 import { getRepositories } from "@/db/container";
 import type { EmailSettings, Session } from "@/db/repositories/interfaces";
 import { sendMail, type EmailMessage } from "@/utils/mailer";
+import { siteUrl } from "@/utils/site-url";
 import { sessionChangedEmail } from "@/emails/session-changed";
 
 // Send `message` to the guest, iff they have opted in to emails for
@@ -38,9 +39,22 @@ async function tryNotifyGuest(
 // change (`changedById`; null when unknown or not a guest, e.g. an admin) is
 // not told about their own edit.
 //
-// Never throws: a failed send is logged and must not break the session
-// update it trails, nor the sends to the other guests.
-export async function notifySessionChanged({
+// Never throws: any failure (including a bad SITE_URL, or a lookup error) is
+// logged and must not break the session update it trails, nor the sends to
+// the other guests.
+export async function notifySessionChanged(args: {
+  before: Session;
+  after: Session;
+  changedById: string | null;
+}): Promise<void> {
+  try {
+    await notifySessionChangedUnsafe(args);
+  } catch (err) {
+    console.error("Failed to send session-changed notifications:", err);
+  }
+}
+
+async function notifySessionChangedUnsafe({
   before,
   after,
   changedById,
@@ -59,7 +73,21 @@ export async function notifySessionChanged({
   const event = await events.findById(after.eventId);
   if (!event) return;
 
+  // No SITE_URL means SMTP is not configured either (initMailer enforces
+  // that), so no email could be sent anyway.
+  const base = siteUrl();
+  if (base === null) {
+    console.warn(
+      "SITE_URL is not set - not sending session change notifications"
+    );
+    return;
+  }
+  // Deep link to the session, same shape as modal-nav's
+  // viewSessionLinkFromElsewhere.
+  const sessionUrl = `${base}/${event.slug}?viewSession=${after.id}`;
+
   const messageProps = {
+    sessionUrl,
     title: after.title,
     description: after.description,
     newTime: formatSessionTime(after, event.timezone),

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -4,6 +4,7 @@ import type { EmailSettings, Session } from "@/db/repositories/interfaces";
 import { sendMail, type EmailMessage } from "@/utils/mailer";
 import { siteUrl } from "@/utils/site-url";
 import { sessionChangedEmail } from "@/emails/session-changed";
+import { cohostAddedEmail } from "@/emails/cohost-added";
 
 // Send `message` to the guest, iff they have opted in to emails for
 // `setting` (see EmailSettings).
@@ -82,12 +83,8 @@ async function notifySessionChangedUnsafe({
     );
     return;
   }
-  // Deep link to the session, same shape as modal-nav's
-  // viewSessionLinkFromElsewhere.
-  const sessionUrl = `${base}/${event.slug}?viewSession=${after.id}`;
-
   const messageProps = {
-    sessionUrl,
+    sessionUrl: sessionUrl(base, event.slug, after.id),
     title: after.title,
     description: after.description,
     newTime: formatSessionTime(after, event.timezone),
@@ -110,6 +107,10 @@ async function notifySessionChangedUnsafe({
   // guest ever be both host and RSVP'd.
   const done = new Set(changedById === null ? [] : [changedById]);
 
+  // We could exclude hosts who were already hosts before the change, since they
+  // also get an email for being added. But that email might not make it clear
+  // the session has changed, if they were previously RSVP'd; and they might
+  // have that email disabled but not this one.
   for (const host of after.hosts) {
     if (done.has(host.id)) continue;
     done.add(host.id);
@@ -120,6 +121,72 @@ async function notifySessionChangedUnsafe({
     done.add(rsvp.guestId);
     await tryNotifyGuest(rsvp.guestId, "rsvpChange", attendeeMessage);
   }
+}
+
+// Email the guests newly added as co-hosts of the session (who have opted
+// in). `previousHostIds` are the session's hosts from before the change —
+// empty for a freshly created session. The guest who made the change
+// (`changedById`; null when unknown or not a guest) isn't emailed about
+// adding themselves.
+//
+// Never throws: any failure (including a bad SITE_URL, or a lookup error) is
+// logged and must not break the change it trails, nor the sends to the other
+// guests.
+export async function notifyCohostsAdded(args: {
+  session: Session;
+  previousHostIds: string[];
+  changedById: string | null;
+}): Promise<void> {
+  try {
+    await notifyCohostsAddedUnsafe(args);
+  } catch (err) {
+    console.error("Failed to send co-host-added notifications:", err);
+  }
+}
+
+async function notifyCohostsAddedUnsafe({
+  session,
+  previousHostIds,
+  changedById,
+}: {
+  session: Session;
+  previousHostIds: string[];
+  changedById: string | null;
+}): Promise<void> {
+  const previous = new Set(previousHostIds);
+  const added = session.hosts.filter(
+    (h) => !previous.has(h.id) && h.id !== changedById
+  );
+  if (added.length === 0) return;
+
+  const event = await getRepositories().events.findById(session.eventId);
+  if (!event) return;
+
+  // No SITE_URL means SMTP is not configured either (initMailer enforces
+  // that), so no email could be sent anyway.
+  const base = siteUrl();
+  if (base === null) {
+    console.warn("SITE_URL is not set - not sending co-host notifications");
+    return;
+  }
+
+  const message = cohostAddedEmail({
+    title: session.title,
+    description: session.description,
+    time: formatSessionTime(session, event.timezone),
+    location: formatLocations(session),
+    sessionUrl: sessionUrl(base, event.slug, session.id),
+  });
+
+  for (const host of added) {
+    await tryNotifyGuest(host.id, "cohostAdd", message);
+  }
+}
+
+// Deep link to the session, same shape as modal-nav's
+// viewSessionLinkFromElsewhere.
+function sessionUrl(base: string, eventSlug: string, sessionId: string) {
+  return `${base}/${eventSlug}?viewSession=${sessionId}`;
 }
 
 function sameLocations(a: { id: string }[], b: { id: string }[]): boolean {

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,19 @@
+import { getRepositories } from "@/db/container";
+import type { EmailSettings } from "@/db/repositories/interfaces";
+import { sendMail, type EmailMessage } from "@/utils/mailer";
+
+// Send `message` to the guest, iff they have opted in to emails for
+// `setting` (see EmailSettings).
+//
+// An unknown guest id is a no-op rather than an error: notifications should be
+// sent after the triggering change is committed, by which time the guest may
+// have been deleted.
+export async function notifyGuest(
+  guestId: string,
+  setting: keyof EmailSettings,
+  message: EmailMessage
+): Promise<void> {
+  const guest = await getRepositories().guests.findById(guestId);
+  if (!guest || !guest.info.emailSettings[setting]) return;
+  await sendMail({ to: guest.info.email, ...message });
+}

--- a/utils/site-url.ts
+++ b/utils/site-url.ts
@@ -1,0 +1,13 @@
+// The site's public base URL (e.g. https://sessions.example.org), used where
+// a relative link won't do — most notably links back to the site in emails.
+//
+// Optional in general (null when unset), but initMailer requires it whenever
+// SMTP is configured, so email code can rely on it in practice.
+export function siteUrl(): string | null {
+  const url = process.env.SITE_URL;
+  if (!url) return null;
+  if (!URL.canParse(url)) {
+    throw new Error(`SITE_URL must be a valid absolute URL, got "${url}"`);
+  }
+  return url.replace(/\/+$/, "");
+}


### PR DESCRIPTION
You'll get an email if you're added as a cohost to an event, or if an event you're RSVP'd to or hosting changes time or location. You can opt out of emails on your profile page, opted in by default.

You now need a `SITE_URL` environment variable if you have email configured. It's optional otherwise.

There's an e2e test checking that we send those emails, and it also checks that all links in the emails are valid. I removed `test-e2e` from `make precommit` per https://github.com/LWCW-Europe/schellingboard/pull/519#issuecomment-4881420382; we don't want devs to be forced to run mailpit when they're not actively working with email.

A slightly awkward thing is that we parse the event description markdown into html, and then convert it back to markdown when we generate the text version of the email. I don't think that's a big deal.

<img width="759" height="379" alt="image" src="https://github.com/user-attachments/assets/5f6453bc-42cf-4ba1-8247-8a4234da364e" />

<img width="893" height="569" alt="image" src="https://github.com/user-attachments/assets/a909277f-49a5-48c6-90f4-be8f0878c71a" />

<img width="912" height="561" alt="image" src="https://github.com/user-attachments/assets/df77ec87-7726-47da-a671-d7e035005cfb" />


