### PR TITLE
fix: deflake RSVP capacity e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- **Flaky RSVP capacity E2E test fixed**: the test left the admin panel for the site with a hard navigation immediately after saving a capacity change. That save triggers a `router.refresh`, and Firefox aborted the navigation when it started while the refresh's RSC fetch was still in flight (`NS_BINDING_ABORTED`) — failing 5 of 15 full suite runs. The existing `waitForLoadState("networkidle")` guard did not close the window, since the refresh can be scheduled just after the network goes quiet. The test now leaves via a client-side link first, which cannot abort a document load. 10 consecutive suite runs are clean
 - **More seed locations**: dev seed data now includes 5 additional locations (reading room, boardroom, auditorium, courtyard, rooftop terrace) with photos, for a more realistic local dev environment
 - **Richer seed profiles**: dev/test seed guests now come with realistic based-in, languages, contact details, and conversation-starter data, with a few guests still left blank to keep the "empty profile" case covered
 - **Configurable mailpit ports**: mailpit's host ports can now be overridden with `MAILPIT_SMTP_PORT`/`MAILPIT_UI_PORT`, so multiple project instances (e.g. separate clones or workspaces) can run on one machine without port clashes. New `make mailpit` target starts it, reading these from `.env.dev.local`; CONTRIBUTING.md documents the recommended per-clone setup

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -124,9 +124,23 @@ test("a full session blocks further RSVPs when the event enforces capacity", asy
   await expect(
     page.getByRole("button", { name: `Edit ${sessionTitle}` })
   ).toBeVisible();
-  // Saving triggers a router.refresh; navigating away while its RSC fetch is
-  // in flight aborts it and trips the console-error guard.
-  await page.waitForLoadState("networkidle");
+  // Saving triggers a router.refresh. A document navigation started while its
+  // RSC fetch is in flight is aborted by Firefox (NS_BINDING_ABORTED), and
+  // waitForLoadState("networkidle") does not reliably close that window — the
+  // refresh can be scheduled just after the network goes quiet. Leaving via a
+  // client-side link instead is a React transition, which cannot abort a
+  // document load, and it supersedes the pending refresh. The hard navigation
+  // to the site below then starts from a settled page.
+  await page
+    .getByRole("navigation", { name: "Admin" })
+    .getByRole("link", { name: "Events" })
+    .click();
+  await expect(
+    page
+      .getByRole("listitem")
+      .filter({ hasText: "Conference Gamma" })
+      .getByRole("link", { name: "Manage" })
+  ).toBeVisible();
 
   // Bob takes the only seat.
   await page.goto("/Conference-Gamma");


### PR DESCRIPTION
A hard page.goto right after an admin save races the router.refresh RSC
fetch, which Firefox aborts (NS_BINDING_ABORTED) — 5 failures in 15 suite
runs. The existing networkidle guard doesn't close the window: the refresh
can be scheduled just after the network goes quiet. Leave via a client-side
link instead, which cannot abort a document load. 10 consecutive runs clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- jip:pushed-commit=e948d39c6b6e33fe3562134ba3506389af73e9f1 -->