### PR TITLE
feat: server actions for account security

### DIFF
--- a/app/actions/user-auth.ts
+++ b/app/actions/user-auth.ts
@@ -1,0 +1,269 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { z } from "zod";
+import { getRepositories } from "@/db/container";
+import {
+  createUserAuthCookie,
+  createUserAuthLogoutCookie,
+  isUserAuthCookieValidFor,
+  USER_AUTH_COOKIE_NAME,
+} from "@/utils/auth";
+import {
+  AUTH_CODE_VALID_MINUTES,
+  generateAuthCode,
+  generateAuthCodeSalt,
+  hashAuthCode,
+  normalizeAuthCode,
+  hashUserPassword,
+  verifyUserPassword,
+} from "@/utils/user-credentials";
+import { isMailerConfigured, sendMail } from "@/utils/mailer";
+import { siteUrl } from "@/utils/site-url";
+import { authCodeEmail } from "@/emails/auth-code";
+
+const REQUEST_THROTTLE_SECONDS = 60;
+const MAX_CODE_ATTEMPTS = 10;
+
+export type UserAuthResult =
+  | { ok: true }
+  // throttled: a recently emailed code is still valid — the UI may present
+  // this as information rather than an error.
+  | { ok: false; error: string; throttled?: boolean };
+export type SelectUserResult =
+  | { ok: true }
+  // needsAuth: the guest is protected and the caller must present a
+  // password or emailed code (loginAsGuestAction) instead.
+  | { ok: false; needsAuth?: boolean; error: string };
+
+// The plain name-selection cookie. Deliberately not httpOnly and unsigned —
+// on its own it only selects a name, as before; the signed
+// USER_AUTH_COOKIE_NAME cookie is what proves identity for protected guests.
+function userSelectionCookie(guestId: string | null) {
+  return {
+    name: "user",
+    value: guestId ?? "",
+    path: "/",
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    ...(guestId === null ? { maxAge: 0 } : {}),
+  };
+}
+
+async function setAuthenticatedIdentity(guestId: string): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(userSelectionCookie(guestId));
+  cookieStore.set(await createUserAuthCookie(guestId));
+}
+
+/**
+ * Checks `input` against the guest's active emailed code, counting failed
+ * attempts so the code dies after too many guesses. The code is multi-use
+ * within its validity window: it is a temporary password, and consuming it
+ * on first use would break "click the link, then type the same code into
+ * the settings form".
+ */
+async function verifyCode(guestId: string, input: string): Promise<boolean> {
+  const { authCodes } = getRepositories();
+  const active = await authCodes.findActive(guestId, new Date());
+  if (!active || active.attempts >= MAX_CODE_ATTEMPTS) return false;
+  if (hashAuthCode(normalizeAuthCode(input), active.salt) === active.codeHash)
+    return true;
+  await authCodes.recordFailedAttempt(active.id);
+  return false;
+}
+
+/** Emails the guest a temporary login code (link + typeable code). */
+export async function requestAuthCodeAction(
+  guestId: string
+): Promise<UserAuthResult> {
+  if (!isMailerConfigured()) {
+    return {
+      ok: false,
+      error: "This server cannot send email, so codes are unavailable",
+    };
+  }
+  const { guests, authCodes } = getRepositories();
+  const guest = await guests.findById(guestId);
+  if (!guest) {
+    return { ok: false, error: "Unknown user" };
+  }
+
+  const now = new Date();
+  const existing = await authCodes.findActive(guestId, now);
+  if (
+    existing &&
+    now.getTime() - existing.createdAt.getTime() <
+      REQUEST_THROTTLE_SECONDS * 1000
+  ) {
+    return {
+      ok: false,
+      throttled: true,
+      error:
+        "A code was emailed to you moments ago — check your inbox and spam folder",
+    };
+  }
+
+  const code = generateAuthCode();
+  const salt = generateAuthCodeSalt();
+  await authCodes.replace({
+    guestId,
+    salt,
+    codeHash: hashAuthCode(code, salt),
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + AUTH_CODE_VALID_MINUTES * 60 * 1000),
+  });
+
+  const loginUrl = `${siteUrl()}/auth/login?guest=${encodeURIComponent(
+    guestId
+  )}&code=${encodeURIComponent(code)}`;
+  try {
+    await sendMail({
+      to: guest.info.email,
+      ...authCodeEmail({
+        name: guest.name,
+        code,
+        loginUrl,
+        validMinutes: AUTH_CODE_VALID_MINUTES,
+      }),
+    });
+  } catch (err) {
+    console.error("Failed to send auth code email:", err);
+    return { ok: false, error: "The email could not be sent — try again" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Authenticates as a (protected) guest with either the permanent password
+ * or a currently valid emailed code, and makes them the current user.
+ */
+export async function loginAsGuestAction(
+  guestId: string,
+  credential: string
+): Promise<UserAuthResult> {
+  const { guests } = getRepositories();
+  const creds = await guests.getAuthCredentials(guestId);
+  if (!creds) {
+    return { ok: false, error: "Unknown user" };
+  }
+  const valid =
+    (await verifyUserPassword(credential, creds.passwordHash)) ||
+    (await verifyCode(guestId, credential));
+  if (!valid) {
+    return { ok: false, error: "Wrong password or code" };
+  }
+  await setAuthenticatedIdentity(guestId);
+  return { ok: true };
+}
+
+/**
+ * Switches the current user without credentials. Allowed for unprotected
+ * guests, for a protected guest whose signed session cookie is still valid,
+ * and for clearing the selection (null). Switching away from a protected
+ * guest drops the authenticated session, so switching back requires
+ * credentials again.
+ */
+export async function selectUserAction(
+  guestId: string | null
+): Promise<SelectUserResult> {
+  const cookieStore = await cookies();
+  if (guestId === null) {
+    cookieStore.set(userSelectionCookie(null));
+    cookieStore.set(createUserAuthLogoutCookie());
+    return { ok: true };
+  }
+
+  const creds = await getRepositories().guests.getAuthCredentials(guestId);
+  if (!creds) {
+    return { ok: false, error: "Unknown user" };
+  }
+  if (creds.authProtected) {
+    const authCookie = cookieStore.get(USER_AUTH_COOKIE_NAME)?.value;
+    if (!(await isUserAuthCookieValidFor(guestId, authCookie))) {
+      return {
+        ok: false,
+        needsAuth: true,
+        error: "This name is protected — a password or emailed code is needed",
+      };
+    }
+    cookieStore.set(userSelectionCookie(guestId));
+    return { ok: true };
+  }
+
+  cookieStore.set(userSelectionCookie(guestId));
+  cookieStore.set(createUserAuthLogoutCookie());
+  return { ok: true };
+}
+
+const authSecuritySchema = z.object({
+  code: z.string().trim().min(1, { message: "Enter the emailed code" }),
+  protect: z.boolean(),
+  newPassword: z
+    .string()
+    .min(8, { message: "Use at least 8 characters" })
+    .max(200)
+    .optional(),
+});
+
+/**
+ * Changes the current user's account security settings. Every change —
+ * enabling or disabling protection, setting or changing the password —
+ * requires a currently valid emailed code, proving control of the email
+ * address (the permanent password is deliberately not accepted here).
+ */
+export async function updateAuthSecurityAction(
+  input: z.input<typeof authSecuritySchema>
+): Promise<UserAuthResult>;
+
+export async function updateAuthSecurityAction(
+  input: unknown
+): Promise<UserAuthResult> {
+  const parsed = authSecuritySchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+  const { code, protect, newPassword } = parsed.data;
+
+  const cookieStore = await cookies();
+  const currentUser = cookieStore.get("user")?.value;
+  if (!currentUser) {
+    return { ok: false, error: "No user is selected" };
+  }
+  const { guests } = getRepositories();
+  const creds = await guests.getAuthCredentials(currentUser);
+  if (!creds) {
+    return { ok: false, error: "Unknown user" };
+  }
+  if (!(await verifyCode(currentUser, code))) {
+    return { ok: false, error: "Wrong or expired code" };
+  }
+
+  if (protect) {
+    const passwordHash = newPassword
+      ? await hashUserPassword(newPassword)
+      : creds.passwordHash;
+    // Sign the session cookie before flipping protection on: if signing
+    // fails (e.g. AUTH_SECRET is missing), the guest must not be left
+    // protected yet impossible to ever log in as.
+    const authCookie = await createUserAuthCookie(currentUser);
+    await guests.setAuthProtection(currentUser, {
+      authProtected: true,
+      passwordHash,
+    });
+    // The code proved control of the email address, so this session is
+    // authenticated from here on.
+    cookieStore.set(userSelectionCookie(currentUser));
+    cookieStore.set(authCookie);
+  } else {
+    await guests.setAuthProtection(currentUser, {
+      authProtected: false,
+      passwordHash: null,
+    });
+    cookieStore.set(createUserAuthLogoutCookie());
+  }
+  return { ok: true };
+}

--- a/emails/auth-code.tsx
+++ b/emails/auth-code.tsx
@@ -1,0 +1,37 @@
+import type { EmailMessage } from "@/utils/mailer";
+
+// Sent when a guest requests a temporary login code — to switch to their
+// (protected) name on some device, or to confirm a change to their account
+// security settings. The code is shown big enough to copy onto another
+// device; the link logs in directly on the device the email is opened on.
+export function authCodeEmail(props: {
+  name: string;
+  code: string;
+  loginUrl: string;
+  validMinutes: number;
+}): EmailMessage {
+  return {
+    subject: "Your temporary login code",
+    body: (
+      <>
+        <p>Hi {props.name},</p>
+        <p>Your temporary login code is:</p>
+        <p style={{ fontSize: "28px", letterSpacing: "4px" }}>
+          <strong>{props.code}</strong>
+        </p>
+        <p>
+          It works for {props.validMinutes} minutes — type it on the device
+          where you are logging in or changing your account security settings,
+          or log in here directly:
+        </p>
+        <p>
+          <a href={props.loginUrl}>Log in as {props.name}</a>
+        </p>
+        <p>
+          If you didn&rsquo;t request this code, you can safely ignore this
+          email.
+        </p>
+      </>
+    ),
+  };
+}

--- a/tests/integration/user-auth-actions.test.ts
+++ b/tests/integration/user-auth-actions.test.ts
@@ -1,0 +1,369 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { render } from "@react-email/render";
+
+type CookieRecord = {
+  name: string;
+  value: string;
+  maxAge?: number;
+  httpOnly?: boolean;
+};
+const cookieJar = new Map<string, CookieRecord>();
+
+function setJarCookie(cookie: CookieRecord) {
+  if (cookie.maxAge === 0) cookieJar.delete(cookie.name);
+  else cookieJar.set(cookie.name, cookie);
+}
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const cookie = cookieJar.get(name);
+        return cookie === undefined ? undefined : { name, value: cookie.value };
+      },
+      set: (cookie: CookieRecord) => setJarCookie(cookie),
+    }),
+}));
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+  isMailerConfigured: vi.fn(() => true),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { sendMail, isMailerConfigured } from "@/utils/mailer";
+import { isUserAuthCookieValidFor, USER_AUTH_COOKIE_NAME } from "@/utils/auth";
+import { hashUserPassword } from "@/utils/user-credentials";
+import {
+  loginAsGuestAction,
+  requestAuthCodeAction,
+  selectUserAction,
+  updateAuthSecurityAction,
+} from "@/app/actions/user-auth";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function lastSentEmail(): Promise<{
+  to: string;
+  subject: string;
+  html: string;
+  code: string;
+}> {
+  const call = vi.mocked(sendMail).mock.calls.at(-1)?.[0];
+  if (!call) throw new Error("No email was sent");
+  const html = await render(call.body);
+  const code = html.match(/>([A-HJ-NP-Z2-9]{8})</)?.[1];
+  if (!code) throw new Error(`No code found in email: ${html}`);
+  return { to: call.to, subject: call.subject, html, code };
+}
+
+async function userAuthCookieValidFor(guestId: string): Promise<boolean> {
+  return isUserAuthCookieValidFor(
+    guestId,
+    cookieJar.get(USER_AUTH_COOKIE_NAME)?.value
+  );
+}
+
+describe("user auth actions", () => {
+  beforeAll(() => {
+    setupTestDb();
+  });
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.mocked(sendMail).mockReset();
+    vi.mocked(isMailerConfigured).mockReturnValue(true);
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+    vi.stubEnv("SITE_URL", "https://sessions.test.example");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  describe("requestAuthCodeAction", () => {
+    it("emails the guest a code and a login link", async () => {
+      const guest = await createGuest();
+      const result = await requestAuthCodeAction(guest.id);
+      expect(result).toEqual({ ok: true });
+      const email = await lastSentEmail();
+      expect(email.to).toMatch(/@test\.example$/);
+      // & is HTML-escaped in the rendered body.
+      expect(email.html).toContain(
+        `https://sessions.test.example/auth/login?guest=${guest.id}&amp;code=${email.code}`
+      );
+    });
+
+    it("throttles repeated requests, allowing a new one after a minute", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-18T12:00:00Z"));
+      const guest = await createGuest();
+      expect((await requestAuthCodeAction(guest.id)).ok).toBe(true);
+      const throttled = await requestAuthCodeAction(guest.id);
+      // throttled is a typed flag so the UI can tell "recent code still
+      // valid" apart from real errors without matching on the message.
+      expect(throttled).toMatchObject({ ok: false, throttled: true });
+      expect(vi.mocked(sendMail)).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(new Date("2026-07-18T12:01:01Z"));
+      expect((await requestAuthCodeAction(guest.id)).ok).toBe(true);
+      expect(vi.mocked(sendMail)).toHaveBeenCalledTimes(2);
+    });
+
+    it("fails for an unknown guest without sending mail", async () => {
+      const result = await requestAuthCodeAction("nope");
+      expect(result.ok).toBe(false);
+      expect(vi.mocked(sendMail)).not.toHaveBeenCalled();
+    });
+
+    it("fails when email is not configured", async () => {
+      vi.mocked(isMailerConfigured).mockReturnValue(false);
+      const guest = await createGuest();
+      const result = await requestAuthCodeAction(guest.id);
+      expect(result.ok).toBe(false);
+      expect(vi.mocked(sendMail)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loginAsGuestAction", () => {
+    async function protectedGuestWithCode() {
+      const guest = await createGuest();
+      await getRepositories().guests.setAuthProtection(guest.id, {
+        authProtected: true,
+        passwordHash: null,
+      });
+      await requestAuthCodeAction(guest.id);
+      const { code } = await lastSentEmail();
+      return { guest, code };
+    }
+
+    it("logs in with a valid emailed code, tolerating sloppy typing", async () => {
+      const { guest, code } = await protectedGuestWithCode();
+      const result = await loginAsGuestAction(
+        guest.id,
+        ` ${code.toLowerCase()} `
+      );
+      expect(result).toEqual({ ok: true });
+      expect(cookieJar.get("user")?.value).toBe(guest.id);
+      expect(await userAuthCookieValidFor(guest.id)).toBe(true);
+    });
+
+    it("the code stays valid for repeated logins within its window", async () => {
+      const { guest, code } = await protectedGuestWithCode();
+      expect((await loginAsGuestAction(guest.id, code)).ok).toBe(true);
+      cookieJar.clear();
+      expect((await loginAsGuestAction(guest.id, code)).ok).toBe(true);
+    });
+
+    it("rejects a wrong code and never sets cookies", async () => {
+      const { guest } = await protectedGuestWithCode();
+      const result = await loginAsGuestAction(guest.id, "WRONGONE");
+      expect(result.ok).toBe(false);
+      expect(cookieJar.get("user")).toBeUndefined();
+      expect(await userAuthCookieValidFor(guest.id)).toBe(false);
+    });
+
+    it("rejects an expired code", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-18T12:00:00Z"));
+      const { guest, code } = await protectedGuestWithCode();
+      vi.setSystemTime(new Date("2026-07-18T12:10:01Z"));
+      const result = await loginAsGuestAction(guest.id, code);
+      expect(result.ok).toBe(false);
+    });
+
+    it("locks the code after too many failed attempts", async () => {
+      const { guest, code } = await protectedGuestWithCode();
+      for (let i = 0; i < 10; i++) {
+        await loginAsGuestAction(guest.id, "WRONGONE");
+      }
+      const result = await loginAsGuestAction(guest.id, code);
+      expect(result.ok).toBe(false);
+    });
+
+    it("logs in with the permanent password", async () => {
+      const guest = await createGuest();
+      await getRepositories().guests.setAuthProtection(guest.id, {
+        authProtected: true,
+        passwordHash: await hashUserPassword("hunter2 forever"),
+      });
+      expect((await loginAsGuestAction(guest.id, "wrong")).ok).toBe(false);
+      const result = await loginAsGuestAction(guest.id, "hunter2 forever");
+      expect(result).toEqual({ ok: true });
+      expect(cookieJar.get("user")?.value).toBe(guest.id);
+      expect(await userAuthCookieValidFor(guest.id)).toBe(true);
+    });
+  });
+
+  describe("selectUserAction", () => {
+    it("switches freely to an unprotected guest", async () => {
+      const guest = await createGuest();
+      const result = await selectUserAction(guest.id);
+      expect(result).toEqual({ ok: true });
+      expect(cookieJar.get("user")?.value).toBe(guest.id);
+    });
+
+    it("refuses a protected guest without credentials", async () => {
+      const guest = await createGuest();
+      await getRepositories().guests.setAuthProtection(guest.id, {
+        authProtected: true,
+        passwordHash: null,
+      });
+      const result = await selectUserAction(guest.id);
+      expect(result).toMatchObject({ ok: false, needsAuth: true });
+      expect(cookieJar.get("user")).toBeUndefined();
+    });
+
+    it("switching away from a protected guest drops the authenticated session", async () => {
+      const protectedGuest = await createGuest();
+      const other = await createGuest();
+      await getRepositories().guests.setAuthProtection(protectedGuest.id, {
+        authProtected: true,
+        passwordHash: await hashUserPassword("hunter2 forever"),
+      });
+      await loginAsGuestAction(protectedGuest.id, "hunter2 forever");
+
+      await selectUserAction(other.id);
+      expect(cookieJar.get("user")?.value).toBe(other.id);
+      expect(await userAuthCookieValidFor(protectedGuest.id)).toBe(false);
+      // Switching back now needs credentials again.
+      expect(await selectUserAction(protectedGuest.id)).toMatchObject({
+        ok: false,
+        needsAuth: true,
+      });
+    });
+
+    it("clears the identity when passed null", async () => {
+      const guest = await createGuest();
+      await selectUserAction(guest.id);
+      await selectUserAction(null);
+      expect(cookieJar.get("user")).toBeUndefined();
+    });
+  });
+
+  describe("updateAuthSecurityAction", () => {
+    async function currentGuestWithCode() {
+      const guest = await createGuest();
+      await selectUserAction(guest.id);
+      await requestAuthCodeAction(guest.id);
+      const { code } = await lastSentEmail();
+      return { guest, code };
+    }
+
+    it("enables protection with a valid code and authenticates the session", async () => {
+      const { guest, code } = await currentGuestWithCode();
+      const result = await updateAuthSecurityAction({ code, protect: true });
+      expect(result).toEqual({ ok: true });
+      expect(
+        await getRepositories().guests.getAuthCredentials(guest.id)
+      ).toEqual({ authProtected: true, passwordHash: null });
+      expect(await userAuthCookieValidFor(guest.id)).toBe(true);
+    });
+
+    it("enables protection with a permanent password usable for login", async () => {
+      const { guest, code } = await currentGuestWithCode();
+      const result = await updateAuthSecurityAction({
+        code,
+        protect: true,
+        newPassword: "correct horse battery",
+      });
+      expect(result).toEqual({ ok: true });
+      cookieJar.clear();
+      expect(
+        (await loginAsGuestAction(guest.id, "correct horse battery")).ok
+      ).toBe(true);
+    });
+
+    it("leaves the guest unprotected when the auth cookie cannot be signed", async () => {
+      const { guest, code } = await currentGuestWithCode();
+      // e.g. AUTH_SECRET unset: enabling protection must fail as a whole,
+      // not flip the flag and then leave a guest nobody can ever log in as.
+      vi.stubEnv("AUTH_SECRET", "");
+      await expect(
+        updateAuthSecurityAction({ code, protect: true })
+      ).rejects.toThrow();
+      expect(
+        (await getRepositories().guests.getAuthCredentials(guest.id))
+          ?.authProtected
+      ).toBe(false);
+    });
+
+    it("rejects a wrong code and leaves the guest unprotected", async () => {
+      const { guest } = await currentGuestWithCode();
+      const result = await updateAuthSecurityAction({
+        code: "WRONGONE",
+        protect: true,
+      });
+      expect(result.ok).toBe(false);
+      expect(
+        await getRepositories().guests.getAuthCredentials(guest.id)
+      ).toEqual({ authProtected: false, passwordHash: null });
+    });
+
+    it("rejects the permanent password in place of a code", async () => {
+      const { guest, code } = await currentGuestWithCode();
+      await updateAuthSecurityAction({
+        code,
+        protect: true,
+        newPassword: "correct horse battery",
+      });
+      // Changing settings must always go through a fresh emailed code.
+      const result = await updateAuthSecurityAction({
+        code: "correct horse battery",
+        protect: false,
+      });
+      expect(result.ok).toBe(false);
+      expect(
+        (await getRepositories().guests.getAuthCredentials(guest.id))
+          ?.authProtected
+      ).toBe(true);
+    });
+
+    it("disables protection and clears the password", async () => {
+      const { guest, code } = await currentGuestWithCode();
+      await updateAuthSecurityAction({
+        code,
+        protect: true,
+        newPassword: "correct horse battery",
+      });
+      const result = await updateAuthSecurityAction({
+        code,
+        protect: false,
+      });
+      expect(result).toEqual({ ok: true });
+      expect(
+        await getRepositories().guests.getAuthCredentials(guest.id)
+      ).toEqual({ authProtected: false, passwordHash: null });
+    });
+
+    it("rejects a too-short password", async () => {
+      const { code } = await currentGuestWithCode();
+      const result = await updateAuthSecurityAction({
+        code,
+        protect: true,
+        newPassword: "short",
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("fails when no user is selected", async () => {
+      const guest = await createGuest();
+      await requestAuthCodeAction(guest.id);
+      const { code } = await lastSentEmail();
+      cookieJar.clear();
+      const result = await updateAuthSecurityAction({ code, protect: true });
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/utils/mailer.ts
+++ b/utils/mailer.ts
@@ -135,6 +135,17 @@ export function resetMailer(): void {
   delete g.__mailerState;
 }
 
+// Whether sending email can work at all. Lets flows that depend on a
+// delivered email (e.g. login codes) fail up front instead of pretending
+// the email went out (sendMail silently no-ops when unconfigured).
+export function isMailerConfigured(): boolean {
+  const state = g.__mailerState;
+  if (!state) {
+    throw new Error("Mailer has not been initialized");
+  }
+  return state.configured;
+}
+
 function getMailer(): Mailer | null {
   const state = g.__mailerState;
   if (!state) {

--- a/utils/user-credentials.ts
+++ b/utils/user-credentials.ts
@@ -11,6 +11,7 @@ import {
 // lives in utils/auth.ts, which must stay free of node:crypto.
 
 export const AUTH_CODE_LENGTH = 8;
+export const AUTH_CODE_VALID_MINUTES = 10;
 // No I, O, 0, 1: codes are meant to be read from an email on one device and
 // typed on another.
 const AUTH_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";


### PR DESCRIPTION
Emailed 10-minute temporary codes (link + typeable 8-char code), login
as a protected guest via password or code, server-side user switching
that drops the authenticated session on switch-away, and email-code-
gated changes to protection/password. Codes are multi-use within their
window so the emailed link and the typed code don't invalidate each
other; failed guesses are capped.

issue #370

<!-- jip:pushed-commit=8e08f879965b5cb367d277642f0cb7f60463f666 -->