### PR TITLE
fix: read the verified guest, not the raw cookie, in profile pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Richer seed profiles**: dev/test seed guests now come with realistic based-in, languages, contact details, and conversation-starter data, with a few guests still left blank to keep the "empty profile" case covered
 - **Configurable mailpit ports**: mailpit's host ports can now be overridden with `MAILPIT_SMTP_PORT`/`MAILPIT_UI_PORT`, so multiple project instances (e.g. separate clones or workspaces) can run on one machine without port clashes. New `make mailpit` target starts it, reading these from `.env.dev.local`; CONTRIBUTING.md documents the recommended per-clone setup
 - **Email tests are opt-in locally**: tests that need mailpit are skipped (and reported as skipped) unless the mail variables are set in `.env.test.local`, so a fresh checkout passes without Docker. CI sets the variables explicitly and the tests fail there if they go missing, so they can never be silently skipped in CI. `make precommit` now includes the e2e tests
+- **Consistent verified-session checks**: three pages (profile edit, public profile, attendee directory) checked who's "logged in" by reading the plain name-selection cookie instead of the verified session, so a protected name without a verified session could still see edit controls meant only for a proven session. They now go through the same verified-session check used elsewhere
 
 ## [3.0.0] - 2026-07-13
 

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -22,6 +22,7 @@ import {
 import { CORE_PROMPTS } from "@/model/prompt-pool";
 import { eventNameToSlug } from "@/utils/utils";
 import { sanitizeGuest } from "@/utils/guests";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { Avatar } from "../avatar";
 import { Markdown } from "@/app/(site)/markdown";
 import { ComponentType, JSX, PropsWithChildren, SVGProps } from "react";
@@ -62,7 +63,7 @@ export default async function GuestProfilePage(props: {
     eventNameToSlug(events.find((e) => e.id === eventId)!.name);
 
   const cookieStore = await cookies();
-  const isOwnProfile = cookieStore.get("user")?.value === guestId;
+  const isOwnProfile = (await verifiedCurrentUser(cookieStore)) === guestId;
   const isSessionHost = hostedSessions.length > 0;
 
   return (

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -2,11 +2,12 @@ import Link from "next/link";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { sanitizeGuest } from "@/utils/guests";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { ProfileForm } from "./profile-form";
 
 export default async function EditProfilePage() {
   const cookieStore = await cookies();
-  const currentUser = cookieStore.get("user")?.value;
+  const currentUser = await verifiedCurrentUser(cookieStore);
 
   if (!currentUser) {
     return (

--- a/app/(site)/guests/page.tsx
+++ b/app/(site)/guests/page.tsx
@@ -6,6 +6,7 @@ import { outOfRangePageRedirect } from "@/utils/pagination";
 import { redirect } from "next/navigation";
 import { AttendeeList } from "@/app/(site)/guests/attendee-list";
 import { searchAttendees } from "@/utils/attendee-search";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { z } from "zod";
 
 const PAGE_SIZE = 25;
@@ -60,7 +61,7 @@ export default async function GuestsPage({
   if (redirectTarget) redirect(redirectTarget);
 
   const cookieStore = await cookies();
-  const currentUser = cookieStore.get("user")?.value;
+  const currentUser = await verifiedCurrentUser(cookieStore);
 
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-6 px-4 sm:px-0">

--- a/tests/integration/verified-guest-reads.test.ts
+++ b/tests/integration/verified-guest-reads.test.ts
@@ -1,0 +1,160 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Guards step 6 of docs/design/auth-improvements-plan.md: server components
+// that read the current guest must use verifiedCurrentUser, not the raw
+// `user` cookie, so a protected guest without a verified session isn't
+// treated as logged in.
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+// These pages render heavy client components (a file-upload form, a table
+// that reads router search params) that need a browser-like environment this
+// test file doesn't set up. Stubbed out: this test only cares which branch
+// the page takes, not those components' own behavior (covered elsewhere).
+vi.mock("@/app/(site)/guests/edit/profile-form", () => ({
+  ProfileForm: () => "PROFILE_FORM_STUB",
+}));
+vi.mock("@/app/(site)/guests/attendee-list", () => ({
+  AttendeeList: () => "ATTENDEE_LIST_STUB",
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createUserAuthCookie, USER_AUTH_COOKIE_NAME } from "@/utils/auth";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
+
+describe("server components read the verified guest, not the raw cookie", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  describe("guests/edit page", () => {
+    it("treats an unverified protected guest as logged out", async () => {
+      const { default: EditProfilePage } =
+        await import("@/app/(site)/guests/edit/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+
+      const html = renderToStaticMarkup(await EditProfilePage());
+      expect(html).toMatch(/select who you are/i);
+    });
+
+    it("renders the edit form for a verified protected guest", async () => {
+      const { default: EditProfilePage } =
+        await import("@/app/(site)/guests/edit/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+      cookieJar.set(
+        USER_AUTH_COOKIE_NAME,
+        (await createUserAuthCookie(guest.id)).value
+      );
+
+      const html = renderToStaticMarkup(await EditProfilePage());
+      expect(html).not.toMatch(/select who you are/i);
+    });
+  });
+
+  describe("guests/[guestId] page", () => {
+    it("doesn't show 'Edit profile' to an unverified protected guest viewing their own page", async () => {
+      const { default: GuestProfilePage } =
+        await import("@/app/(site)/guests/[guestId]/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+
+      const html = renderToStaticMarkup(
+        await GuestProfilePage({
+          params: Promise.resolve({ guestId: guest.id }),
+          searchParams: Promise.resolve({}),
+        })
+      );
+      expect(html).not.toMatch(/edit profile/i);
+    });
+
+    it("shows 'Edit profile' to a verified protected guest viewing their own page", async () => {
+      const { default: GuestProfilePage } =
+        await import("@/app/(site)/guests/[guestId]/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+      cookieJar.set(
+        USER_AUTH_COOKIE_NAME,
+        (await createUserAuthCookie(guest.id)).value
+      );
+
+      const html = renderToStaticMarkup(
+        await GuestProfilePage({
+          params: Promise.resolve({ guestId: guest.id }),
+          searchParams: Promise.resolve({}),
+        })
+      );
+      expect(html).toMatch(/edit profile/i);
+    });
+  });
+
+  describe("guests page", () => {
+    it("doesn't show 'Edit profile' for an unverified protected guest", async () => {
+      const { default: GuestsPage } = await import("@/app/(site)/guests/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+
+      const html = renderToStaticMarkup(
+        await GuestsPage({ searchParams: Promise.resolve({}) })
+      );
+      expect(html).not.toMatch(/edit profile/i);
+    });
+
+    it("shows 'Edit profile' for a verified protected guest", async () => {
+      const { default: GuestsPage } = await import("@/app/(site)/guests/page");
+      const guest = await createGuest();
+      await protectGuest(guest.id);
+      cookieJar.set("user", guest.id);
+      cookieJar.set(
+        USER_AUTH_COOKIE_NAME,
+        (await createUserAuthCookie(guest.id)).value
+      );
+
+      const html = renderToStaticMarkup(
+        await GuestsPage({ searchParams: Promise.resolve({}) })
+      );
+      expect(html).toMatch(/edit profile/i);
+    });
+  });
+});


### PR DESCRIPTION
Profile edit, public profile, and the attendee directory checked the
plain `user` cookie for "who's logged in" instead of the verified
session, so a protected guest without a verified session could still
see edit controls meant only for a proven session.

<!-- jip:pushed-commit=5244ce6073baf7ca2cc2256ecde740f6fc913230 -->