### PR TITLE
chore: ignore a local .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log*
 
 # local env files
 .env*.local
+# not used by the dev setup, but `.env.docker.example` is meant to be copied
+# here as `.env`, and it holds secrets
+/.env
 
 # vercel
 .vercel


### PR DESCRIPTION
.env*.local doesn't cover it, and the hosting docs tell people to copy
.env.docker.example to .env, which carries AUTH_SECRET and passwords.

<!-- jip:pushed-commit=5727831a3ae820c919e74eb254c7fa09ab420b30 -->