### PR TITLE
feat: add guest auth protection fields and auth codes table

### DIFF
--- a/db/container.ts
+++ b/db/container.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import path from "path";
 import * as schema from "./schema";
 import { resolveDbPath, runMigrations } from "./migrate";
+import { SqliteAuthCodesRepository } from "./repositories/sqlite/auth-codes";
 import { SqliteDaysRepository } from "./repositories/sqlite/days";
 import { SqliteEventsRepository } from "./repositories/sqlite/events";
 import { SqliteGuestsRepository } from "./repositories/sqlite/guests";
@@ -13,6 +14,7 @@ import { SqliteSessionProposalsRepository } from "./repositories/sqlite/session-
 import { SqliteSessionsRepository } from "./repositories/sqlite/sessions";
 import { SqliteVotesRepository } from "./repositories/sqlite/votes";
 import type {
+  AuthCodesRepository,
   DaysRepository,
   EventsRepository,
   GuestsRepository,
@@ -25,6 +27,7 @@ import type {
 } from "./repositories/interfaces";
 
 export type Repositories = {
+  authCodes: AuthCodesRepository;
   days: DaysRepository;
   events: EventsRepository;
   guests: GuestsRepository;
@@ -42,6 +45,7 @@ let _repositories: Repositories | null = null;
 function buildRepositories(sqlite: Database.Database): Repositories {
   const db = drizzle(sqlite, { schema });
   return {
+    authCodes: new SqliteAuthCodesRepository(db),
     days: new SqliteDaysRepository(db),
     events: new SqliteEventsRepository(db),
     guests: new SqliteGuestsRepository(db),

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -161,8 +161,51 @@ export type Guest<PI extends GuestPrivateInfo | void = void> = {
   prompts?: ProfilePrompt[] | null;
   languages?: string[] | null;
   contacts?: ProfileContact[] | null;
+  // Public (the name switcher must know to ask for credentials); the
+  // password hash itself is server-only, see GuestAuthCredentials.
+  authProtected?: boolean;
   info: PI;
 };
+
+/** Server-only auth state of a guest; never send to the client. */
+export type GuestAuthCredentials = {
+  authProtected: boolean;
+  passwordHash: string | null;
+};
+
+/**
+ * An emailed temporary login code. `codeHash` is a digest of `salt + code`,
+ * never the code.
+ */
+export type AuthCode = {
+  id: string;
+  guestId: string;
+  salt: string;
+  codeHash: string;
+  createdAt: Date;
+  expiresAt: Date;
+  attempts: number;
+};
+
+/** Input for issuing a code; `id` and `attempts` are filled in on insert. */
+export type NewAuthCode = {
+  guestId: string;
+  salt: string;
+  codeHash: string;
+  createdAt: Date;
+  expiresAt: Date;
+};
+
+export interface AuthCodesRepository {
+  /**
+   * Stores a new code for the guest, replacing any previous one — only the
+   * most recently issued code can ever be valid.
+   */
+  replace(code: NewAuthCode): Promise<void>;
+  /** The guest's current code, or null if none exists or it expired at `now`. */
+  findActive(guestId: string, now: Date): Promise<AuthCode | null>;
+  recordFailedAttempt(id: string): Promise<void>;
+}
 
 export type CompleteGuest = Guest<GuestPrivateInfo>;
 
@@ -249,6 +292,10 @@ export interface GuestsRepository {
     }
   ): Promise<EventGuestPage>;
   findById(id: string): Promise<CompleteGuest | undefined>;
+  /** Server-only: protection flag + password hash, for credential checks. */
+  getAuthCredentials(id: string): Promise<GuestAuthCredentials | null>;
+  /** Returns false when the guest doesn't exist. */
+  setAuthProtection(id: string, creds: GuestAuthCredentials): Promise<boolean>;
   // Matches the email case-insensitively.
   findByEmail(email: string): Promise<CompleteGuest | undefined>;
   /** Guests whose email matches any of `emails`, compared case-insensitively. */

--- a/db/repositories/sqlite/auth-codes.ts
+++ b/db/repositories/sqlite/auth-codes.ts
@@ -1,0 +1,55 @@
+import { eq, sql } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { nanoid } from "nanoid";
+import * as schema from "../../schema";
+import type { AuthCode, AuthCodesRepository, NewAuthCode } from "../interfaces";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+export class SqliteAuthCodesRepository implements AuthCodesRepository {
+  constructor(private readonly db: DB) {}
+
+  async replace(code: NewAuthCode): Promise<void> {
+    this.db.transaction((tx) => {
+      tx.delete(schema.authCodes)
+        .where(eq(schema.authCodes.guestId, code.guestId))
+        .run();
+      tx.insert(schema.authCodes)
+        .values({
+          id: nanoid(),
+          guestId: code.guestId,
+          salt: code.salt,
+          codeHash: code.codeHash,
+          createdAt: code.createdAt.toISOString(),
+          expiresAt: code.expiresAt.toISOString(),
+        })
+        .run();
+    });
+  }
+
+  async findActive(guestId: string, now: Date): Promise<AuthCode | null> {
+    const row = this.db
+      .select()
+      .from(schema.authCodes)
+      .where(eq(schema.authCodes.guestId, guestId))
+      .get();
+    if (!row || row.expiresAt <= now.toISOString()) return null;
+    return {
+      id: row.id,
+      guestId: row.guestId,
+      salt: row.salt,
+      codeHash: row.codeHash,
+      createdAt: new Date(row.createdAt),
+      expiresAt: new Date(row.expiresAt),
+      attempts: row.attempts,
+    };
+  }
+
+  async recordFailedAttempt(id: string): Promise<void> {
+    this.db
+      .update(schema.authCodes)
+      .set({ attempts: sql`${schema.authCodes.attempts} + 1` })
+      .where(eq(schema.authCodes.id, id))
+      .run();
+  }
+}

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -17,6 +17,7 @@ import {
   type EmailSettings,
   type EventGuestPage,
   type Guest,
+  type GuestAuthCredentials,
   type GuestsRepository,
   type GuestPage,
   type NewGuest,
@@ -45,6 +46,7 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
     prompts: row.prompts,
     languages: row.languages,
     contacts: row.contacts,
+    authProtected: row.authProtected,
     info: {
       email: row.email,
       emailSettings: {
@@ -66,14 +68,17 @@ export class SqliteGuestsRepository implements GuestsRepository {
     // UI actually shows them.
     return (await this.listFull())
       .map(sanitizeGuest)
-      .map(({ id, name, aboutMe, avatarUrl, pronouns, info }) => ({
-        id,
-        name,
-        aboutMe,
-        avatarUrl,
-        pronouns,
-        info,
-      }));
+      .map(
+        ({ id, name, aboutMe, avatarUrl, pronouns, authProtected, info }) => ({
+          id,
+          name,
+          aboutMe,
+          avatarUrl,
+          pronouns,
+          authProtected,
+          info,
+        })
+      );
   }
 
   async listFull(): Promise<CompleteGuest[]> {
@@ -285,6 +290,33 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .map(rowToGuest);
   }
 
+  async getAuthCredentials(id: string): Promise<GuestAuthCredentials | null> {
+    const row = this.db
+      .select({
+        authProtected: schema.guests.authProtected,
+        passwordHash: schema.guests.passwordHash,
+      })
+      .from(schema.guests)
+      .where(eq(schema.guests.id, id))
+      .get();
+    return row ?? null;
+  }
+
+  async setAuthProtection(
+    id: string,
+    creds: GuestAuthCredentials
+  ): Promise<boolean> {
+    const result = this.db
+      .update(schema.guests)
+      .set({
+        authProtected: creds.authProtected,
+        passwordHash: creds.passwordHash,
+      })
+      .where(eq(schema.guests.id, id))
+      .run();
+    return result.changes > 0;
+  }
+
   async create(data: NewGuest): Promise<CompleteGuest> {
     const id = nanoid();
     const {
@@ -297,6 +329,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
     return {
       id,
       name,
+      authProtected: false,
       info: { email, emailSettings: { ...DEFAULT_EMAIL_SETTINGS } },
     };
   }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -43,12 +43,40 @@ export const guests = sqliteTable(
       .notNull()
       .default(true),
     avatarUrl: text("avatar_url"),
+    // Account security (issue #370): when set, acting as this guest requires
+    // a verified session (password or emailed code) instead of the open
+    // name-switcher.
+    authProtected: integer("auth_protected", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    // The guest's optional permanent password, stored as a self-describing
+    // scrypt string that embeds its own per-guest random salt (and KDF
+    // parameters) — hence no separate salt column, unlike auth_codes below.
+    // The salt is mandatory: never derive this without one. Never leaves the
+    // server.
+    passwordHash: text("password_hash"),
   },
   (table) => [
     // Case-insensitive: two guests must never share an email up to case.
     uniqueIndex("guests_email_unique").on(sql`lower(${table.email})`),
   ]
 );
+
+// Temporary login codes emailed to guests ("8-character temporary password").
+// At most one valid code per guest: issuing a new one replaces the old.
+// A code stays usable until it expires (multi-use within its window).
+export const authCodes = sqliteTable("auth_codes", {
+  id: text("id").primaryKey(),
+  guestId: text("guest_id")
+    .notNull()
+    .references(() => guests.id, { onDelete: "cascade" }),
+  // Per-code random salt; codeHash is sha256(salt + code), never the code.
+  salt: text("salt").notNull(),
+  codeHash: text("code_hash").notNull(),
+  createdAt: text("created_at").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  attempts: integer("attempts").notNull().default(0),
+});
 
 export const events = sqliteTable(
   "events",

--- a/drizzle/0020_user-auth-protection.sql
+++ b/drizzle/0020_user-auth-protection.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `auth_codes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`guest_id` text NOT NULL,
+	`salt` text NOT NULL,
+	`code_hash` text NOT NULL,
+	`created_at` text NOT NULL,
+	`expires_at` text NOT NULL,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`guest_id`) REFERENCES `guests`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `guests` ADD `auth_protected` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `guests` ADD `password_hash` text;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1099 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "893595b3-36cb-47cb-85fe-e8b6e7c70567",
+  "prevId": "aea9b47e-531b-4997-ac89-329164bd882b",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784367197755,
       "tag": "0019_guest_profile_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1784389404349,
+      "tag": "0020_user-auth-protection",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/user-auth-repos.test.ts
+++ b/tests/integration/user-auth-repos.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+describe("guest auth protection (repository)", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("new guests are unprotected with no password", async () => {
+    const guest = await createGuest();
+    const creds = await getRepositories().guests.getAuthCredentials(guest.id);
+    expect(creds).toEqual({ authProtected: false, passwordHash: null });
+    const listed = (await getRepositories().guests.list()).find(
+      (g) => g.id === guest.id
+    );
+    expect(listed?.authProtected).toBe(false);
+  });
+
+  it("enabling protection with a password hash is reflected everywhere public except the hash", async () => {
+    const guest = await createGuest();
+    const { guests } = getRepositories();
+    const updated = await guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: "hash-value",
+    });
+    expect(updated).toBe(true);
+    expect(await guests.getAuthCredentials(guest.id)).toEqual({
+      authProtected: true,
+      passwordHash: "hash-value",
+    });
+    const listed = (await guests.list()).find((g) => g.id === guest.id);
+    expect(listed?.authProtected).toBe(true);
+    // The hash must never appear on guest objects handed to the UI.
+    expect(JSON.stringify(listed)).not.toContain("hash-value");
+    const full = await guests.findById(guest.id);
+    expect(JSON.stringify(full)).not.toContain("hash-value");
+  });
+
+  it("disabling protection clears the password hash", async () => {
+    const guest = await createGuest();
+    const { guests } = getRepositories();
+    await guests.setAuthProtection(guest.id, {
+      authProtected: true,
+      passwordHash: "hash-value",
+    });
+    await guests.setAuthProtection(guest.id, {
+      authProtected: false,
+      passwordHash: null,
+    });
+    expect(await guests.getAuthCredentials(guest.id)).toEqual({
+      authProtected: false,
+      passwordHash: null,
+    });
+  });
+
+  it("returns null / false for an unknown guest", async () => {
+    const { guests } = getRepositories();
+    expect(await guests.getAuthCredentials("nope")).toBeNull();
+    expect(
+      await guests.setAuthProtection("nope", {
+        authProtected: true,
+        passwordHash: null,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("auth codes (repository)", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  const dates = {
+    created: new Date("2026-07-18T12:00:00Z"),
+    expires: new Date("2026-07-18T12:10:00Z"),
+    beforeExpiry: new Date("2026-07-18T12:09:59Z"),
+    afterExpiry: new Date("2026-07-18T12:10:01Z"),
+  };
+
+  it("stores a code and finds it while unexpired", async () => {
+    const guest = await createGuest();
+    const { authCodes } = getRepositories();
+    await authCodes.replace({
+      guestId: guest.id,
+      salt: "salt1",
+      codeHash: "abc",
+      createdAt: dates.created,
+      expiresAt: dates.expires,
+    });
+    const active = await authCodes.findActive(guest.id, dates.beforeExpiry);
+    expect(active).toMatchObject({
+      guestId: guest.id,
+      salt: "salt1",
+      codeHash: "abc",
+      attempts: 0,
+    });
+    expect(active?.createdAt).toEqual(dates.created);
+    expect(await authCodes.findActive(guest.id, dates.afterExpiry)).toBeNull();
+  });
+
+  it("replace invalidates the previous code", async () => {
+    const guest = await createGuest();
+    const { authCodes } = getRepositories();
+    await authCodes.replace({
+      guestId: guest.id,
+      salt: "salt1",
+      codeHash: "old",
+      createdAt: dates.created,
+      expiresAt: dates.expires,
+    });
+    await authCodes.replace({
+      guestId: guest.id,
+      salt: "salt2",
+      codeHash: "new",
+      createdAt: dates.created,
+      expiresAt: dates.expires,
+    });
+    const active = await authCodes.findActive(guest.id, dates.beforeExpiry);
+    expect(active?.codeHash).toBe("new");
+  });
+
+  it("records failed attempts", async () => {
+    const guest = await createGuest();
+    const { authCodes } = getRepositories();
+    await authCodes.replace({
+      guestId: guest.id,
+      salt: "salt1",
+      codeHash: "abc",
+      createdAt: dates.created,
+      expiresAt: dates.expires,
+    });
+    const first = await authCodes.findActive(guest.id, dates.beforeExpiry);
+    await authCodes.recordFailedAttempt(first!.id);
+    await authCodes.recordFailedAttempt(first!.id);
+    const after = await authCodes.findActive(guest.id, dates.beforeExpiry);
+    expect(after?.attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
Groundwork for opt-in account security (issue #370): guests gain an
auth_protected flag and an optional password hash; emailed temporary
login codes are stored hashed in auth_codes (one active code per guest).

issue #370

<!-- jip:pushed-commit=9bee557eac56f403cd4f8a335cb14afc32b9a984 -->