### PR TITLE
fix: reject RSVPs from a host to their own session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **Host RSVPs cleared on edit**: adding an attendee as a session host now removes their RSVP to that session, including when an organizer edits the session from the admin panel
+- **Hosts can no longer RSVP to their own session**: this was already prevented everywhere in the interface, but a direct request could still add the RSVP
 
 ### Internal
 

--- a/app/api/toggle-rsvp/route.ts
+++ b/app/api/toggle-rsvp/route.ts
@@ -43,6 +43,13 @@ export async function POST(req: Request) {
   }
 
   if (!remove) {
+    if (session.hosts.some((h) => h.id === guestId)) {
+      return Response.json(
+        { error: "Hosts cannot RSVP to their own session" },
+        { status: 403 }
+      );
+    }
+
     const enforceCapacity = event.rsvpCapacityHardLimit && session.capacity > 0;
     try {
       if (enforceCapacity) {

--- a/tests/integration/rsvp.test.ts
+++ b/tests/integration/rsvp.test.ts
@@ -92,6 +92,19 @@ describe("POST /api/toggle-rsvp", () => {
     expect(await rsvpsForGuest(guest.id)).toHaveLength(0);
   });
 
+  it("rejects a host RSVPing to their own session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest();
+    const session = await createSession(event.id, { hostIds: [host.id] });
+    await getRepositories().guests.assignToEvent(event.id, [host.id]);
+
+    const res = await toggleRsvp(
+      makeToggleReq({ sessionId: session.id, guestId: host.id })
+    );
+    expect(res.status).toBe(403);
+    expect(await rsvpsForGuest(host.id)).toHaveLength(0);
+  });
+
   it("rejects RSVPs from a guest who isn't assigned to the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest();


### PR DESCRIPTION
toggle-rsvp didn't enforce the host/RSVP invariant that clash-actions.ts
already assumed, so a direct request could still create one.

<!-- jip:pushed-commit=7f96c69390ccde8094fea271af3494a29ae435ff -->