### PR TITLE
fix: enforce host-ownership on session and proposal mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Hosts can no longer RSVP to their own session**: this was already prevented everywhere in the interface, but a direct request could still add the RSVP
 - **Alphabetical sorting ignores case**: attendee, session, and proposal lists now sort names and titles case-insensitively, so e.g. "bob" no longer sorts after "Zoe"
 - **"Back to attendees" keeps your place**: returning from an attendee's profile now goes back to the same page, search, and filter you were viewing, instead of resetting to the top of the list
+- **Session and proposal editing is now enforced everywhere, not just hidden in the interface**: only a session or proposal's hosts (or, for an unclaimed proposal, anyone) can create, edit, or delete it — previously the interface hid those actions from everyone else, but a direct request could still make the change. Creating or editing as a protected name now always requires that name's password or emailed code, matching the rule already documented
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -1,6 +1,23 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { SessionProposalForm } from "@/app/(site)/[eventSlug]/session-proposal-form";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { notFound } from "next/navigation";
+
+function CantEdit(props: { eventSlug: string; children: React.ReactNode }) {
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
+      <p className="text-gray-700">{props.children}</p>
+      <Link
+        href={`/${props.eventSlug}/proposals`}
+        className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+      >
+        Back to proposals
+      </Link>
+    </div>
+  );
+}
 
 export default async function EditProposalPage({
   params,
@@ -23,6 +40,31 @@ export default async function EditProposalPage({
 
   if (!proposal) {
     notFound();
+  }
+
+  if (proposal.hosts.length > 0) {
+    const cookieStore = await cookies();
+    const currentUser = await verifiedCurrentUser(cookieStore);
+    if (!currentUser) {
+      // verifiedCurrentUser is null both when no name is selected and when the
+      // selected name is protected but unverified — distinguish so a protected
+      // host is told to authenticate, not to pick a name they already picked.
+      const nameSelected = Boolean(cookieStore.get("user")?.value);
+      return (
+        <CantEdit eventSlug={eventSlug}>
+          {nameSelected
+            ? "This name is protected. Switch to it with your password or emailed code — via the name chip in the header — before editing this proposal."
+            : "You need to select who you are before editing this proposal. Pick your name via the “Select your name” chip in the header at the top of the page."}
+        </CantEdit>
+      );
+    }
+    if (!proposal.hosts.some((h) => h.id === currentUser)) {
+      return (
+        <CantEdit eventSlug={eventSlug}>
+          Only a host of this proposal can edit it.
+        </CantEdit>
+      );
+    }
   }
 
   return (

--- a/app/(site)/[eventSlug]/proposals/actions.ts
+++ b/app/(site)/[eventSlug]/proposals/actions.ts
@@ -1,10 +1,20 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
+import {
+  actingUserIsVerified,
+  NAME_PROTECTED_ERROR,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 
 export async function createProposal(formData: FormData) {
+  if (!(await actingUserIsVerified(await cookies()))) {
+    return { error: NAME_PROTECTED_ERROR };
+  }
+
   const eventId = formData.get("event") as string;
   const eventSlug = formData.get("eventSlug") as string;
   const title = formData.get("title") as string;
@@ -76,6 +86,16 @@ export async function updateProposal(id: string, formData: FormData) {
       return { error: "Proposal not found" };
     }
 
+    if (proposal.hosts.length > 0) {
+      const actor = await verifiedCurrentUser(await cookies());
+      if (!actor || !proposal.hosts.some((h) => h.id === actor)) {
+        return {
+          error:
+            "Only a host may edit this proposal — switch to your name first",
+        };
+      }
+    }
+
     const eventGuestIds = new Set(
       (await getRepositories().guests.listByEvent(proposal.eventId)).map(
         (g) => g.id
@@ -103,6 +123,21 @@ export async function updateProposal(id: string, formData: FormData) {
 // their proposal in any phase, including scheduling.
 export async function deleteProposal(id: string, eventSlug: string) {
   try {
+    const proposal = await getRepositories().sessionProposals.findById(id);
+    if (!proposal) {
+      return { error: "Proposal not found" };
+    }
+
+    if (proposal.hosts.length > 0) {
+      const actor = await verifiedCurrentUser(await cookies());
+      if (!actor || !proposal.hosts.some((h) => h.id === actor)) {
+        return {
+          error:
+            "Only a host may delete this proposal — switch to your name first",
+        };
+      }
+    }
+
     await getRepositories().sessionProposals.delete(id);
     revalidatePath(`/${eventSlug}/proposals`);
   } catch (error) {

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -2,13 +2,20 @@ import type { NextRequest } from "next/server";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
 import { notifyCohostsAdded } from "@/utils/notifications";
-import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  actingUserIsVerified,
+  guestProtectionError,
+  verifiedCurrentUser,
+} from "@/utils/acting-guest";
 import { prepareToInsert, validateSession } from "../session-form-utils";
 import type { SessionParams } from "../session-form-utils";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
 export async function POST(req: NextRequest) {
+  if (!(await actingUserIsVerified(req.cookies))) {
+    return guestProtectionError();
+  }
   const params = (await req.json()) as SessionParams;
   const repos = getRepositories();
   const input = prepareToInsert(params);

--- a/app/api/delete-session/route.ts
+++ b/app/api/delete-session/route.ts
@@ -1,9 +1,11 @@
+import type { NextRequest } from "next/server";
 import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const { id } = (await req.json()) as { id: string };
   const repos = getRepositories();
 
@@ -22,6 +24,14 @@ export async function POST(req: Request) {
 
   if (session.adminManaged || session.blocker) {
     return new Response("Cannot delete via web app", { status: 400 });
+  }
+
+  const actor = await verifiedCurrentUser(req.cookies);
+  if (!actor || !session.hosts.some((h) => h.id === actor)) {
+    return Response.json(
+      { error: "Only a host may delete this session" },
+      { status: 403 }
+    );
   }
 
   try {

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -37,6 +37,13 @@ export async function POST(req: NextRequest) {
   if (prevSession.adminManaged || prevSession.blocker) {
     return new Response("Cannot edit via web app", { status: 400 });
   }
+  const actor = await verifiedCurrentUser(req.cookies);
+  if (!actor || !prevSession.hosts.some((h) => h.id === actor)) {
+    return Response.json(
+      { error: "Only a host may edit this session" },
+      { status: 403 }
+    );
+  }
   const eventGuestIds = new Set(
     (await repos.guests.listByEvent(event.id)).map((g) => g.id)
   );
@@ -58,18 +65,15 @@ export async function POST(req: NextRequest) {
       return Response.error();
     }
 
-    // Verified so notifications can't attribute the change to a protected
-    // guest someone merely claims to be.
-    const changedById = await verifiedCurrentUser(req.cookies);
     await notifyCohostsAdded({
       session: updated,
       previousHostIds: prevSession.hosts.map((h) => h.id),
-      changedById,
+      changedById: actor,
     });
     await notifySessionChanged({
       before: prevSession,
       after: updated,
-      changedById,
+      changedById: actor,
     });
     return Response.json({ success: true });
   } else {

--- a/tests/e2e/proposals.spec.ts
+++ b/tests/e2e/proposals.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./helpers/fixtures";
 import { loginAndGoto, login } from "./helpers/auth";
+import { selectUser } from "./helpers/user";
 
 test("should auto-focus the title input for new proposals", async ({
   page,
@@ -115,6 +116,52 @@ test("should delete a proposal from its edit page", async ({ page }) => {
   await page.reload();
   await expect(
     page.getByRole("row", { name: new RegExp(proposalTitle) })
+  ).toHaveCount(0);
+});
+
+test("a non-host cannot edit or delete another guest's proposal", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Alpha/proposals");
+  const proposalTitle = `Playwright Ownership Proposal ${Date.now()}`;
+
+  // Alice creates a proposal; she's prefilled as its only host.
+  await selectUser(page, /Alice Test/i);
+  await page.getByRole("link", { name: /Add Proposal/i }).click();
+  await page.getByLabel("Title").fill(proposalTitle);
+  await expect(page.getByRole("main").getByText("Alice Test")).toBeVisible();
+  await Promise.all([
+    page.waitForURL(/\/Conference-Alpha\/proposals$/),
+    page.getByRole("button", { name: /Submit/i }).click(),
+  ]);
+  const row = page.getByRole("row", { name: new RegExp(proposalTitle) });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: /Edit/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /Edit Session Proposal/i })
+  ).toBeVisible();
+  const editUrl = page.url();
+
+  // Bob switches in; the list no longer offers him an Edit affordance...
+  await selectUser(page, /Bob Test/i);
+  await expect(
+    page.getByRole("button", { name: "Your name: Bob Test" })
+  ).toBeVisible();
+  await page.getByRole("link", { name: /Back to Proposals/i }).click();
+  await page.waitForURL(/\/Conference-Alpha\/proposals$/);
+  await expect(
+    page.getByRole("row", { name: new RegExp(proposalTitle) })
+  ).not.toContainText("Edit");
+
+  // ...and revisiting the edit page directly (e.g. via browser history) is
+  // refused server-side too, not just hidden from the UI.
+  await page.goto(editUrl);
+  await expect(
+    page.getByText(/Only a host of this proposal can edit it/i)
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /Edit Session Proposal/i })
   ).toHaveCount(0);
 });
 

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/utils/mailer", () => ({
@@ -15,20 +23,44 @@ import {
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { POST } from "@/app/api/add-session/route";
+import { createUserAuthCookie } from "@/utils/auth";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
 
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
+
 function makeReq(
   payload: unknown,
-  opts?: { editorGuestId?: string }
+  opts?: { editorGuestId?: string; verified?: boolean }
 ): NextRequest {
+  const cookies: string[] = [];
+  if (opts?.editorGuestId) cookies.push(`user=${opts.editorGuestId}`);
   return new NextRequest("http://test/api/add-session", {
     method: "POST",
     body: JSON.stringify(payload),
     // The `user` cookie identifies the acting guest, like the site sets it.
-    headers: opts?.editorGuestId
-      ? { cookie: `user=${opts.editorGuestId}` }
-      : undefined,
+    headers: cookies.length ? { cookie: cookies.join("; ") } : undefined,
+  });
+}
+
+async function makeReqWithAuthCookie(
+  payload: unknown,
+  editorGuestId: string
+): Promise<NextRequest> {
+  const authCookie = await createUserAuthCookie(editorGuestId);
+  return new NextRequest("http://test/api/add-session", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: {
+      cookie: `user=${editorGuestId}; ${authCookie.name}=${authCookie.value}`,
+    },
   });
 }
 
@@ -57,7 +89,9 @@ describe("POST /api/add-session", () => {
   beforeEach(() => {
     resetTestDb();
     vi.mocked(sendMail).mockReset();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
   });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("emails co-hosts of the new session, but not its creator", async () => {
     const event = await createEvent({ phase: "scheduling" });
@@ -213,6 +247,40 @@ describe("POST /api/add-session", () => {
 
     const sessions = await getRepositories().sessions.listByEvent(event.id);
     expect(sessions).toHaveLength(0);
+  });
+
+  it("rejects creating as a protected guest without a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    await protectGuest(guest.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, location, day), {
+        editorGuestId: guest.id,
+      })
+    );
+    expect(res.status).toBe(403);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("creates as a protected guest with a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    await protectGuest(guest.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      await makeReqWithAuthCookie(buildPayload(guest, location, day), guest.id)
+    );
+    expect(res.ok).toBe(true);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(1);
   });
 
   // Route does not guard req.json() — parse errors surface as a thrown SyntaxError

--- a/tests/integration/delete-proposal.test.ts
+++ b/tests/integration/delete-proposal.test.ts
@@ -1,7 +1,27 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
 }));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
@@ -12,13 +32,28 @@ import {
   createSession,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { createUserAuthCookie, USER_AUTH_COOKIE_NAME } from "@/utils/auth";
 import { VoteChoice } from "@/db/repositories/interfaces";
 import { deleteProposal } from "@/app/(site)/[eventSlug]/proposals/actions";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
 
 describe("deleteProposal", () => {
   beforeAll(() => setupTestDb());
 
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("cascade-deletes votes and host links and nulls the session's proposalId, leaving other data intact", async () => {
     const repos = getRepositories();
@@ -43,6 +78,7 @@ describe("deleteProposal", () => {
     const session = await createSession(event.id, { hostIds: [host.id] });
     await repos.sessions.update(session.id, { proposalId: proposal.id });
 
+    cookieJar.set("user", host.id);
     const result = await deleteProposal(proposal.id, "test-event");
     expect(result).toEqual({ success: true });
 
@@ -64,5 +100,74 @@ describe("deleteProposal", () => {
     expect(await repos.guests.findById(host.id)).toBeDefined();
     const otherAfter = await repos.sessionProposals.findById(otherProposal.id);
     expect(otherAfter?.hosts.map((h) => h.id)).toEqual([host.id]);
+  });
+
+  it("rejects a non-host attempting to delete", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    const nonHost = await createGuest({ name: "NonHost" });
+    const proposal = await createProposal(event.id, [host.id]);
+    cookieJar.set("user", nonHost.id);
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toHaveProperty("error");
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeDefined();
+  });
+
+  it("rejects deleting with no acting guest at all", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    const proposal = await createProposal(event.id, [host.id]);
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toHaveProperty("error");
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeDefined();
+  });
+
+  it("allows anyone to delete a hostless proposal", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const proposal = await createProposal(event.id, []);
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toEqual({ success: true });
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
+  });
+
+  it("rejects a protected host without a verified session", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    await protectGuest(host.id);
+    const proposal = await createProposal(event.id, [host.id]);
+    cookieJar.set("user", host.id);
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toHaveProperty("error");
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeDefined();
+  });
+
+  it("accepts a protected host with a verified session", async () => {
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host" });
+    await protectGuest(host.id);
+    const proposal = await createProposal(event.id, [host.id]);
+    cookieJar.set("user", host.id);
+    cookieJar.set(
+      USER_AUTH_COOKIE_NAME,
+      (await createUserAuthCookie(host.id)).value
+    );
+
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toEqual({ success: true });
+
+    expect(await repos.sessionProposals.findById(proposal.id)).toBeUndefined();
   });
 });

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/utils/mailer", () => ({
@@ -13,10 +21,20 @@ import {
   createDay,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { createUserAuthCookie } from "@/utils/auth";
 import { POST as addPOST } from "@/app/api/add-session/route";
 import { POST } from "@/app/api/delete-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
 
 function makeAddReq(payload: unknown): NextRequest {
   return new NextRequest("http://test/api/add-session", {
@@ -25,10 +43,30 @@ function makeAddReq(payload: unknown): NextRequest {
   });
 }
 
-function makeDeleteReq(id: string): Request {
-  return new Request("http://test/api/delete-session", {
+function makeDeleteReq(
+  id: string,
+  opts?: { editorGuestId?: string }
+): NextRequest {
+  return new NextRequest("http://test/api/delete-session", {
     method: "POST",
     body: JSON.stringify({ id }),
+    headers: opts?.editorGuestId
+      ? { cookie: `user=${opts.editorGuestId}` }
+      : undefined,
+  });
+}
+
+async function makeDeleteReqWithAuthCookie(
+  id: string,
+  editorGuestId: string
+): Promise<NextRequest> {
+  const authCookie = await createUserAuthCookie(editorGuestId);
+  return new NextRequest("http://test/api/delete-session", {
+    method: "POST",
+    body: JSON.stringify({ id }),
+    headers: {
+      cookie: `user=${editorGuestId}; ${authCookie.name}=${authCookie.value}`,
+    },
   });
 }
 
@@ -60,7 +98,11 @@ async function createScheduledSession(
 
 describe("POST /api/delete-session", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("deleted session is absent from listByEvent", async () => {
     const event = await createEvent({ phase: "scheduling" });
@@ -70,7 +112,7 @@ describe("POST /api/delete-session", () => {
 
     const id = await createScheduledSession(event.id, guest, location, day);
 
-    const res = await POST(makeDeleteReq(id));
+    const res = await POST(makeDeleteReq(id, { editorGuestId: guest.id }));
     expect(res.ok).toBe(true);
 
     const sessions = await getRepositories().sessions.listByEvent(event.id);
@@ -98,7 +140,9 @@ describe("POST /api/delete-session", () => {
       eventId: event.id,
     });
 
-    const res = await POST(makeDeleteReq(created.id));
+    const res = await POST(
+      makeDeleteReq(created.id, { editorGuestId: guest.id })
+    );
     expect(res.status).toBe(403);
 
     const still = await getRepositories().sessions.findById(created.id);
@@ -123,10 +167,71 @@ describe("POST /api/delete-session", () => {
     const before = await getRepositories().rsvps.listByGuest(attendee.id);
     expect(before).toHaveLength(1);
 
-    const res = await POST(makeDeleteReq(sessionId));
+    const res = await POST(
+      makeDeleteReq(sessionId, { editorGuestId: host.id })
+    );
     expect(res.ok).toBe(true);
 
     const after = await getRepositories().rsvps.listByGuest(attendee.id);
     expect(after).toHaveLength(0);
+  });
+
+  it("rejects a non-host attempting to delete", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const nonHost = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(makeDeleteReq(id, { editorGuestId: nonHost.id }));
+    expect(res.status).toBe(403);
+
+    const still = await getRepositories().sessions.findById(id);
+    expect(still).toBeDefined();
+  });
+
+  it("rejects deleting with no acting guest at all", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(makeDeleteReq(id));
+    expect(res.status).toBe(403);
+
+    const still = await getRepositories().sessions.findById(id);
+    expect(still).toBeDefined();
+  });
+
+  it("rejects a protected host without a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(makeDeleteReq(id, { editorGuestId: host.id }));
+    expect(res.status).toBe(403);
+
+    const still = await getRepositories().sessions.findById(id);
+    expect(still).toBeDefined();
+  });
+
+  it("accepts a protected host with a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(await makeDeleteReqWithAuthCookie(id, host.id));
+    expect(res.ok).toBe(true);
+
+    const gone = await getRepositories().sessions.findById(id);
+    expect(gone).toBeUndefined();
   });
 });

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -1,0 +1,327 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+// Guards the invariant in CONTRIBUTING.md § Authorization: every mutating
+// handler must resolve the acting guest and refuse to act as a protected
+// guest without a verified session. This file enumerates app/api route
+// files so a newly added, unguarded handler fails the suite instead of
+// silently shipping — it must be added to VERIFIERS (with a check that
+// proves the 403) or to READ_ONLY (with a reason).
+//
+// `app/(site)/[eventSlug]/proposals/actions.ts` is covered the same way:
+// its export list is asserted below so a new export must be added to
+// PROPOSAL_ACTION_VERIFIERS too.
+
+vi.mock("@/utils/mailer", () => ({
+  sendMail: vi.fn(),
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import {
+  createEvent,
+  createGuest,
+  createLocation,
+  createDay,
+  createProposal,
+  createSession,
+} from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
+
+function apiRouteFiles(): string[] {
+  const root = path.join(process.cwd(), "app/api");
+  const results: string[] = [];
+  function walk(dir: string, rel: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name), `${rel}${entry.name}/`);
+      } else if (entry.name === "route.ts") {
+        results.push(rel.replace(/\/$/, ""));
+      }
+    }
+  }
+  walk(root, "");
+  return results.sort();
+}
+
+// Independent auth layers (admin/site gates), not the acting-guest
+// invariant this guard covers; and the unauthenticated health check.
+const OUT_OF_SCOPE_PREFIXES = ["admin/", "auth/"];
+const OUT_OF_SCOPE_EXACT = new Set(["health"]);
+
+// Read-only surfaces are exempt from the invariant per CONTRIBUTING.md.
+const READ_ONLY = new Set(["rsvps", "votes"]);
+
+type Verifier = () => Promise<void>;
+
+const VERIFIERS: Record<string, Verifier> = {
+  "add-session": async () => {
+    const { POST } = await import("@/app/api/add-session/route");
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    await protectGuest(guest.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const res = await POST(
+      new NextRequest("http://test/api/add-session", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "T",
+          description: "",
+          closed: false,
+          hosts: [guest],
+          location,
+          day,
+          startTimeMinutes: 600,
+          duration: 60,
+          timezone: "UTC",
+        }),
+        headers: { cookie: `user=${guest.id}` },
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+
+  "update-session": async () => {
+    const { POST } = await import("@/app/api/update-session/route");
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const session = await createSession(event.id, {
+      hostIds: [host.id],
+      locationIds: [location.id],
+      startTime: new Date(Date.now() + 60 * 60 * 1000),
+      endTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+    await protectGuest(host.id);
+    const res = await POST(
+      new NextRequest("http://test/api/update-session", {
+        method: "POST",
+        body: JSON.stringify({
+          id: session.id,
+          title: "Renamed",
+          description: "",
+          closed: false,
+          hosts: [host],
+          location,
+          day,
+          startTimeMinutes: 600,
+          duration: 60,
+          timezone: "UTC",
+        }),
+        headers: { cookie: `user=${host.id}` },
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+
+  "delete-session": async () => {
+    const { POST } = await import("@/app/api/delete-session/route");
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const session = await createSession(event.id, {
+      hostIds: [host.id],
+      locationIds: [location.id],
+      startTime: new Date(Date.now() + 60 * 60 * 1000),
+      endTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+    await protectGuest(host.id);
+    const res = await POST(
+      new NextRequest("http://test/api/delete-session", {
+        method: "POST",
+        body: JSON.stringify({ id: session.id }),
+        headers: { cookie: `user=${host.id}` },
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+
+  "add-vote": async () => {
+    const { POST } = await import("@/app/api/add-vote/route");
+    const guest = await createGuest();
+    await protectGuest(guest.id);
+    const res = await POST(
+      new Request("http://test/api/add-vote", {
+        method: "POST",
+        body: JSON.stringify({
+          proposalId: "nonexistent",
+          guestId: guest.id,
+          choice: "interested",
+        }),
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+
+  "delete-vote": async () => {
+    const { POST } = await import("@/app/api/delete-vote/route");
+    const guest = await createGuest();
+    await protectGuest(guest.id);
+    const res = await POST(
+      new Request("http://test/api/delete-vote", {
+        method: "POST",
+        body: JSON.stringify({
+          proposalId: "nonexistent",
+          guestId: guest.id,
+        }),
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+
+  "toggle-rsvp": async () => {
+    const { POST } = await import("@/app/api/toggle-rsvp/route");
+    const guest = await createGuest();
+    await protectGuest(guest.id);
+    const res = await POST(
+      new Request("http://test/api/toggle-rsvp", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: "nonexistent",
+          guestId: guest.id,
+        }),
+      })
+    );
+    expect(res.status).toBe(403);
+  },
+};
+
+const PROPOSAL_ACTION_EXPORTS = [
+  "createProposal",
+  "updateProposal",
+  "deleteProposal",
+] as const;
+
+const PROPOSAL_ACTION_VERIFIERS: Record<
+  (typeof PROPOSAL_ACTION_EXPORTS)[number],
+  Verifier
+> = {
+  createProposal: async () => {
+    const { createProposal } =
+      await import("@/app/(site)/[eventSlug]/proposals/actions");
+    const event = await createEvent();
+    const guest = await createGuest({ eventId: event.id });
+    await protectGuest(guest.id);
+    cookieJar.set("user", guest.id);
+    const fd = new FormData();
+    fd.set("event", event.id);
+    fd.set("eventSlug", "test-event");
+    fd.set("title", "T");
+    fd.append("hosts", guest.id);
+    const result = await createProposal(fd);
+    expect(result).toHaveProperty("error");
+  },
+
+  updateProposal: async () => {
+    const { updateProposal } =
+      await import("@/app/(site)/[eventSlug]/proposals/actions");
+    const event = await createEvent();
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const proposal = await createProposal(event.id, [host.id]);
+    cookieJar.set("user", host.id);
+    const fd = new FormData();
+    fd.set("eventSlug", "test-event");
+    fd.set("title", "Renamed");
+    const result = await updateProposal(proposal.id, fd);
+    expect(result).toHaveProperty("error");
+  },
+
+  deleteProposal: async () => {
+    const { deleteProposal } =
+      await import("@/app/(site)/[eventSlug]/proposals/actions");
+    const event = await createEvent();
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const proposal = await createProposal(event.id, [host.id]);
+    cookieJar.set("user", host.id);
+    const result = await deleteProposal(proposal.id, "test-event");
+    expect(result).toHaveProperty("error");
+  },
+};
+
+describe("mutating-surface regression guard", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  const files = apiRouteFiles().filter(
+    (f) =>
+      !OUT_OF_SCOPE_PREFIXES.some((p) => f.startsWith(p)) &&
+      !OUT_OF_SCOPE_EXACT.has(f)
+  );
+
+  for (const f of files) {
+    it(`app/api/${f}/route.ts is guarded or explicitly read-only`, () => {
+      expect(
+        READ_ONLY.has(f) || f in VERIFIERS,
+        `app/api/${f}/route.ts is neither in READ_ONLY nor VERIFIERS in ` +
+          `tests/integration/mutating-surface-guard.test.ts — add it to one`
+      ).toBe(true);
+    });
+  }
+
+  for (const [name, verify] of Object.entries(VERIFIERS)) {
+    it(
+      `app/api/${name} rejects acting as a protected guest without a verified session`,
+      verify
+    );
+  }
+
+  it("proposals/actions.ts exports exactly the known mutating actions", async () => {
+    const actions = await import("@/app/(site)/[eventSlug]/proposals/actions");
+    const exported = Object.keys(actions).sort();
+    expect(
+      exported,
+      "a new export in proposals/actions.ts needs a matching entry in " +
+        "PROPOSAL_ACTION_VERIFIERS in this file"
+    ).toEqual([...PROPOSAL_ACTION_EXPORTS].sort());
+  });
+
+  for (const [name, verify] of Object.entries(PROPOSAL_ACTION_VERIFIERS)) {
+    it(
+      `${name} rejects acting as a protected guest without a verified session`,
+      verify
+    );
+  }
+});

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -5,6 +5,13 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: () => undefined,
+    }),
+}));
+
 vi.mock("@/utils/mailer", () => ({
   sendMail: vi.fn(),
 }));

--- a/tests/integration/proposals.test.ts
+++ b/tests/integration/proposals.test.ts
@@ -1,7 +1,27 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+}));
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
 }));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
@@ -11,10 +31,20 @@ import {
   createProposal as createProposalFixture,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { createUserAuthCookie, USER_AUTH_COOKIE_NAME } from "@/utils/auth";
 import {
   createProposal,
   updateProposal,
 } from "@/app/(site)/[eventSlug]/proposals/actions";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
 
 function proposalForm(fields: Record<string, string | string[]>): FormData {
   const fd = new FormData();
@@ -30,7 +60,12 @@ function proposalForm(fields: Record<string, string | string[]>): FormData {
 
 describe("createProposal", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("creates a proposal with hosts and duration, readable via listByEvent", async () => {
     const event = await createEvent();
@@ -100,11 +135,64 @@ describe("createProposal", () => {
     );
     expect(result).toHaveProperty("error");
   });
+
+  it("rejects creating as a protected guest without a verified session", async () => {
+    const event = await createEvent();
+    const guest = await createGuest({ name: "Host", eventId: event.id });
+    await protectGuest(guest.id);
+    cookieJar.set("user", guest.id);
+
+    const result = await createProposal(
+      proposalForm({
+        event: event.id,
+        eventSlug: "test-event",
+        title: "My Proposal",
+        hosts: [guest.id],
+      })
+    );
+    expect(result).toHaveProperty("error");
+
+    const proposals = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    expect(proposals).toHaveLength(0);
+  });
+
+  it("creates as a protected guest with a verified session", async () => {
+    const event = await createEvent();
+    const guest = await createGuest({ name: "Host", eventId: event.id });
+    await protectGuest(guest.id);
+    cookieJar.set("user", guest.id);
+    cookieJar.set(
+      USER_AUTH_COOKIE_NAME,
+      (await createUserAuthCookie(guest.id)).value
+    );
+
+    const result = await createProposal(
+      proposalForm({
+        event: event.id,
+        eventSlug: "test-event",
+        title: "My Proposal",
+        hosts: [guest.id],
+      })
+    );
+    expect(result).toEqual({ success: true });
+
+    const proposals = await getRepositories().sessionProposals.listByEvent(
+      event.id
+    );
+    expect(proposals).toHaveLength(1);
+  });
 });
 
 describe("updateProposal", () => {
   beforeAll(() => setupTestDb());
-  beforeEach(() => resetTestDb());
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("updates title, description, hosts, and duration", async () => {
     const event = await createEvent();
@@ -114,6 +202,7 @@ describe("updateProposal", () => {
       title: "Original",
       durationMinutes: 30,
     });
+    cookieJar.set("user", alice.id);
 
     const result = await updateProposal(
       proposal.id,
@@ -146,6 +235,7 @@ describe("updateProposal", () => {
     const proposal = await createProposalFixture(event.id, [host.id], {
       durationMinutes: 60,
     });
+    cookieJar.set("user", host.id);
 
     const result = await updateProposal(
       proposal.id,
@@ -187,6 +277,7 @@ describe("updateProposal", () => {
     const alice = await createGuest({ name: "Alice", eventId: event.id });
     const outsider = await createGuest({ name: "Outsider" }); // not assigned
     const proposal = await createProposalFixture(event.id, [alice.id]);
+    cookieJar.set("user", alice.id);
 
     const result = await updateProposal(
       proposal.id,
@@ -202,5 +293,109 @@ describe("updateProposal", () => {
       proposal.id
     );
     expect(after?.hosts.map((h) => h.id)).toEqual([alice.id]);
+  });
+
+  it("rejects a non-host attempting to edit", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host", eventId: event.id });
+    const nonHost = await createGuest({ name: "NonHost", eventId: event.id });
+    const proposal = await createProposalFixture(event.id, [host.id], {
+      title: "Original",
+    });
+    cookieJar.set("user", nonHost.id);
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "Hijacked" })
+    );
+    expect(result).toHaveProperty("error");
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Original");
+  });
+
+  it("rejects editing with no acting guest at all", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host", eventId: event.id });
+    const proposal = await createProposalFixture(event.id, [host.id], {
+      title: "Original",
+    });
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "Hijacked" })
+    );
+    expect(result).toHaveProperty("error");
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Original");
+  });
+
+  it("allows anyone to edit a hostless proposal", async () => {
+    const event = await createEvent();
+    const proposal = await createProposalFixture(event.id, [], {
+      title: "Unclaimed",
+    });
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "Claimed by nobody" })
+    );
+    expect(result).toEqual({ success: true });
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Claimed by nobody");
+  });
+
+  it("rejects a protected host without a verified session", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host", eventId: event.id });
+    await protectGuest(host.id);
+    const proposal = await createProposalFixture(event.id, [host.id], {
+      title: "Original",
+    });
+    cookieJar.set("user", host.id);
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "Hijacked" })
+    );
+    expect(result).toHaveProperty("error");
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Original");
+  });
+
+  it("accepts a protected host with a verified session", async () => {
+    const event = await createEvent();
+    const host = await createGuest({ name: "Host", eventId: event.id });
+    await protectGuest(host.id);
+    const proposal = await createProposalFixture(event.id, [host.id], {
+      title: "Original",
+    });
+    cookieJar.set("user", host.id);
+    cookieJar.set(
+      USER_AUTH_COOKIE_NAME,
+      (await createUserAuthCookie(host.id)).value
+    );
+
+    const result = await updateProposal(
+      proposal.id,
+      proposalForm({ eventSlug: "test-event", title: "Renamed" })
+    );
+    expect(result).toEqual({ success: true });
+
+    const after = await getRepositories().sessionProposals.findById(
+      proposal.id
+    );
+    expect(after?.title).toBe("Renamed");
   });
 });

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { NextRequest } from "next/server";
 
 vi.mock("@/utils/mailer", () => ({
@@ -15,10 +23,20 @@ import {
   createDay,
 } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
+import { createUserAuthCookie } from "@/utils/auth";
 import { POST as addPOST } from "@/app/api/add-session/route";
 import { POST } from "@/app/api/update-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
 
 function makeAddReq(payload: unknown): NextRequest {
   return new NextRequest("http://test/api/add-session", {
@@ -38,6 +56,20 @@ function makeUpdateReq(
     headers: opts?.editorGuestId
       ? { cookie: `user=${opts.editorGuestId}` }
       : undefined,
+  });
+}
+
+async function makeUpdateReqWithAuthCookie(
+  payload: unknown,
+  editorGuestId: string
+): Promise<NextRequest> {
+  const authCookie = await createUserAuthCookie(editorGuestId);
+  return new NextRequest("http://test/api/update-session", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: {
+      cookie: `user=${editorGuestId}; ${authCookie.name}=${authCookie.value}`,
+    },
   });
 }
 
@@ -83,7 +115,9 @@ describe("POST /api/update-session", () => {
   beforeEach(() => {
     resetTestDb();
     vi.mocked(sendMail).mockReset();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
   });
+  afterEach(() => vi.unstubAllEnvs());
 
   it("emails RSVP'd guests when the session time changes", async () => {
     const event = await createEvent({ phase: "scheduling" });
@@ -173,10 +207,13 @@ describe("POST /api/update-session", () => {
     const before = (await getRepositories().sessions.findById(id))!;
 
     const res = await POST(
-      makeUpdateReq({
-        ...basePayload(guest, location, day, { startTimeMinutes: 12 * 60 }),
-        id,
-      })
+      makeUpdateReq(
+        {
+          ...basePayload(guest, location, day, { startTimeMinutes: 12 * 60 }),
+          id,
+        },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.ok).toBe(true);
 
@@ -210,13 +247,16 @@ describe("POST /api/update-session", () => {
       .startTime;
 
     const res = await POST(
-      makeUpdateReq({
-        ...basePayload(guest, location, day, {
-          title: "Moving",
-          startTimeMinutes: 10 * 60 + 30,
-        }),
-        id: movingId,
-      })
+      makeUpdateReq(
+        {
+          ...basePayload(guest, location, day, {
+            title: "Moving",
+            startTimeMinutes: 10 * 60 + 30,
+          }),
+          id: movingId,
+        },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.ok).toBe(false);
 
@@ -233,7 +273,10 @@ describe("POST /api/update-session", () => {
     const id = await createScheduledSession(event.id, guest, location, day);
 
     const res = await POST(
-      makeUpdateReq({ ...basePayload(guest, location, day), id })
+      makeUpdateReq(
+        { ...basePayload(guest, location, day), id },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.ok).toBe(true);
   });
@@ -261,13 +304,16 @@ describe("POST /api/update-session", () => {
     });
 
     const res = await POST(
-      makeUpdateReq({
-        ...basePayload(guest, location, day, {
-          title: "Renamed",
-          startTimeMinutes: 14 * 60,
-        }),
-        id: created.id,
-      })
+      makeUpdateReq(
+        {
+          ...basePayload(guest, location, day, {
+            title: "Renamed",
+            startTimeMinutes: 14 * 60,
+          }),
+          id: created.id,
+        },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.status).toBe(403);
 
@@ -285,7 +331,10 @@ describe("POST /api/update-session", () => {
     const outsider = await createGuest(); // not assigned to the event
 
     const res = await POST(
-      makeUpdateReq({ ...basePayload(outsider, location, day), id })
+      makeUpdateReq(
+        { ...basePayload(outsider, location, day), id },
+        { editorGuestId: guest.id }
+      )
     );
     expect(res.status).toBe(403);
 
@@ -311,10 +360,13 @@ describe("POST /api/update-session", () => {
     });
 
     const res = await POST(
-      makeUpdateReq({
-        ...basePayload(host, location, day, { hosts: [host, rsvper] }),
-        id,
-      })
+      makeUpdateReq(
+        {
+          ...basePayload(host, location, day, { hosts: [host, rsvper] }),
+          id,
+        },
+        { editorGuestId: host.id }
+      )
     );
     expect(res.ok).toBe(true);
     const remaining = await getRepositories().rsvps.listBySession(id);
@@ -332,7 +384,10 @@ describe("POST /api/update-session", () => {
     const id = await createScheduledSession(event.id, host1, loc1, day);
 
     const res = await POST(
-      makeUpdateReq({ ...basePayload(host2, loc2, day), id })
+      makeUpdateReq(
+        { ...basePayload(host2, loc2, day), id },
+        { editorGuestId: host1.id }
+      )
     );
     expect(res.ok).toBe(true);
 
@@ -340,5 +395,84 @@ describe("POST /api/update-session", () => {
     expect(updated.hosts[0].id).toBe(host2.id);
     expect(updated.locations[0].id).toBe(loc2.id);
     expect(updated.capacity).toBe(50);
+  });
+
+  it("rejects a non-host attempting to edit", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const nonHost = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, location, day, { title: "Renamed" }), id },
+        { editorGuestId: nonHost.id }
+      )
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.title).toBe("Test Session");
+  });
+
+  it("rejects editing with no acting guest at all", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq({
+        ...basePayload(host, location, day, { title: "Renamed" }),
+        id,
+      })
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.title).toBe("Test Session");
+  });
+
+  it("rejects a protected host without a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, location, day, { title: "Renamed" }), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.title).toBe("Test Session");
+  });
+
+  it("accepts a protected host with a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    await protectGuest(host.id);
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      await makeUpdateReqWithAuthCookie(
+        { ...basePayload(host, location, day, { title: "Renamed" }), id },
+        host.id
+      )
+    );
+    expect(res.ok).toBe(true);
+
+    const updated = (await getRepositories().sessions.findById(id))!;
+    expect(updated.title).toBe("Renamed");
   });
 });

--- a/utils/acting-guest.ts
+++ b/utils/acting-guest.ts
@@ -79,3 +79,21 @@ export async function verifiedCurrentUser(
   );
   return verified ? currentUser : null;
 }
+
+/**
+ * True unless the `user` cookie claims a protected guest without a verified
+ * session. Unlike verifiedCurrentUser, an absent `user` cookie doesn't fail
+ * this check — there's no protected identity being claimed, so there's
+ * nothing to verify. For creation endpoints, which have no existing object
+ * to check ownership against.
+ */
+export async function actingUserIsVerified(
+  cookieStore: ReadonlyCookies
+): Promise<boolean> {
+  const currentUser = cookieStore.get("user")?.value;
+  if (!currentUser) return true;
+  return isVerifiedAsGuest(
+    currentUser,
+    cookieStore.get(USER_AUTH_COOKIE_NAME)?.value
+  );
+}


### PR DESCRIPTION
Ownership was checked in the UI only; every mutating session/proposal
route and action now resolves the acting guest server-side and
refuses to act as a protected guest without a verified session, or as
a non-host on an existing session/proposal (hostless proposals stay
open to anyone). Adds a regression-guard test enumerating app/api
routes and proposal actions so a future unguarded handler fails CI,
and one E2E covering a non-host being refused both in the UI and on
direct navigation to the edit page.

<!-- jip:pushed-commit=32bb69ebd1a58ca36a343a7fb531b7ec7ec27132 -->