### PR TITLE
fix: don't double-prefix event website links with https://

### DIFF
--- a/app/(site)/[eventSlug]/schedule-toolbar.tsx
+++ b/app/(site)/[eventSlug]/schedule-toolbar.tsx
@@ -91,7 +91,7 @@ function EventDetails(props: { event: Event }) {
         {event.website && (
           <a
             className="flex items-center gap-1 hover:underline"
-            href={`https://${event.website}`}
+            href={event.website}
           >
             <LinkIcon className="h-4 w-4 stroke-2" />
             <span>{event.website}</span>

--- a/app/(site)/summary-page.tsx
+++ b/app/(site)/summary-page.tsx
@@ -42,13 +42,15 @@ export default function SummaryPage(props: {
                       .toFormat("LLL d")}
                   </span>
                 </span>
-                <a
-                  className="flex gap-1 items-center hover:underline"
-                  href={`https://${event.website}`}
-                >
-                  <LinkIcon className="h-3 w-3 stroke-2" />
-                  <span>{event.website}</span>
-                </a>
+                {event.website && (
+                  <a
+                    className="flex gap-1 items-center hover:underline"
+                    href={event.website}
+                  >
+                    <LinkIcon className="h-3 w-3 stroke-2" />
+                    <span>{event.website}</span>
+                  </a>
+                )}
               </div>
               <div className="text-gray-900 mt-2">
                 <Markdown>{event.description}</Markdown>

--- a/app/actions/admin-events.ts
+++ b/app/actions/admin-events.ts
@@ -3,7 +3,11 @@
 import { revalidatePath } from "next/cache";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import { eventNameToSlug, RESERVED_EVENT_SLUGS } from "@/utils/utils";
+import {
+  eventNameToSlug,
+  normalizeWebsiteUrl,
+  RESERVED_EVENT_SLUGS,
+} from "@/utils/utils";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
 import type { Event } from "@/db/repositories/interfaces";
 import type { AdminActionResult } from "./admin-guests";
@@ -96,7 +100,7 @@ function parseEventInput(input: EventInput): ParseResult {
     data: {
       name,
       description: input.description.trim(),
-      website: input.website.trim(),
+      website: normalizeWebsiteUrl(input.website),
       start,
       end,
       timezone,

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { ADMIN_COOKIE_NAME, isAdminCookieValid } from "@/utils/auth";
-import { eventNameToSlug, RESERVED_EVENT_SLUGS } from "@/utils/utils";
+import {
+  eventNameToSlug,
+  normalizeWebsiteUrl,
+  RESERVED_EVENT_SLUGS,
+} from "@/utils/utils";
 import {
   DEFAULT_SLOT_INCREMENT_MINUTES,
   SLOT_INCREMENT_OPTIONS,
@@ -151,7 +155,7 @@ export async function POST(req: Request) {
     event = await events.create({
       name,
       description: (body.description ?? "").trim(),
-      website: (body.website ?? "").trim(),
+      website: normalizeWebsiteUrl(body.website ?? ""),
       start,
       end,
       timezone,

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -1289,7 +1289,7 @@ function seedTestData() {
     slug: eventNameToSlug(config.name),
     description: config.description,
     icon: config.icon,
-    website: `test-event-${index + 1}.example.com`,
+    website: `https://test-event-${index + 1}.example.com`,
     start: config.start.toISOString(),
     end: config.end.toISOString(),
     proposalPhaseStart: config.proposalPhaseStart.toISOString(),

--- a/tests/integration/admin-create-event-route.test.ts
+++ b/tests/integration/admin-create-event-route.test.ts
@@ -91,6 +91,25 @@ describe("POST /api/admin/create-event", () => {
     expect(event?.schedulingPhaseEnd).toBeUndefined();
   });
 
+  it("adds an https:// scheme to a bare website domain", async () => {
+    const res = await POST(makeReq({ ...VALID_BODY, website: "example.com" }));
+    expect(res.status).toBe(201);
+    const event = await getRepositories().events.findBySlug("Summer-Camp");
+    expect(event?.website).toBe("https://example.com");
+  });
+
+  it("keeps an already-schemed website URL unchanged", async () => {
+    const res = await POST(
+      makeReq({
+        ...VALID_BODY,
+        website: "https://example.com",
+      })
+    );
+    expect(res.status).toBe(201);
+    const event = await getRepositories().events.findBySlug("Summer-Camp");
+    expect(event?.website).toBe("https://example.com");
+  });
+
   it("accepts explicit timezone, durations and scheduling phase", async () => {
     const res = await POST(
       makeReq({

--- a/tests/integration/admin-events.test.ts
+++ b/tests/integration/admin-events.test.ts
@@ -451,6 +451,26 @@ describe("event actions", () => {
       const event = await getRepositories().events.findByName("Test Event");
       expect(event?.rsvpCapacityHardLimit).toBe(false);
     });
+
+    it("adds an https:// scheme to a bare website domain", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        website: "example.com",
+      });
+      expect(result.ok).toBe(true);
+      const event = await getRepositories().events.findByName("Test Event");
+      expect(event?.website).toBe("https://example.com");
+    });
+
+    it("keeps an already-schemed website URL unchanged", async () => {
+      const result = await createEventAction({
+        ...VALID_EVENT_INPUT,
+        website: "https://example.com",
+      });
+      expect(result.ok).toBe(true);
+      const event = await getRepositories().events.findByName("Test Event");
+      expect(event?.website).toBe("https://example.com");
+    });
   });
 
   describe("updateEventAction", () => {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -3,6 +3,7 @@ import {
   durationMinusBreak,
   formatDuration,
   eventNameToSlug,
+  normalizeWebsiteUrl,
   dateOnDay,
   getPercentThroughDay,
   getStartTimePlusBreak,
@@ -70,6 +71,37 @@ describe("eventNameToSlug", () => {
 
   it("returns an empty slug when nothing safe remains", () =>
     expect(eventNameToSlug("///")).toBe(""));
+});
+
+// ── normalizeWebsiteUrl ──────────────────────────────────────────────────────
+
+describe("normalizeWebsiteUrl", () => {
+  it("adds an https:// scheme to a bare domain", () =>
+    expect(normalizeWebsiteUrl("example.com")).toBe("https://example.com"));
+
+  it("leaves an https:// URL unchanged", () =>
+    expect(normalizeWebsiteUrl("https://example.com")).toBe(
+      "https://example.com"
+    ));
+
+  it("leaves an http:// URL unchanged", () =>
+    expect(normalizeWebsiteUrl("http://example.com")).toBe(
+      "http://example.com"
+    ));
+
+  it("is case-insensitive about an existing scheme", () =>
+    expect(normalizeWebsiteUrl("HTTPS://example.com")).toBe(
+      "HTTPS://example.com"
+    ));
+
+  it("trims surrounding whitespace", () =>
+    expect(normalizeWebsiteUrl("  example.com  ")).toBe("https://example.com"));
+
+  it("returns an empty string unchanged", () =>
+    expect(normalizeWebsiteUrl("")).toBe(""));
+
+  it("returns an empty string for whitespace-only input", () =>
+    expect(normalizeWebsiteUrl("   ")).toBe(""));
 });
 
 // ── votesApiUrl ──────────────────────────────────────────────────────────────

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -41,6 +41,18 @@ export function eventNameToSlug(name: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+/**
+ * Normalizes an admin-entered website value into a URL with a scheme, so it
+ * can be used directly as a link href. Admins may enter a bare domain
+ * ("example.com") or a full URL ("https://example.com"); prefixing a scheme
+ * unconditionally would turn the latter into "https://https://example.com".
+ */
+export function normalizeWebsiteUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
 // Top-level route segments served by this app (see app/); an event slug
 // matching one of these would shadow or be shadowed by that route.
 export const RESERVED_EVENT_SLUGS = new Set(["admin", "api", "login", "media"]);


### PR DESCRIPTION
The admin config lets organizers enter a full URL (https://example.com)
or a bare domain (example.com); links always prepended https:// blindly,
breaking the former into https://https://example.com.

<!-- jip:pushed-commit=e78661e22038ad3b4bccd07af8a4ff13179f44ea -->