### PR TITLE
feat: let mailpit's host ports be overridden per clone

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -12,4 +12,7 @@ SB_UPLOADS_DIR=./uploads-test/
 MAILPIT_API_URL=http://localhost:8025
 SMTP_URL=smtp://localhost:1025
 SMTP_FROM='Test <mailer-test@test.example>'
+
+# For e2e, playwright.config.ts always overwrites SITE_URL with the URL of the
+# server it starts on a free port of its own.
 SITE_URL=http://localhost:3000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Internal
 
 - **More seed locations**: dev seed data now includes 5 additional locations (reading room, boardroom, auditorium, courtyard, rooftop terrace) with photos, for a more realistic local dev environment
+- **Configurable mailpit ports**: mailpit's host ports can now be overridden with `MAILPIT_SMTP_PORT`/`MAILPIT_UI_PORT`, so multiple project instances (e.g. separate clones or workspaces) can run on one machine without port clashes. New `make mailpit` target starts it, reading these from `.env.dev.local`; CONTRIBUTING.md documents the recommended per-clone setup
 
 ## [3.0.0] - 2026-07-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,109 @@ Before committing or pushing, run:
 make precommit  # Format, lint, type check, and run tests
 ```
 
+## Running Multiple Instances
+
+Several clones or `jj` workspaces of this project on one machine compete for the
+same ports. The recommended pattern is to give each clone explicit, distinct
+ports in its two local env files, rather than leaning on defaults or automatic
+port selection — then nothing depends on which instance you happened to start
+first. Neither file is committed:
+
+| File              | Read by                      | Sets                                         |
+| ----------------- | ---------------------------- | -------------------------------------------- |
+| `.env.dev.local`  | `make dev`, `make mailpit`   | dev server port, mailpit's host ports, email |
+| `.env.test.local` | `make test`, `make test-e2e` | email (wins over `.env.test`)                |
+
+Start mailpit with `make mailpit` rather than `docker compose up mailpit`: on its
+own, compose reads only a file literally named `.env`, so the make target points
+it at `.env.dev.local` instead. That keeps each clone's ports in one place.
+
+### Example: two clones side by side
+
+Clone A in `~/src/sb-a` keeps the defaults:
+
+```bash
+# .env.dev.local
+DATABASE_URL=file:./data.db
+AUTH_SECRET=<openssl rand -base64 32>
+PORT=3000
+SITE_URL=http://localhost:3000
+COMPOSE_PROJECT_NAME=sb-a
+MAILPIT_SMTP_PORT=1025
+MAILPIT_UI_PORT=8025
+SMTP_FROM=dev@example.test
+SMTP_URL=smtp://localhost:1025
+```
+
+```bash
+# .env.test.local
+SMTP_URL=smtp://localhost:1025
+MAILPIT_API_URL=http://localhost:8025
+```
+
+Clone B in `~/src/sb-b` shifts every port by one:
+
+```bash
+# .env.dev.local
+DATABASE_URL=file:./data.db
+AUTH_SECRET=<openssl rand -base64 32>
+PORT=3001
+SITE_URL=http://localhost:3001
+COMPOSE_PROJECT_NAME=sb-b
+MAILPIT_SMTP_PORT=1026
+MAILPIT_UI_PORT=8026
+SMTP_FROM=dev@example.test
+SMTP_URL=smtp://localhost:1026
+```
+
+```bash
+# .env.test.local
+SMTP_URL=smtp://localhost:1026
+MAILPIT_API_URL=http://localhost:8026
+```
+
+Each clone can now run `make mailpit`, `make dev`, `make test`, and
+`make test-e2e` at the same time as the other. Not every line is always needed:
+`COMPOSE_PROJECT_NAME`, `MAILPIT_SMTP_PORT`, and `MAILPIT_UI_PORT` are consumed
+by `docker compose` rather than the app, and the `SMTP_*`/`SITE_URL` lines only
+matter if you want the dev server itself to send email — `PORT` alone is enough
+otherwise.
+
+### What each variable is for
+
+Mailpit publishes two host ports, and the two app-side variables that point at
+them are unrelated to each other — each tracks a different one:
+
+| Compose variable    | Default | Mailpit port for            | App-side variable to match |
+| ------------------- | ------- | --------------------------- | -------------------------- |
+| `MAILPIT_SMTP_PORT` | `1025`  | receiving mail over SMTP    | `SMTP_URL`                 |
+| `MAILPIT_UI_PORT`   | `8025`  | the web UI and its REST API | `MAILPIT_API_URL`          |
+
+- `SMTP_URL` (`utils/mailer.ts`) is how schellingboard **sends** mail: an
+  ordinary SMTP connection string, with mailpit merely one possible server
+  behind it.
+- `MAILPIT_API_URL` (`tests/helpers/mailpit.ts`) is how the **test suite** reads
+  mail back out of mailpit to assert on it. It is test-only and
+  mailpit-specific; the app itself never reads it.
+
+`PORT` is read by `next dev`. Without it a second `make dev` won't fail — it
+quietly retries the next free port (3001, 3002, …), which is easy to miss.
+`SITE_URL` must then agree with `PORT`, since it's the base URL emails use to
+link back to the site; a stale value sends readers to the _other_ instance.
+
+`COMPOSE_PROJECT_NAME` only matters when two clones share a directory name —
+compose derives the project from the directory, so `~/a/sb` and `~/b/sb` would
+otherwise fight over a single mailpit container. Setting it is cheap insurance.
+Note that mailpit is behind a compose profile, so a bare `docker compose down`
+won't stop it; use `docker compose --profile dev down` (or just Ctrl-C the
+foreground `make mailpit`).
+
+Some things need no attention: `DATABASE_URL` and `SB_UPLOADS_DIR` are relative
+paths, so each clone already gets its own database and uploads. E2E runs pick a
+free port per run and override `SITE_URL` to match (`playwright.config.ts`), so
+don't set `SITE_URL` in `.env.test.local` expecting it to apply — only `SMTP_URL`
+and `MAILPIT_API_URL` matter there. `make test` binds no port at all.
+
 ## Database Migrations
 
 `make dev-migrate-create` (`drizzle-kit generate`) diffs `db/schema.ts` against the latest
@@ -204,9 +307,11 @@ make test-e2e-headed     # Run E2E tests (headed, for local dev)
 
 **Warning**: E2E tests reset the test database before each run. Do not run against production data.
 
-By default, `make test` tests that we can successfully send email to a local [mailpit](https://mailpit.axllent.org/) (start it with `docker compose up mailpit`). You can skip that test by setting `MAILPIT_API_URL` to blank in `.env.test.local`.
+By default, `make test` tests that we can successfully send email to a local [mailpit](https://mailpit.axllent.org/) (start it with `make mailpit`). You can skip that test by setting `MAILPIT_API_URL` to blank in `.env.test.local`.
 
 Some e2e tests (`make test-e2e`) also require mailpit. These ones fail if it's unreachable.
+
+Running another clone or workspace of this project alongside this one? See [Running Multiple Instances](#running-multiple-instances) for the ports that have to be kept apart.
 
 Install Playwright browsers before first use:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev build start lint typecheck lint-watch test test-unit test-integration test-watch test-coverage test-e2e test-e2e-headed format format-check precommit dev-migrate-up dev-migrate-status dev-migrate-create dev-db-seed install install-playwright clean clean-all docker-build check-and-format dev-db-reset test-e2e-ci
+.PHONY: help dev mailpit build start lint typecheck lint-watch test test-unit test-integration test-watch test-coverage test-e2e test-e2e-headed format format-check precommit dev-migrate-up dev-migrate-status dev-migrate-create dev-db-seed install install-playwright clean clean-all docker-build check-and-format dev-db-reset test-e2e-ci
 
 SHELL := /usr/bin/env bash
 
@@ -6,6 +6,7 @@ help:
 	@printf "Available commands:\n"
 	@printf "\nDevelopment:\n"
 	@printf "  %-28s %s\n" "make dev"                "Start development server"
+	@printf "  %-28s %s\n" "make mailpit"            "Start local mail server (for email in dev and tests)"
 	@printf "  %-28s %s\n" "make precommit"          "Format, lint, typecheck, and run all tests (incl. e2e)"
 	@printf "\nBuilding:\n"
 	@printf "  %-28s %s\n" "make build"              "Build for production"
@@ -46,6 +47,13 @@ install-playwright: install
 
 dev: dev-migrate-up install
 	bun set-env.ts dev bun x next dev
+
+# `docker compose` only auto-reads `.env`, so point it at `.env.dev.local`
+# instead — that way one file per clone carries MAILPIT_SMTP_PORT/MAILPIT_UI_PORT
+# (and COMPOSE_PROJECT_NAME), letting several clones run mailpit side by side.
+# The flag is conditional because compose errors out on a missing --env-file.
+mailpit:
+	docker compose $(if $(wildcard .env.dev.local),--env-file .env.dev.local,) up mailpit
 
 build: install
 	bun x next build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,15 @@ services:
   # We give it a profile[2] so that plain `docker compose up` doesn't start it.
   # You can do either
   #
+  #     make mailpit                     # only starts mailpit (preferred)
   #     docker compose --profile dev up  # starts `app` too
-  #     docker compose up mailpit        # only starts mailpit
+  #
+  # MAILPIT_SMTP_PORT/MAILPIT_UI_PORT let you run multiple instances of this
+  # project (e.g. separate clones or workspaces) on the same machine without
+  # port clashes. Not relevant for production. `make mailpit` is preferred over
+  # `docker compose up mailpit` because it feeds compose the per-clone values
+  # from `.env.dev.local`, which compose does not read on its own. See
+  # CONTRIBUTING.md#running-multiple-instances.
   #
   # [1]: https://mailpit.axllent.org/
   # [2]: https://docs.docker.com/compose/how-tos/profiles/
@@ -47,8 +54,8 @@ services:
     profiles:
       - dev
     ports:
-      - "1025:1025" # SMTP
-      - "8025:8025" # web UI
+      - "${MAILPIT_SMTP_PORT:-1025}:1025" # SMTP
+      - "${MAILPIT_UI_PORT:-8025}:8025" # web UI
 
 volumes:
   data:

--- a/tests/e2e/update-session.spec.ts
+++ b/tests/e2e/update-session.spec.ts
@@ -33,7 +33,7 @@ test("updating a session emails the RSVP'd guest and the added co-host", async (
 }) => {
   expect(
     MAILPIT_API_URL,
-    "MAILPIT_API_URL must be set: this test needs Mailpit (docker compose up mailpit) and fails rather than skips without it"
+    "MAILPIT_API_URL must be set: this test needs Mailpit (make mailpit) and fails rather than skips without it"
   ).toBeTruthy();
 
   await login(page);

--- a/tests/helpers/mailpit.ts
+++ b/tests/helpers/mailpit.ts
@@ -1,5 +1,5 @@
-// Talking to Mailpit's API (docker compose up mailpit), for tests that check
-// real email delivery.
+// Talking to Mailpit's API (make mailpit), for tests that check real email
+// delivery.
 export const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
 
 export type MessageSummary = {


### PR DESCRIPTION
This is a stacked PR[^1]. Only review commit [65e6894](https://github.com/LWCW-Europe/schellingboard/pull/618/commits/65e68940a1d3418dc4d597b2aea8d33a7ec97ab6).

PRs:
* #620
* ➡️ #618 (this PR, base of the stack — can be merged first)

---

## Description

Hardcoded 1025/8025 meant only one clone or workspace could run mailpit,
so parallel instances on one machine clashed. MAILPIT_SMTP_PORT and
MAILPIT_UI_PORT now override them.

Compose only auto-reads a file named .env, which would mean yet another
env file per clone; `make mailpit` feeds it .env.dev.local instead, so a
clone's ports live in the file it already has.

[^1]: A stacked PR is a pull request that depends on other pull requests. The current PR depends on the ones listed below it and MUST NOT be merged before they are merged. The PRs listed above the current one in turn depend on it and won't be merged until the current one is. Learn more about [why](https://github.com/omarkohl/jip/blob/main/docs/why.md) and [how to review](https://github.com/omarkohl/jip/blob/main/docs/reviewing.md).


<!-- jip:pushed-commit=65e68940a1d3418dc4d597b2aea8d33a7ec97ab6 -->