### PR TITLE
feat: header user menu and separate settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **Email notifications**: attendees are emailed when a session they've RSVP'd to changes time or location, hosts are emailed when a session they're hosting changes time or location, and guests are emailed when they're added as a co-host of a session. Each notification can be turned on or off individually from the profile page (requires SMTP and `SITE_URL` to be configured)
+- **Email notifications**: attendees are emailed when a session they've RSVP'd to changes time or location, hosts are emailed when a session they're hosting changes time or location, and guests are emailed when they're added as a co-host of a session. Each notification can be turned on or off individually from the new settings page (requires SMTP and `SITE_URL` to be configured)
+- **Profile and settings in the header**: once attendees pick their name, the name chip in the header opens a menu with quick links to their own profile, profile editing, and a new Settings page
 - **Richer attendee profiles**: attendees can now share where they're based, the languages they speak, contact details (email, phone, WhatsApp, Signal, Telegram, Discord, website, or anything else), and conversation starters — answers to prompts like "Ask me about", "Looking for", and "Offering", with a button that suggests more playful prompts to pick from
 - **Smarter attendee search**: searching the attendees page now looks through whole profiles (name, languages, location, bio, and prompt answers) and shows the best matches first — searching "Italian" finds Italian speakers before someone who merely mentions Italian food
 
 ### Changed
 
+- **Settings separated from the public profile**: email notification preferences moved from the profile edit page to the dedicated Settings page, so private preferences are clearly apart from what other attendees can see
 - **Your name is always visible**: the attendee you're acting as now shows as a chip in the header on every page — proposals, voting, and schedule — so it's always clear who "you" are, and you can switch attendee from there (handy for a shared device)
 - **Attendee list shows location, not bio**: rows on the attendees page now show each person's pronouns and where they're based instead of a preview of their bio
 - **Smoother schedule scrolling**: the grid view now has a single scroll area instead of nested scrollbars, and wide schedules can be dragged sideways with the mouse. The view controls (Grid, Text, RSVP'd) sit on one bar alongside an "Event details" popup and a "Proposals" link; the bar scrolls away with the schedule while the room headers stay pinned. The redundant schedule title is gone, since the header already shows the current event

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/navigation";
 import { Input } from "@/app/input";
 import { updateProfileAction } from "@/app/actions/profile";
 import { Avatar } from "../avatar";
-import type { EmailSettings, Guest } from "@/db/repositories/interfaces";
+import type { Guest } from "@/db/repositories/interfaces";
 import { CONTACT_TYPES } from "@/db/repositories/interfaces";
 import { resizeImage } from "@/utils/images-client";
 import clsx from "clsx";
@@ -80,13 +80,7 @@ function seedPrompts(saved: Guest["prompts"]) {
   ];
 }
 
-export function ProfileForm({
-  guest,
-  emailSettings,
-}: {
-  guest: Guest;
-  emailSettings: EmailSettings;
-}) {
+export function ProfileForm({ guest }: { guest: Guest }) {
   const router = useRouter();
   const form = useForm({
     defaultValues: {
@@ -101,7 +95,6 @@ export function ProfileForm({
         label: c.label ?? "",
         value: c.value,
       })),
-      emailSettings,
     },
     resolver: zodResolver(profileFormSchema),
   });
@@ -238,6 +231,17 @@ export function ProfileForm({
         Back to attendees
       </Link>
       <h1 className="text-2xl font-bold">Edit profile</h1>
+      <p className="text-sm text-gray-500">
+        Everything here is shown on your public profile. Email notifications and
+        other private preferences live in{" "}
+        <Link
+          href="/settings"
+          className="text-rose-500 hover:text-rose-600 underline"
+        >
+          Settings
+        </Link>
+        .
+      </p>
 
       <canvas ref={canvas} hidden />
 
@@ -549,31 +553,6 @@ export function ProfileForm({
               form.formState.errors.contacts?.message}
           </span>
         </DisclosureSection>
-
-        <fieldset className="flex flex-col gap-2">
-          <legend className="font-medium mb-1">Email me when…</legend>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              {...form.register("emailSettings.rsvpChange")}
-            />
-            a session I&rsquo;ve RSVP&rsquo;d to changes time or location
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              {...form.register("emailSettings.hostChange")}
-            />
-            a session I&rsquo;m hosting changes time or location
-          </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              {...form.register("emailSettings.cohostAdd")}
-            />
-            someone adds me as a session co-host
-          </label>
-        </fieldset>
 
         {form.formState.errors.root && (
           <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">

--- a/app/(site)/header-user-select.tsx
+++ b/app/(site)/header-user-select.tsx
@@ -1,48 +1,129 @@
 "use client";
 import { useContext, useState } from "react";
 import clsx from "clsx";
-import { UserCircleIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  MenuSeparator,
+} from "@headlessui/react";
+import { ChevronDownIcon, UserCircleIcon } from "@heroicons/react/24/outline";
 import type { Guest } from "@/db/repositories/interfaces";
 import { UserSelect } from "./user-select";
 import { Modal } from "./modals";
 import { UserContext } from "./context";
 
 // The current identity lives in the header so it is always visible who "I" am.
-// The chip shows the selected name (or a prompt to pick one); switching is
-// possible but intentionally gated behind a modal so it isn't encouraged —
-// the only real use case is a shared device.
+// Once a name is selected the chip opens a menu leading to the user's own
+// profile, profile editing, and settings; switching names is possible but
+// tucked behind a menu entry so it isn't encouraged — the only real use case
+// is a shared device. Without a name, the chip prompts a selection directly.
 export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
   const { user: currentUser } = useContext(UserContext);
   const [open, setOpen] = useState(false);
-  const currentName = guests.find((g) => g.id === currentUser)?.name;
+  const currentGuest = guests.find((g) => g.id === currentUser);
+
+  const chipClasses =
+    "flex min-w-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-400";
+
+  const selectModal = (
+    <Modal open={open} setOpen={setOpen}>
+      <label htmlFor="user-selection" className="text-gray-500">
+        My name is:
+      </label>
+      <UserSelect guests={guests} onSelect={() => setOpen(false)} />
+    </Modal>
+  );
+
+  if (!currentGuest) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          // aria-label always starts with "Your name" so it's a stable target
+          // regardless of who is selected.
+          aria-label="Your name"
+          className={clsx(
+            chipClasses,
+            // No name set: gently draw attention to prompt a selection.
+            "bg-rose-50 text-rose-500 hover:bg-rose-100"
+          )}
+        >
+          <UserCircleIcon className="h-5 w-5 shrink-0 stroke-2" />
+          <span className="max-w-[40vw] truncate sm:max-w-[12rem]">
+            Select your name
+          </span>
+        </button>
+        {selectModal}
+      </>
+    );
+  }
+
+  const itemClasses = (focus: boolean) =>
+    clsx(
+      "block w-full text-left px-4 py-2 text-sm",
+      focus ? "bg-gray-100 text-gray-900" : "text-gray-700"
+    );
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        // aria-label always starts with "Your name" so it's a stable target
-        // regardless of who is selected.
-        aria-label={currentName ? `Your name: ${currentName}` : "Your name"}
-        className={clsx(
-          "flex min-w-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-400",
-          currentName
-            ? "text-gray-600 hover:bg-gray-100"
-            : // No name set: gently draw attention to prompt a selection.
-              "bg-rose-50 text-rose-500 hover:bg-rose-100"
-        )}
-      >
-        <UserCircleIcon className="h-5 w-5 shrink-0 stroke-2" />
-        <span className="max-w-[40vw] truncate sm:max-w-[12rem]">
-          {currentName ?? "Select your name"}
-        </span>
-      </button>
-      <Modal open={open} setOpen={setOpen}>
-        <label htmlFor="user-selection" className="text-gray-500">
-          My name is:
-        </label>
-        <UserSelect guests={guests} onSelect={() => setOpen(false)} />
-      </Modal>
+      <Menu>
+        <MenuButton
+          aria-label={`Your name: ${currentGuest.name}`}
+          className={clsx(chipClasses, "text-gray-600 hover:bg-gray-100")}
+        >
+          <UserCircleIcon className="h-5 w-5 shrink-0 stroke-2" />
+          <span className="max-w-[40vw] truncate sm:max-w-[12rem]">
+            {currentGuest.name}
+          </span>
+          <ChevronDownIcon className="h-4 w-4 shrink-0 stroke-2" />
+        </MenuButton>
+        <MenuItems
+          anchor="bottom end"
+          className="z-40 mt-1 w-48 rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none"
+        >
+          <MenuItem>
+            {({ focus }) => (
+              <Link
+                href={`/guests/${currentGuest.id}`}
+                className={itemClasses(focus)}
+              >
+                My profile
+              </Link>
+            )}
+          </MenuItem>
+          <MenuItem>
+            {({ focus }) => (
+              <Link href="/guests/edit" className={itemClasses(focus)}>
+                Edit profile
+              </Link>
+            )}
+          </MenuItem>
+          <MenuItem>
+            {({ focus }) => (
+              <Link href="/settings" className={itemClasses(focus)}>
+                Settings
+              </Link>
+            )}
+          </MenuItem>
+          <MenuSeparator className="my-1 h-px bg-gray-100" />
+          <MenuItem>
+            {({ focus }) => (
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                className={itemClasses(focus)}
+              >
+                Switch name
+              </button>
+            )}
+          </MenuItem>
+        </MenuItems>
+      </Menu>
+      {selectModal}
     </>
   );
 }

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { sanitizeGuest } from "@/utils/guests";
-import { ProfileForm } from "./profile-form";
+import { SettingsForm } from "./settings-form";
 
-export default async function EditProfilePage() {
+export default async function SettingsPage() {
   const cookieStore = await cookies();
   const currentUser = cookieStore.get("user")?.value;
 
@@ -12,9 +11,9 @@ export default async function EditProfilePage() {
     return (
       <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
         <p className="text-gray-700">
-          You need to select who you are before editing your profile. Pick your
-          name via the &ldquo;Select your name&rdquo; chip in the header at the
-          top of the page.
+          You need to select who you are before changing your settings. Pick
+          your name via the &ldquo;Select your name&rdquo; chip in the header at
+          the top of the page.
         </p>
         <Link
           href="/guests"
@@ -34,7 +33,7 @@ export default async function EditProfilePage() {
     );
   }
 
-  // Strip private info (email, email settings) before handing the guest to a
-  // client component; those live on the settings page, not here.
-  return <ProfileForm guest={sanitizeGuest(guest)} />;
+  // Never render the stored email address here: switching the current user
+  // is unauthenticated, so anyone could impersonate a guest and read it.
+  return <SettingsForm emailSettings={guest.info.emailSettings} />;
 }

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { updateEmailSettingsAction } from "@/app/actions/settings";
+import { emailSettingsSchema } from "@/model/guest";
+import type { EmailSettings } from "@/db/repositories/interfaces";
+
+export function SettingsForm({
+  emailSettings,
+}: {
+  emailSettings: EmailSettings;
+}) {
+  const form = useForm({
+    defaultValues: emailSettings,
+    resolver: zodResolver(emailSettingsSchema),
+  });
+  const [saved, setSaved] = useState(false);
+
+  const handleSubmit = async (
+    settings: z.infer<typeof emailSettingsSchema>
+  ) => {
+    setSaved(false);
+    try {
+      const result = await updateEmailSettingsAction(settings);
+      if (!result.ok) {
+        form.setError("root", {
+          message:
+            typeof result.error === "string"
+              ? result.error
+              : "Invalid settings",
+        });
+      } else {
+        // Rebaseline so isDirty reflects "differs from what's saved".
+        form.reset(settings);
+        setSaved(true);
+      }
+    } catch (err) {
+      form.setError("root", { message: "An unexpected error occurred" });
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-6 px-4 sm:px-0">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <p className="text-sm text-gray-500">
+        Everything here is private and never shown to other attendees. Your{" "}
+        <Link
+          href="/guests/edit"
+          className="text-rose-500 hover:text-rose-600 underline"
+        >
+          public profile
+        </Link>{" "}
+        is edited separately.
+      </p>
+
+      <form
+        onSubmit={(e) => form.handleSubmit(handleSubmit)(e) as never}
+        className="flex flex-col gap-4"
+      >
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-lg font-semibold mb-1">
+            Email me when&hellip;
+          </legend>
+          <p className="text-sm text-gray-500 mb-1">
+            Notifications go to the email address the organizers have for you.
+            Contact an organizer to change it.
+          </p>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" {...form.register("rsvpChange")} />a session
+            I&rsquo;ve RSVP&rsquo;d to changes time or location
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" {...form.register("hostChange")} />a session
+            I&rsquo;m hosting changes time or location
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" {...form.register("cohostAdd")} />
+            someone adds me as a session co-host
+          </label>
+        </fieldset>
+
+        {form.formState.errors.root && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+            <p className="text-sm font-medium">
+              Error: {form.formState.errors.root.message}
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-4">
+          <button
+            type="submit"
+            className="bg-rose-400 text-white font-semibold py-2 rounded shadow disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500 px-12"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Saving..." : "Save"}
+          </button>
+          {saved && !form.formState.isDirty && (
+            <span role="status" className="text-sm text-green-700">
+              Saved
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { getRepositories } from "@/db/container";
+import { emailSettingsSchema } from "@/model/guest";
+import { z } from "zod";
+
+export type SettingsActionResult =
+  { ok: true } | { ok: false; error: string | z.core.$ZodIssue[] };
+
+export async function updateEmailSettingsAction(
+  settings: z.input<typeof emailSettingsSchema>
+): Promise<SettingsActionResult>;
+
+export async function updateEmailSettingsAction(
+  settings: unknown
+): Promise<SettingsActionResult> {
+  const parseResult = emailSettingsSchema.safeParse(settings);
+  if (!parseResult.success) {
+    return { ok: false, error: parseResult.error.issues };
+  }
+
+  const cookieStore = await cookies();
+  const currentUser = cookieStore.get("user")?.value;
+  if (!currentUser) {
+    return { ok: false, error: "No user is logged in" };
+  }
+
+  const { guests } = getRepositories();
+  const updated = await guests.updateEmailSettings(
+    currentUser,
+    parseResult.data
+  );
+  if (!updated) {
+    return { ok: false, error: "Profile not found" };
+  }
+
+  return { ok: true };
+}

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -268,8 +268,7 @@ export interface GuestsRepository {
     id: string,
     data: { name: string; info: { email: string } }
   ): Promise<CompleteGuest | undefined>;
-  // Usage: a user updates their own profile (name, public profile fields, and
-  // their email notification settings).
+  // Usage: a user updates their own public profile (name and profile fields).
   updateProfile(
     id: string,
     data: {
@@ -281,8 +280,14 @@ export interface GuestsRepository {
       prompts: ProfilePrompt[] | null;
       languages: string[] | null;
       contacts: ProfileContact[] | null;
-      emailSettings: EmailSettings;
     }
+  ): Promise<CompleteGuest | undefined>;
+  // Usage: a user updates their own email notification settings. Kept apart
+  // from updateProfile: settings are private and independent of the public
+  // profile.
+  updateEmailSettings(
+    id: string,
+    settings: EmailSettings
   ): Promise<CompleteGuest | undefined>;
   /** Deletes the guest and all records referencing them (votes, RSVPs, host links, event assignments). */
   delete(id: string): Promise<void>;

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -360,7 +360,6 @@ export class SqliteGuestsRepository implements GuestsRepository {
       prompts: ProfilePrompt[] | null;
       languages: string[] | null;
       contacts: ProfileContact[] | null;
-      emailSettings: EmailSettings;
     }
   ): Promise<CompleteGuest | undefined> {
     const result = this.db
@@ -374,9 +373,23 @@ export class SqliteGuestsRepository implements GuestsRepository {
         prompts: data.prompts,
         languages: data.languages,
         contacts: data.contacts,
-        emailOnRsvpChange: data.emailSettings.rsvpChange,
-        emailOnHostChange: data.emailSettings.hostChange,
-        emailOnCohostAdd: data.emailSettings.cohostAdd,
+      })
+      .where(eq(schema.guests.id, id))
+      .run();
+    if (result.changes === 0) return undefined;
+    return this.findById(id);
+  }
+
+  async updateEmailSettings(
+    id: string,
+    settings: EmailSettings
+  ): Promise<CompleteGuest | undefined> {
+    const result = this.db
+      .update(schema.guests)
+      .set({
+        emailOnRsvpChange: settings.rsvpChange,
+        emailOnHostChange: settings.hostChange,
+        emailOnCohostAdd: settings.cohostAdd,
       })
       .where(eq(schema.guests.id, id))
       .run();

--- a/model/guest.ts
+++ b/model/guest.ts
@@ -122,5 +122,4 @@ export const profileSchema = z.object({
     .refine((cs) => (cs?.length ?? 0) <= MAX_CONTACTS, {
       message: `At most ${MAX_CONTACTS} contacts`,
     }),
-  emailSettings: emailSettingsSchema,
 });

--- a/tests/e2e/helpers/user.ts
+++ b/tests/e2e/helpers/user.ts
@@ -1,10 +1,15 @@
-import { Page } from "@playwright/test";
+import { Page, expect } from "@playwright/test";
 
-// Selects the current identity via the site header. The active name lives in a
-// header chip (accessible name starts with "Your name"); tapping it opens a
-// modal with the "My name is:" combobox where a guest is picked.
+// Selects the current identity via the site header. The active name lives in
+// a header chip (accessible name starts with "Your name"). With no name set,
+// tapping it opens a modal with the "My name is:" combobox; with a name set,
+// it opens the user menu whose "Switch name" entry leads to the same modal.
 export async function selectUser(page: Page, name: string | RegExp) {
   await page.getByRole("button", { name: /your name/i }).click();
-  await page.getByLabel("My name is:").click();
+  const switchName = page.getByRole("menuitem", { name: "Switch name" });
+  const nameBox = page.getByLabel("My name is:");
+  await expect(switchName.or(nameBox)).toBeVisible();
+  if (await switchName.isVisible()) await switchName.click();
+  await nameBox.click();
   await page.getByRole("option", { name }).click();
 }

--- a/tests/e2e/user-settings.spec.ts
+++ b/tests/e2e/user-settings.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
+
+// Amara Okafor is used by no other spec, so her email settings can be
+// mutated without racing parallel test files.
+test("header user menu reaches profile, edit profile, and settings; email preferences persist", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Alpha/proposals");
+  await selectUser(page, /Amara Okafor/i);
+
+  // Once a name is selected, the header chip opens a user menu.
+  await page.getByRole("button", { name: /your name/i }).click();
+  await page.getByRole("menuitem", { name: /my profile/i }).click();
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Amara Okafor" })
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /your name/i }).click();
+  await page.getByRole("menuitem", { name: /edit profile/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /edit profile/i })
+  ).toBeVisible();
+  // Email preferences are private settings, not part of the public profile.
+  await expect(page.getByText(/email me when/i)).toHaveCount(0);
+
+  await page.getByRole("button", { name: /your name/i }).click();
+  await page.getByRole("menuitem", { name: /settings/i }).click();
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  // Switching names is unauthenticated, so the stored email address must
+  // never be rendered — anyone could impersonate a guest and read it.
+  await expect(page.getByText("amara.okafor@example.com")).toHaveCount(0);
+
+  const rsvpToggle = page.getByLabel(/RSVP.d to changes time or location/i);
+  await expect(rsvpToggle).toBeChecked();
+  await rsvpToggle.uncheck();
+  await page.getByRole("button", { name: /^Save$/ }).click();
+  await expect(page.getByText(/saved/i)).toBeVisible();
+
+  // Editing again invalidates the confirmation: what's on screen is no
+  // longer what was saved. (Left unsaved on purpose — the reload below
+  // must only see the rsvpChange update.)
+  await page.getByLabel(/hosting changes time or location/i).uncheck();
+  await expect(page.getByText(/saved/i)).toHaveCount(0);
+
+  await page.reload();
+  await expect(
+    page.getByLabel(/RSVP.d to changes time or location/i)
+  ).not.toBeChecked();
+});
+
+test("settings page asks to select a name when none is chosen", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/settings");
+
+  await expect(page.getByText(/select who you are/i)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Settings" })).toHaveCount(0);
+});

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -103,18 +103,8 @@ export async function createGuest(opts?: {
     .then((g) => g && sanitizeGuest(g));
   if (opts?.emailSettings) {
     // Guests are created with default settings; non-default settings are
-    // applied the way a real guest would, via their profile.
-    await guests.updateProfile(guest.id, {
-      name: guest.name,
-      aboutMe: guest.aboutMe ?? null,
-      avatarUrl: guest.avatarUrl ?? null,
-      pronouns: guest.pronouns ?? null,
-      basedIn: guest.basedIn ?? null,
-      prompts: guest.prompts ?? null,
-      languages: guest.languages ?? null,
-      contacts: guest.contacts ?? null,
-      emailSettings: opts.emailSettings,
-    });
+    // applied the way a real guest would, via their settings.
+    await guests.updateEmailSettings(guest.id, opts.emailSettings);
   }
   if (opts?.eventId) {
     await guests.assignToEvent(opts.eventId, [guest.id]);

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -8,7 +8,6 @@ import {
   createSession,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 
 describe("guest profile repositories", () => {
   beforeAll(() => setupTestDb());
@@ -76,7 +75,6 @@ describe("guest profile repositories", () => {
         prompts: null,
         languages: null,
         contacts: null,
-        emailSettings: DEFAULT_EMAIL_SETTINGS,
       });
 
       expect(updated).toMatchObject({
@@ -112,7 +110,6 @@ describe("guest profile repositories", () => {
           { type: "signal", value: "@someone.01" },
           { type: "other", label: "Matrix", value: "@someone:matrix.org" },
         ],
-        emailSettings: DEFAULT_EMAIL_SETTINGS,
       });
 
       expect(updated).toMatchObject({ id: guest.id, basedIn: "Berlin" });

--- a/tests/integration/guest-search-attendees.test.ts
+++ b/tests/integration/guest-search-attendees.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createEvent, createGuest, createSession } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 
 describe("guests.listAttendees", () => {
   beforeAll(() => setupTestDb());
@@ -63,7 +62,6 @@ describe("guests.listAttendees", () => {
       prompts: [{ prompt: "Offering", answer: "Sourdough starters" }],
       languages: ["Portuguese"],
       contacts: null,
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
 
     const rows = await repos.guests.listAttendees({});

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -27,7 +27,6 @@ vi.mock("next/cache", () => ({
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
-import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
 import { updateProfileAction } from "@/app/actions/profile";
 import { createImageFile } from "@/tests/helpers/utils";
 import fs from "fs";
@@ -52,13 +51,15 @@ describe("updateProfileAction", () => {
     fs.rmSync(uploadsDir, { recursive: true, force: true });
   });
 
-  it("updates email settings for the current user", async () => {
-    const guest = await createGuest({ name: "Guest" });
+  it("leaves email settings untouched: those belong to the settings action", async () => {
+    const guest = await createGuest({
+      name: "Guest",
+      emailSettings: { rsvpChange: false, hostChange: false, cohostAdd: true },
+    });
     cookieJar.set("user", guest.id);
     const result = await updateProfileAction({
       name: "Guest",
       aboutMe: null,
-      emailSettings: { rsvpChange: false, hostChange: false, cohostAdd: true },
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -76,7 +77,6 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       pronouns: "they/them",
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -95,7 +95,6 @@ describe("updateProfileAction", () => {
       aboutMe: "Hello there",
       avatar: await createImageFile(256, 256, "avatar.png"),
       pronouns: "they/them",
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -118,7 +117,6 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       avatar: await createImageFile(512, 512, "avatar.png"),
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -145,7 +143,6 @@ describe("updateProfileAction", () => {
         { type: "telegram", value: "@guest" },
         { type: "other", label: "Matrix", value: "@guest:matrix.org" },
       ],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -173,7 +170,6 @@ describe("updateProfileAction", () => {
       ],
       languages: ["", "  ", "French"],
       contacts: [{ type: "email", value: "   " }],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -195,7 +191,6 @@ describe("updateProfileAction", () => {
         { prompt: "Ask me about", answer: "Fermentation" },
         { prompt: "Ask me about", answer: "Beekeeping" },
       ],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -213,7 +208,6 @@ describe("updateProfileAction", () => {
       // A label typed while the type was "other" sticks around in the form
       // state after switching the type; it must not be persisted.
       contacts: [{ type: "telegram", label: "Matrix", value: "@guest" }],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
@@ -227,7 +221,6 @@ describe("updateProfileAction", () => {
       name: "Guest",
       aboutMe: null,
       contacts: [{ type: "other", value: "@guest:matrix.org" }],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toMatchObject({ ok: false });
   });
@@ -240,7 +233,6 @@ describe("updateProfileAction", () => {
       name: "Guest",
       aboutMe: null,
       languages: Array.from({ length: 11 }, (_, i) => `Lang ${i}`),
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(tooManyLanguages).toMatchObject({ ok: false });
 
@@ -248,7 +240,6 @@ describe("updateProfileAction", () => {
       name: "Guest",
       aboutMe: null,
       prompts: [{ prompt: "Ask me about", answer: "x".repeat(501) }],
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(answerTooLong).toMatchObject({ ok: false });
   });
@@ -260,7 +251,6 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       avatar: await createImageFile(128, 128, "avatar.png"),
-      emailSettings: DEFAULT_EMAIL_SETTINGS,
     });
     expect(result).toMatchObject({ ok: false });
   });

--- a/tests/integration/settings-action.test.ts
+++ b/tests/integration/settings-action.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { DEFAULT_EMAIL_SETTINGS } from "@/db/repositories/interfaces";
+import { updateEmailSettingsAction } from "@/app/actions/settings";
+
+describe("updateEmailSettingsAction", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+  });
+
+  it("updates the current user's email settings", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set("user", guest.id);
+    const result = await updateEmailSettingsAction({
+      rsvpChange: false,
+      hostChange: false,
+      cohostAdd: true,
+    });
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated?.info.emailSettings).toEqual({
+      rsvpChange: false,
+      hostChange: false,
+      cohostAdd: true,
+    });
+  });
+
+  it("fails when no user is selected", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    const result = await updateEmailSettingsAction({
+      rsvpChange: false,
+      hostChange: false,
+      cohostAdd: false,
+    });
+    expect(result).toEqual({ ok: false, error: "No user is logged in" });
+    const unchanged = await getRepositories().guests.findById(guest.id);
+    expect(unchanged?.info.emailSettings).toEqual(DEFAULT_EMAIL_SETTINGS);
+  });
+
+  it("rejects an invalid payload", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set("user", guest.id);
+    // A payload the typed signature can't produce; simulates a hand-crafted
+    // request hitting the server action directly.
+    const result = await updateEmailSettingsAction({
+      rsvpChange: "yes",
+    } as never);
+    expect(result.ok).toBe(false);
+    const unchanged = await getRepositories().guests.findById(guest.id);
+    expect(unchanged?.info.emailSettings).toEqual(DEFAULT_EMAIL_SETTINGS);
+  });
+});


### PR DESCRIPTION
Email preferences were buried in the public profile form and hard to
find. Split them into a private /settings screen (leaving room for
future settings like authentication) and make profile, profile
editing, and settings reachable from the header name chip. The stored
email address is deliberately not shown there: switching users is
unauthenticated.

<!-- jip:pushed-commit=f3449350c0c9ed0839bf525402c48332317996c7 -->