### PR TITLE
fix: stop input fields shifting slightly on focus

### DIFF
--- a/app/input.tsx
+++ b/app/input.tsx
@@ -19,7 +19,7 @@ export const Input = forwardRef(
             "h-12 rounded-md border bg-white px-4 shadow-sm transition-colors invalid:border-red-500 invalid:text-red-900 invalid:placeholder-red-300 focus:outline-none disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500",
             error
               ? "border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500" // matches invalid: styles
-              : "border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none",
+              : "border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-transparent",
             className
           )}
           {...rest}


### PR DESCRIPTION
focus:border-none dropped the border width to 0, which shifted
content inward by ~1px since it's measured from the border edge.
Use focus:border-transparent instead to keep the box model stable.

<!-- jip:pushed-commit=62b977447cffe4698d4576c0fd56f63b44c1f2cb -->