### PR TITLE
test: make email tests opt-in locally, mandatory in CI

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,10 +8,12 @@ AUTH_SECRET=test-only-do-not-use-in-production-7f4c8e2a1b9d6f3e
 DATABASE_URL=file:./data.test.db
 SB_UPLOADS_DIR=./uploads-test/
 
-# To skip tests that send emails, set these to blank in .env.test.local.
-MAILPIT_API_URL=http://localhost:8025
-SMTP_URL=smtp://localhost:1025
-SMTP_FROM='Test <mailer-test@test.example>'
+# Email tests are opt-in: they need Mailpit running (make mailpit) and these
+# variables set in .env.test.local, otherwise they are skipped. See
+# CONTRIBUTING.md § Running tests. Typical values:
+#   MAILPIT_API_URL=http://localhost:8025
+#   SMTP_URL=smtp://localhost:1025
+#   SMTP_FROM='Test <mailer-test@test.example>'
 
 # For e2e, playwright.config.ts always overwrites SITE_URL with the URL of the
 # server it starts on a free port of its own.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # Email tests are opt-in via these vars (unset means skip — see
+    # CONTRIBUTING.md § Running tests), but CI must always run them: they
+    # fail loudly here if the vars are missing, rather than silently skip.
+    env:
+      MAILPIT_API_URL: http://localhost:8025
+      SMTP_URL: smtp://localhost:1025
+      SMTP_FROM: Test <mailer-test@test.example>
+
     services:
       # The mailer integration test sends real email to mailpit (see
       # CONTRIBUTING.md § Running tests). Same pinned image as
@@ -107,6 +115,14 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
+
+    # Email tests are opt-in via these vars (unset means skip — see
+    # CONTRIBUTING.md § Running tests), but CI must always run them: they
+    # fail loudly here if the vars are missing, rather than silently skip.
+    env:
+      MAILPIT_API_URL: http://localhost:8025
+      SMTP_URL: smtp://localhost:1025
+      SMTP_FROM: Test <mailer-test@test.example>
 
     services:
       # e2e tests send real email to mailpit (see CONTRIBUTING.md § Running

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **More seed locations**: dev seed data now includes 5 additional locations (reading room, boardroom, auditorium, courtyard, rooftop terrace) with photos, for a more realistic local dev environment
 - **Configurable mailpit ports**: mailpit's host ports can now be overridden with `MAILPIT_SMTP_PORT`/`MAILPIT_UI_PORT`, so multiple project instances (e.g. separate clones or workspaces) can run on one machine without port clashes. New `make mailpit` target starts it, reading these from `.env.dev.local`; CONTRIBUTING.md documents the recommended per-clone setup
+- **Email tests are opt-in locally**: tests that need mailpit are skipped (and reported as skipped) unless the mail variables are set in `.env.test.local`, so a fresh checkout passes without Docker. CI sets the variables explicitly and the tests fail there if they go missing, so they can never be silently skipped in CI. `make precommit` now includes the e2e tests
 
 ## [3.0.0] - 2026-07-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ make format   # Format code
 Before committing or pushing, run:
 
 ```bash
-make precommit  # Format, lint, type check, and run tests
+make precommit  # Format, lint, type check, and run all tests (incl. e2e)
 ```
 
 ## Running Multiple Instances
@@ -112,10 +112,10 @@ ports in its two local env files, rather than leaning on defaults or automatic
 port selection — then nothing depends on which instance you happened to start
 first. Neither file is committed:
 
-| File              | Read by                      | Sets                                         |
-| ----------------- | ---------------------------- | -------------------------------------------- |
-| `.env.dev.local`  | `make dev`, `make mailpit`   | dev server port, mailpit's host ports, email |
-| `.env.test.local` | `make test`, `make test-e2e` | email (wins over `.env.test`)                |
+| File              | Read by                      | Sets                                                |
+| ----------------- | ---------------------------- | --------------------------------------------------- |
+| `.env.dev.local`  | `make dev`, `make mailpit`   | dev server port, mailpit's host ports, email        |
+| `.env.test.local` | `make test`, `make test-e2e` | email (opt-in, see [Running tests](#running-tests)) |
 
 Start mailpit with `make mailpit` rather than `docker compose up mailpit`: on its
 own, compose reads only a file literally named `.env`, so the make target points
@@ -142,6 +142,7 @@ SMTP_URL=smtp://localhost:1025
 # .env.test.local
 SMTP_URL=smtp://localhost:1025
 MAILPIT_API_URL=http://localhost:8025
+SMTP_FROM='Test <mailer-test@test.example>'
 ```
 
 Clone B in `~/src/sb-b` shifts every port by one:
@@ -163,6 +164,7 @@ SMTP_URL=smtp://localhost:1026
 # .env.test.local
 SMTP_URL=smtp://localhost:1026
 MAILPIT_API_URL=http://localhost:8026
+SMTP_FROM='Test <mailer-test@test.example>'
 ```
 
 Each clone can now run `make mailpit`, `make dev`, `make test`, and
@@ -307,9 +309,22 @@ make test-e2e-headed     # Run E2E tests (headed, for local dev)
 
 **Warning**: E2E tests reset the test database before each run. Do not run against production data.
 
-By default, `make test` tests that we can successfully send email to a local [mailpit](https://mailpit.axllent.org/) (start it with `make mailpit`). You can skip that test by setting `MAILPIT_API_URL` to blank in `.env.test.local`.
+Tests that send real email (in `make test` and `make test-e2e`) are opt-in:
+they need a local [mailpit](https://mailpit.axllent.org/) (start it with
+`make mailpit`) and the mail variables set in `.env.test.local`:
 
-Some e2e tests (`make test-e2e`) also require mailpit. These ones fail if it's unreachable.
+```bash
+# .env.test.local
+MAILPIT_API_URL=http://localhost:8025
+SMTP_URL=smtp://localhost:1025
+SMTP_FROM='Test <mailer-test@test.example>'
+```
+
+When these are unset (the default on a fresh checkout), the email tests are
+reported as skipped; when they are set but mailpit is unreachable, the tests
+fail. CI always sets them (in `.github/workflows/ci.yml`, alongside a mailpit
+service container) and the tests fail there if the variables go missing, so
+they can never be silently skipped in CI.
 
 Running another clone or workspace of this project alongside this one? See [Running Multiple Instances](#running-multiple-instances) for the ports that have to be kept apart.
 

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,7 @@ format: install
 format-check: install
 	bun x prettier --check .
 
-# We don't run test-e2e here, because it fails if mailpit isn't running and we
-# don't want to require devs to run it.
-precommit: format lint typecheck test-coverage
+precommit: format lint typecheck test-coverage test-e2e
 
 clean:
 	rm -rf .next

--- a/tests/e2e/update-session.spec.ts
+++ b/tests/e2e/update-session.spec.ts
@@ -3,9 +3,9 @@ import { test, expect } from "./helpers/fixtures";
 import { login } from "./helpers/auth";
 import { selectUser } from "./helpers/user";
 import {
-  MAILPIT_API_URL,
   getMessage,
   searchBySubject,
+  skipWithoutMailpit,
 } from "../helpers/mailpit";
 
 // Form idioms shared with scheduling.spec.ts: the form's labels are not wired
@@ -27,10 +27,10 @@ const dayRadios = (page: Page) =>
 test("updating a session emails the RSVP'd guest and the added co-host", async ({
   page,
 }) => {
-  expect(
-    MAILPIT_API_URL,
-    "MAILPIT_API_URL must be set: this test needs Mailpit (make mailpit) and fails rather than skips without it"
-  ).toBeTruthy();
+  test.skip(
+    skipWithoutMailpit(),
+    "mail env vars unset — start Mailpit (make mailpit) and set them in .env.test.local to run this test (see CONTRIBUTING.md § Running tests)"
+  );
 
   await login(page);
   // The title doubles as the unique token for finding this test's emails

--- a/tests/helpers/mailpit.ts
+++ b/tests/helpers/mailpit.ts
@@ -2,6 +2,19 @@
 // delivery.
 export const MAILPIT_API_URL = process.env.MAILPIT_API_URL ?? "";
 
+// Skip-condition for mail tests. Locally they are opt-in: unset mail vars mean
+// skip, so a fresh checkout passes without Mailpit. In CI they must never be
+// silently skipped, so a missing MAILPIT_API_URL throws instead.
+export function skipWithoutMailpit(): boolean {
+  if (MAILPIT_API_URL) return false;
+  if (process.env.CI) {
+    throw new Error(
+      "MAILPIT_API_URL is unset in CI — mail tests must always run there. Check the mailpit service and env vars in .github/workflows/ci.yml."
+    );
+  }
+  return true;
+}
+
 export type MessageSummary = {
   ID: string;
   From: { Name: string; Address: string };

--- a/tests/integration/mailer.test.tsx
+++ b/tests/integration/mailer.test.tsx
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initMailer, resetMailer, sendMail } from "@/utils/mailer";
 import {
-  MAILPIT_API_URL,
   getMessage,
   searchBySubject,
+  skipWithoutMailpit,
 } from "../helpers/mailpit";
 
-// This suite runs only when MAILPIT_API_URL points at a mailpit instance (e.g.
-// http://localhost:8025 via `docker compose up mailpit`). Skips when
-// MAILPIT_API_URL is unset or empty; fails when it's set but mailpit is
-// unreachable.
-describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
+// This suite runs only when MAILPIT_API_URL points at a mailpit instance
+// (start one with `make mailpit`, see CONTRIBUTING.md § Running tests). Skips
+// when MAILPIT_API_URL is unset (throws instead in CI); fails when it's set
+// but mailpit is unreachable.
+describe.skipIf(skipWithoutMailpit())("sendMail via mailpit", () => {
   beforeEach(() => {
     // Fix the sender rather than using the environment's SMTP_FROM, whose
     // format (bare address or `Name <address>`) the assertions would
@@ -18,9 +18,6 @@ describe.skipIf(!MAILPIT_API_URL)("sendMail via mailpit", () => {
     vi.stubEnv("SMTP_FROM", "Test Sender <sender@test.example>");
     resetMailer();
     initMailer();
-    console.warn(
-      "This test fails if you don't have Mailpit running. If you want to skip the test instead of running Mailpit, set `MAILPIT_API_URL=''`."
-    );
   });
 
   afterEach(() => vi.unstubAllEnvs());


### PR DESCRIPTION
A fresh checkout failed `make test`/`make test-e2e` unless mailpit was running.
This is a bad experience for (new) developers who checkout out the repository
because it immediately makes them wonder what they did wrong and forces them to
fix one thing when they wanted to do something else.

Mail env vars now default to unset (skip, reported as such); CI sets them
explicitly and the tests fail loudly there if they go missing, so they can
never be silently skipped.

This also lets `make precommit` include e2e.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=d435a206f30acf81c6bf36951a41289fd7c97563 -->