### PR TITLE
feat: signed per-guest auth cookie and credential helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@
    AUTH_SECRET=<generated via openssl rand -base64 32>
    ```
 
-   See [Environment Variables](#environment-variables) for all options. Note: `AUTH_SECRET` is required only when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set. Omitting this file uses sensible defaults.
+   See [Environment Variables](#environment-variables) for all options. Note: `AUTH_SECRET` is required only when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set or guests protect their name (it signs their session cookies). Omitting this file uses sensible defaults.
 
 3. (Optional) Seed the database with test data:
 
@@ -77,8 +77,9 @@ See [docs/hosting](docs/hosting/README.md#environment-variables) for the full li
 
 For local development, `DATABASE_URL` is the only required variable — unlike
 Docker, no default is provided (e.g. `file:./data.db`). `AUTH_SECRET` is
-additionally required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set;
-generate one with:
+additionally required when `SITE_PASSWORD` or `ADMIN_PASSWORD` is set or
+guests protect their name (it signs their session cookies); generate one
+with:
 
 ```bash
 openssl rand -base64 32

--- a/tests/unit/user-auth.test.ts
+++ b/tests/unit/user-auth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  createUserAuthCookie,
+  createUserAuthLogoutCookie,
+  isUserAuthCookieValidFor,
+  USER_AUTH_COOKIE_NAME,
+} from "@/utils/auth";
+import {
+  AUTH_CODE_LENGTH,
+  generateAuthCode,
+  generateAuthCodeSalt,
+  hashAuthCode,
+  normalizeAuthCode,
+  hashUserPassword,
+  verifyUserPassword,
+} from "@/utils/user-credentials";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef"; // 32 chars
+
+describe("user auth cookie", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("validates only for the guest it was issued for", async () => {
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    const cookie = await createUserAuthCookie("guest-1");
+    expect(cookie.name).toBe(USER_AUTH_COOKIE_NAME);
+    expect(await isUserAuthCookieValidFor("guest-1", cookie.value)).toBe(true);
+    expect(await isUserAuthCookieValidFor("guest-2", cookie.value)).toBe(false);
+    expect(await isUserAuthCookieValidFor("guest-1", undefined)).toBe(false);
+    expect(
+      await isUserAuthCookieValidFor("guest-1", cookie.value.slice(0, -2))
+    ).toBe(false);
+  });
+
+  it("is httpOnly and long-lived; the logout cookie expires immediately", async () => {
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    const cookie = await createUserAuthCookie("guest-1");
+    expect(cookie.httpOnly).toBe(true);
+    expect(cookie.maxAge).toBeGreaterThan(0);
+    expect(createUserAuthLogoutCookie().maxAge).toBe(0);
+  });
+});
+
+describe("auth codes", () => {
+  it("generates 8-character codes from the unambiguous alphabet", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = generateAuthCode();
+      expect(code).toHaveLength(AUTH_CODE_LENGTH);
+      expect(code).toMatch(/^[A-HJ-NP-Z2-9]+$/);
+    }
+  });
+
+  it("normalizes user input (case, whitespace)", () => {
+    expect(normalizeAuthCode(" ab cd\tefgh ")).toBe("ABCDEFGH");
+  });
+
+  it("hashes deterministically for the same code and salt, and never returns the code itself", () => {
+    const code = generateAuthCode();
+    const salt = generateAuthCodeSalt();
+    expect(hashAuthCode(code, salt)).toBe(hashAuthCode(code, salt));
+    expect(hashAuthCode(code, salt)).not.toContain(code);
+    expect(hashAuthCode(code, salt)).not.toBe(
+      hashAuthCode(generateAuthCode(), salt)
+    );
+  });
+
+  it("salts hashes (same code, different salt gives a different hash)", () => {
+    const code = generateAuthCode();
+    expect(hashAuthCode(code, generateAuthCodeSalt())).not.toBe(
+      hashAuthCode(code, generateAuthCodeSalt())
+    );
+  });
+
+  it("generates random, non-empty salts", () => {
+    expect(generateAuthCodeSalt()).not.toBe(generateAuthCodeSalt());
+    expect(generateAuthCodeSalt().length).toBeGreaterThan(0);
+  });
+});
+
+describe("user passwords", () => {
+  it("verifies the right password and rejects the wrong one", async () => {
+    const hash = await hashUserPassword("correct horse");
+    expect(await verifyUserPassword("correct horse", hash)).toBe(true);
+    expect(await verifyUserPassword("wrong", hash)).toBe(false);
+    expect(await verifyUserPassword("correct horse", null)).toBe(false);
+  });
+
+  it("salts hashes (same password, different hash)", async () => {
+    const a = await hashUserPassword("pw");
+    const b = await hashUserPassword("pw");
+    expect(a).not.toBe(b);
+    expect(a).not.toContain("pw");
+  });
+});

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -2,11 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const AUTH_COOKIE_NAME = "site-auth";
 export const ADMIN_COOKIE_NAME = "admin-auth";
+// Proves "I am this guest" for auth-protected guests (issue #370). Separate
+// from the plain `user` cookie, which merely selects the current name and
+// stays client-writable for unprotected guests.
+export const USER_AUTH_COOKIE_NAME = "user-auth";
 export const ADMIN_DISABLED_MESSAGE =
   "Admin UI is disabled: set the ADMIN_PASSWORD environment variable on the server to enable it. See the project documentation.";
 const ADMIN_SCOPE = "admin";
 const COOKIE_MAX_AGE_SEC = 7 * 24 * 60 * 60;
 const COOKIE_MAX_AGE_MS = COOKIE_MAX_AGE_SEC * 1000;
+
+// The guest id becomes part of the signed scope, so a cookie issued for one
+// guest can never validate for another. Guest ids are nanoids (no dots), so
+// the existing dot-delimited payload format stays parseable.
+function userScope(guestId: string): string {
+  return `user.${guestId}`;
+}
 
 /**
  * Returns a safe same-origin redirect path, or `fallback` if `value` could
@@ -78,7 +89,7 @@ function getAuthSecret(): string {
   const secret = process.env.AUTH_SECRET;
   if (!secret) {
     throw new Error(
-      "AUTH_SECRET environment variable must be set when SITE_PASSWORD or ADMIN_PASSWORD is set"
+      "AUTH_SECRET environment variable must be set when SITE_PASSWORD or ADMIN_PASSWORD is set or guests protect their name"
     );
   }
   if (secret.length < MIN_AUTH_SECRET_LENGTH) {
@@ -214,6 +225,29 @@ export function createLogoutCookie() {
     value: "",
     ...cookieOptions(0),
   };
+}
+
+export async function createUserAuthCookie(guestId: string) {
+  return {
+    name: USER_AUTH_COOKIE_NAME,
+    value: await signCookieValue(userScope(guestId)),
+    ...cookieOptions(COOKIE_MAX_AGE_SEC),
+  };
+}
+
+export function createUserAuthLogoutCookie() {
+  return {
+    name: USER_AUTH_COOKIE_NAME,
+    value: "",
+    ...cookieOptions(0),
+  };
+}
+
+export async function isUserAuthCookieValidFor(
+  guestId: string,
+  value: string | undefined
+): Promise<boolean> {
+  return isSignedCookieValid(value, userScope(guestId));
 }
 
 export async function createAdminAuthCookie() {

--- a/utils/user-credentials.ts
+++ b/utils/user-credentials.ts
@@ -1,0 +1,75 @@
+import {
+  createHash,
+  randomInt,
+  randomBytes,
+  scrypt,
+  timingSafeEqual,
+} from "node:crypto";
+
+// Server-only credential helpers for guest account security (issue #370):
+// emailed temporary codes and optional permanent passwords. Cookie signing
+// lives in utils/auth.ts, which must stay free of node:crypto.
+
+export const AUTH_CODE_LENGTH = 8;
+// No I, O, 0, 1: codes are meant to be read from an email on one device and
+// typed on another.
+const AUTH_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+export function generateAuthCode(): string {
+  let code = "";
+  for (let i = 0; i < AUTH_CODE_LENGTH; i++) {
+    code += AUTH_CODE_ALPHABET[randomInt(AUTH_CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+/** Forgives case and stray whitespace in a hand-typed code. */
+export function normalizeAuthCode(input: string): string {
+  return input.replace(/\s/g, "").toUpperCase();
+}
+
+/** Per-code random salt, stored alongside the hash (see hashAuthCode). */
+export function generateAuthCodeSalt(): string {
+  return randomBytes(16).toString("hex");
+}
+
+// SHA-256 over salt + code (no stretching): codes live for 10 minutes and
+// carry ~40 bits of entropy, so hashing only needs to protect against a
+// leaked DB snapshot during that window. The salt isn't secret — it's
+// stored alongside the hash — but it stops a precomputed table over the
+// code alphabet from being reused across codes or guests.
+export function hashAuthCode(code: string, salt: string): string {
+  return createHash("sha256")
+    .update(salt + code)
+    .digest("hex");
+}
+
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
+const SCRYPT_KEYLEN = 32;
+
+function scryptDerive(password: string, salt: Buffer): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, SCRYPT_KEYLEN, SCRYPT_PARAMS, (err, key) =>
+      err ? reject(err) : resolve(key)
+    );
+  });
+}
+
+/** Format: scrypt$<salt base64>$<key base64>, parameters fixed above. */
+export async function hashUserPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const key = await scryptDerive(password, salt);
+  return `scrypt$${salt.toString("base64")}$${key.toString("base64")}`;
+}
+
+export async function verifyUserPassword(
+  password: string,
+  storedHash: string | null
+): Promise<boolean> {
+  if (!storedHash) return false;
+  const [scheme, saltB64, keyB64] = storedHash.split("$");
+  if (scheme !== "scrypt" || !saltB64 || !keyB64) return false;
+  const expected = Buffer.from(keyB64, "base64");
+  const actual = await scryptDerive(password, Buffer.from(saltB64, "base64"));
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}


### PR DESCRIPTION
HMAC cookie binding a session to one guest id, plus emailed-code
generation/hashing and scrypt password hashing for account security.

issue #370

<!-- jip:pushed-commit=07dcd15e047334ebc6de5131a4cb89fd533f95cc -->