### PR TITLE
feat: credential prompt and lock icon for protected users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Protect your name**: attendees can secure the name they act as with a password, so on a shared device others can't pick it and act as them. A protected name shows a small lock in the name selector; choosing it asks for the password or a one-time code emailed to the attendee. Requires SMTP for the emailed-code option
 - **Email notifications**: attendees are emailed when a session they've RSVP'd to changes time or location, hosts are emailed when a session they're hosting changes time or location, and guests are emailed when they're added as a co-host of a session. Each notification can be turned on or off individually from the new settings page (requires SMTP and `SITE_URL` to be configured)
 - **Profile and settings in the header**: once attendees pick their name, the name chip in the header opens a menu with quick links to their own profile, profile editing, and a new Settings page
 - **Richer attendee profiles**: attendees can now share where they're based, the languages they speak, contact details (email, phone, WhatsApp, Signal, Telegram, Discord, website, or anything else), and conversation starters — answers to prompts like "Ask me about", "Looking for", and "Offering", with a button that suggests more playful prompts to pick from

--- a/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/quick-voting/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import Link from "next/link";
 
 import { QuickVoting } from "./quick-voting";
@@ -8,7 +9,7 @@ export default async function ProposalQuickVoting(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const currentUser = (await cookies()).get("user")?.value;
+  const currentUser = await verifiedCurrentUser(await cookies());
   if (!currentUser) {
     return (
       <div>

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { cookies } from "next/headers";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 
 import { SessionForm } from "./session-form";
 import { getRepositories } from "@/db/container";
@@ -8,7 +9,7 @@ export async function renderSessionForm(props: {
   params: Promise<{ eventSlug: string }>;
 }) {
   const { eventSlug } = await props.params;
-  const currentUser = (await cookies()).get("user")?.value;
+  const currentUser = await verifiedCurrentUser(await cookies());
   const repos = getRepositories();
 
   const event = await repos.events.findBySlug(eventSlug);

--- a/app/(site)/auth/login/login-confirm.tsx
+++ b/app/(site)/auth/login/login-confirm.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useContext } from "react";
+import { useRouter } from "next/navigation";
+import { UserContext } from "../../context";
+import { GuestLoginForm } from "../../guest-login-form";
+
+export function LoginConfirm({
+  guestId,
+  guestName,
+  code,
+}: {
+  guestId: string;
+  guestName: string;
+  code: string;
+}) {
+  const router = useRouter();
+  const { applyUser } = useContext(UserContext);
+  return (
+    <GuestLoginForm
+      guestId={guestId}
+      guestName={guestName}
+      initialCredential={code}
+      onSuccess={() => {
+        applyUser?.(guestId);
+        router.push("/");
+        router.refresh();
+      }}
+    />
+  );
+}

--- a/app/(site)/auth/login/page.tsx
+++ b/app/(site)/auth/login/page.tsx
@@ -1,0 +1,37 @@
+import { getRepositories } from "@/db/container";
+import { LoginConfirm } from "./login-confirm";
+
+// Landing page for the emailed login link. Deliberately changes no state on
+// GET (mail scanners prefetch links); the user must submit the form below.
+export default async function AuthLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ guest?: string; code?: string }>;
+}) {
+  const { guest: guestId, code } = await searchParams;
+  const guest = guestId
+    ? await getRepositories().guests.findById(guestId)
+    : null;
+
+  if (!guest) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 sm:px-0">
+        <p className="text-gray-700">
+          This login link is invalid. Request a new code from the name selector
+          or your settings page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
+      <h1 className="text-2xl font-bold">Log in as {guest.name}</h1>
+      <LoginConfirm
+        guestId={guest.id}
+        guestName={guest.name}
+        code={code ?? ""}
+      />
+    </div>
+  );
+}

--- a/app/(site)/context.tsx
+++ b/app/(site)/context.tsx
@@ -1,5 +1,4 @@
 "use client";
-import Cookies from "js-cookie";
 import {
   createContext,
   useState,
@@ -16,6 +15,10 @@ import type {
   Rsvp,
 } from "@/db/repositories/interfaces";
 import { Vote, voteChoiceToEmoji } from "@/app/(site)/votes";
+import {
+  selectUserAction,
+  type SelectUserResult,
+} from "@/app/actions/user-auth";
 import { DEFAULT_BREAK_MINUTES, votesApiUrl } from "@/utils/utils";
 import { DEFAULT_SLOT_INCREMENT_MINUTES } from "@/utils/slots";
 import { startNowTicker } from "@/utils/now-ticker";
@@ -24,12 +27,21 @@ export type DayWithSessions = Day & { sessions: Session[] };
 
 export interface UserContextType {
   user: string | null;
-  setUser: ((u: string | null) => void) | null;
+  /**
+   * Switches the current user via the server, which owns the identity
+   * cookies. Fails with needsAuth for a protected guest — the caller should
+   * then collect credentials and call the login action, followed by
+   * applyUser on success.
+   */
+  switchUser: ((u: string | null) => Promise<SelectUserResult>) | null;
+  /** Syncs client state after the server already authenticated the user. */
+  applyUser: ((u: string | null) => void) | null;
 }
 
 export const UserContext = createContext<UserContextType>({
   user: null,
-  setUser: null,
+  switchUser: null,
+  applyUser: null,
 });
 
 export interface EventContextType {
@@ -124,18 +136,18 @@ export function UserProvider({
 }) {
   const [user, setUser] = useState<string | null>(initialUser);
 
-  const setCurrentUser = (user: string | null) => {
-    if (user) {
-      setUser(user);
-      Cookies.set("user", user);
-    } else {
-      setUser(null);
-      Cookies.remove("user");
+  const switchUser = async (
+    guestId: string | null
+  ): Promise<SelectUserResult> => {
+    const result = await selectUserAction(guestId);
+    if (result.ok) {
+      setUser(guestId);
     }
+    return result;
   };
 
   return (
-    <UserContext.Provider value={{ user, setUser: setCurrentUser }}>
+    <UserContext.Provider value={{ user, switchUser, applyUser: setUser }}>
       {children}
     </UserContext.Provider>
   );

--- a/app/(site)/guest-login-form.tsx
+++ b/app/(site)/guest-login-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+import { useState } from "react";
+import {
+  loginAsGuestAction,
+  requestAuthCodeAction,
+} from "@/app/actions/user-auth";
+
+// Credential prompt for switching to a protected guest: accepts either the
+// permanent password or an emailed temporary code in one field, with a
+// button to request a fresh code.
+export function GuestLoginForm({
+  guestId,
+  guestName,
+  initialCredential = "",
+  onSuccess,
+}: {
+  guestId: string;
+  guestName: string;
+  initialCredential?: string;
+  onSuccess: () => void;
+}) {
+  const [credential, setCredential] = useState(initialCredential);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const result = await loginAsGuestAction(guestId, credential);
+      if (result.ok) {
+        onSuccess();
+      } else {
+        setError(result.error);
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Something went wrong — try again");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const requestCode = async () => {
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const result = await requestAuthCodeAction(guestId);
+      if (result.ok) {
+        setInfo("Code sent — check your email");
+      } else {
+        setError(result.error);
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Something went wrong — try again");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+    >
+      <p className="text-sm text-gray-600">
+        {guestName} has protected their account. Enter their password or a code
+        emailed to them. No password, or forgot it? Use an emailed code instead.
+      </p>
+      <label
+        htmlFor="guest-credential"
+        className="text-sm font-medium text-gray-700"
+      >
+        Password or emailed code
+      </label>
+      <input
+        id="guest-credential"
+        type="password"
+        autoComplete="current-password"
+        value={credential}
+        onChange={(e) => setCredential(e.target.value)}
+        className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-rose-400 focus:border-transparent outline-none"
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {info && <p className="text-sm text-green-700">{info}</p>}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="submit"
+          disabled={busy || credential.length === 0}
+          className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500"
+        >
+          Log in
+        </button>
+        <button
+          type="button"
+          onClick={() => void requestCode()}
+          disabled={busy}
+          className="text-sm text-rose-500 hover:text-rose-600 underline disabled:text-gray-400"
+        >
+          Email me a code
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(site)/lock-icon.tsx
+++ b/app/(site)/lock-icon.tsx
@@ -1,11 +1,22 @@
-export function LockIcon({ className = "h-4 w-4" }: { className?: string }) {
+export function LockIcon({
+  className = "h-4 w-4",
+  title,
+}: {
+  className?: string;
+  title?: string;
+}) {
   return (
     <svg
       className={className}
       fill="currentColor"
       viewBox="0 0 20 20"
       xmlns="http://www.w3.org/2000/svg"
+      // With a title the icon conveys meaning ("this name is protected") and
+      // must be exposed to assistive tech; without one it is decorative.
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
     >
+      {title && <title>{title}</title>}
       <path
         fillRule="evenodd"
         d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"

--- a/app/(site)/user-select.tsx
+++ b/app/(site)/user-select.tsx
@@ -1,8 +1,9 @@
 "use client";
 import type { Guest } from "@/db/repositories/interfaces";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { SelectHosts } from "@/app/select-hosts";
 import { UserContext } from "./context";
+import { GuestLoginForm } from "./guest-login-form";
 
 export function UserSelect({
   guests,
@@ -13,20 +14,56 @@ export function UserSelect({
   showOnlyWhenUserSet?: boolean;
   onSelect?: () => void;
 }) {
-  const { user: currentUser, setUser } = useContext(UserContext);
+  const { user: currentUser, switchUser, applyUser } = useContext(UserContext);
+  // Set when a protected guest was picked and credentials are needed.
+  const [pendingGuest, setPendingGuest] = useState<Guest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSelect = async (guest: Guest | null) => {
+    setError(null);
+    setPendingGuest(null);
+    try {
+      const result = await switchUser?.(guest?.id ?? null);
+      if (!result) return;
+      if (result.ok) {
+        onSelect?.();
+      } else if (result.needsAuth && guest) {
+        setPendingGuest(guest);
+      } else {
+        setError(result.error);
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Something went wrong — try again");
+    }
+  };
 
   return (
     (!showOnlyWhenUserSet || currentUser) && (
-      <SelectHosts
-        id="user-selection"
-        guests={guests}
-        hosts={guests.filter((guest) => guest.id === currentUser)}
-        setHosts={(hosts) => {
-          setUser?.(hosts?.at(-1)?.id || null);
-          onSelect?.();
-        }}
-        selectMany={false}
-      />
+      <div className="flex flex-col gap-3">
+        <SelectHosts
+          id="user-selection"
+          guests={guests}
+          hosts={guests.filter((guest) => guest.id === currentUser)}
+          setHosts={(hosts) => {
+            void handleSelect(hosts?.at(-1) ?? null);
+          }}
+          selectMany={false}
+          showProtected
+        />
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {pendingGuest && (
+          <GuestLoginForm
+            guestId={pendingGuest.id}
+            guestName={pendingGuest.name}
+            onSuccess={() => {
+              applyUser?.(pendingGuest.id);
+              setPendingGuest(null);
+              onSelect?.();
+            }}
+          />
+        )}
+      </div>
     )
   );
 }

--- a/app/select-hosts.tsx
+++ b/app/select-hosts.tsx
@@ -4,15 +4,23 @@ import { Fragment, useState } from "react";
 import { Combobox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/16/solid";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { LockIcon } from "@/app/(site)/lock-icon";
 
-export function SelectHosts<T extends { id: string; name: string }>(props: {
+export function SelectHosts<
+  T extends { id: string; name: string; authProtected?: boolean },
+>(props: {
   guests: T[];
   hosts: T[];
   setHosts: (hosts: T[]) => void;
   id?: string;
   selectMany: boolean;
+  // Show a lock beside protected guests. Only meaningful where selecting a
+  // guest switches the current user (the name switcher), since that is the
+  // one flow that then asks for a password or code; in co-host pickers the
+  // indicator would wrongly imply credentials are needed to add someone.
+  showProtected?: boolean;
 }) {
-  const { guests, hosts, setHosts, id, selectMany } = props;
+  const { guests, hosts, setHosts, id, selectMany, showProtected } = props;
   const [query, setQuery] = useState("");
   const filteredGuests = guests
     .filter((guest) => guest.name.toLowerCase().includes(query.toLowerCase()))
@@ -87,12 +95,18 @@ export function SelectHosts<T extends { id: string; name: string }>(props: {
                   <>
                     <span
                       className={clsx(
-                        "block truncate",
+                        "flex items-center gap-1.5 truncate",
                         selected ? "font-medium" : "font-normal",
                         disabled ? "text-gray-400" : "text-gray-900"
                       )}
                     >
-                      {guest.name}
+                      <span className="truncate">{guest.name}</span>
+                      {showProtected && guest.authProtected && (
+                        <LockIcon
+                          className="h-3.5 w-3.5 shrink-0 text-gray-400"
+                          title="Protected — password or emailed code needed"
+                        />
+                      )}
                     </span>
                     {selected ? (
                       <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-rose-400">

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -92,6 +92,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
         name: schema.guests.name,
         avatarUrl: schema.guests.avatarUrl,
         aboutMe: schema.guests.aboutMe,
+        authProtected: schema.guests.authProtected,
       })
       .from(schema.guests)
       .innerJoin(


### PR DESCRIPTION
Switching users now goes through server actions; picking a protected
name shows a password/code form, and the emailed link lands on a
confirmation page instead of logging in on GET (mail scanners prefetch
links). Server pages read the verified user so a stale cookie cannot
impersonate a protected guest.

issue #370

<!-- jip:pushed-commit=73c26c268639aa08e1d26fbb24520e012af8092e -->