### PR TITLE
feat: persist kiosk mode in a cookie across navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Kiosk mode stays on while browsing**: opening a schedule with `?kiosk=1` used to only stay in kiosk mode on that exact page — clicking any link (e.g. to Proposals) dropped back to the normal view. It now stays on across the whole site until turned off with `?kiosk=0`
 - **Settings separated from the public profile**: email notification preferences moved from the profile edit page to the dedicated Settings page, so private preferences are clearly apart from what other attendees can see
 - **Your name is always visible**: the attendee you're acting as now shows as a chip in the header on every page — proposals, voting, and schedule — so it's always clear who "you" are, and you can switch attendee from there (handy for a shared device)
 - **Attendee list shows location, not bio**: rows on the attendees page now show each person's pronouns and where they're based instead of a preview of their bio

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a public open-source fork of [rachelweinberg12/scheduling-app](https://g
 - **Scheduling board** — drag sessions onto a time/location grid
 - **Event phases** — proposal, voting, and scheduling phases with configurable date ranges
 - **Multi-event support** — host multiple events from one deployment
-- **Kiosk mode** — append `?kiosk=1` to a schedule URL for large screens at the venue: a red line marks the current time, the schedule auto-scrolls to it and refreshes periodically, and the screen is kept awake. The schedule stays fully interactive. Combine with `loc` filters (e.g. `?kiosk=1&loc=Main+Hall`) to show only some rooms.
+- **Kiosk mode** — append `?kiosk=1` to a schedule URL for large screens at the venue: a red line marks the current time, the schedule auto-scrolls to it and refreshes periodically, and the screen is kept awake. The schedule stays fully interactive. Kiosk mode sticks across navigation once set — turn it off with `?kiosk=0`. Combine with `loc` filters (e.g. `?kiosk=1&loc=Main+Hall`) to show only some rooms.
 - **Site password protection** — optional single-password gate for the whole app
 
 ![Scheduling board](https://schellingboard.org/screenshots/schedule-grid.png)

--- a/app/(site)/[eventSlug]/kiosk.tsx
+++ b/app/(site)/[eventSlug]/kiosk.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 // Kiosk mode (?kiosk=1) is for unattended large screens at the venue: a red
@@ -18,9 +18,50 @@ const INTERACTION_IDLE_MS = 60 * 1000;
 /** How often the event data is refetched so the display never goes stale. */
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
+/** Cookie that lets kiosk mode survive navigation once ?kiosk=1 has set it. */
+const KIOSK_COOKIE_NAME = "kiosk";
+const KIOSK_COOKIE_MAX_AGE_SEC = 365 * 24 * 60 * 60;
+
+function hasKioskCookie(): boolean {
+  return document.cookie
+    .split("; ")
+    .some((entry) => entry.split("=")[0] === KIOSK_COOKIE_NAME);
+}
+
+// The cookie is only ever written by this hook (never by another tab we need
+// to react to live), so subscribing is a no-op; the value is re-read on every
+// render a ?kiosk change or navigation already triggers.
+const subscribeKioskCookie = () => () => {};
+
+/**
+ * Kiosk mode is entered via ?kiosk=1 and left via ?kiosk=0; a cookie makes it
+ * stick across navigation the rest of the time, so a kiosk display doesn't
+ * fall out of kiosk mode just because a visitor clicked a link.
+ */
 export function useKioskMode(): boolean {
   const searchParams = useSearchParams();
-  return searchParams?.get("kiosk") != null;
+  const param = searchParams?.get("kiosk") ?? null;
+
+  useEffect(() => {
+    if (param === "0") {
+      document.cookie = `${KIOSK_COOKIE_NAME}=; path=/; max-age=0`;
+    } else if (param != null) {
+      document.cookie = `${KIOSK_COOKIE_NAME}=1; path=/; max-age=${KIOSK_COOKIE_MAX_AGE_SEC}`;
+    }
+  }, [param]);
+
+  // The cookie can't be read during render on the server, so report false for
+  // SSR and the first hydration pass; useSyncExternalStore then re-reads it on
+  // the client. Only consulted when the URL carries no ?kiosk parameter.
+  const cookieEnabled = useSyncExternalStore(
+    subscribeKioskCookie,
+    hasKioskCookie,
+    () => false
+  );
+
+  if (param === "0") return false;
+  if (param != null) return true;
+  return cookieEnabled;
 }
 
 /**

--- a/docs/hosting/how-it-works.md
+++ b/docs/hosting/how-it-works.md
@@ -50,9 +50,11 @@ Rules:
 Append `?kiosk=1` to a schedule URL for an unattended screen at the venue: a
 red line marks the current time, the view auto-scrolls back to it after a
 minute of no interaction, the screen is kept awake, and the page refreshes
-periodically. It stays fully interactive. Add `&loc=Main+Hall` (repeatable)
-to show only specific locations — handy for a kiosk in one room or a
-shareable filtered link.
+periodically. It stays fully interactive. Once set, kiosk mode sticks as
+visitors browse the site — clicking through to Proposals and back keeps the
+display in kiosk mode — until you turn it off with `?kiosk=0`. Add
+`&loc=Main+Hall` (repeatable) to show only specific locations — handy for a
+kiosk in one room or a shareable filtered link.
 
 ## Multi-event installs
 

--- a/tests/e2e/kiosk.spec.ts
+++ b/tests/e2e/kiosk.spec.ts
@@ -40,7 +40,10 @@ async function openGammaScheduleDuringEvent(page: Page, path: string) {
   await page.getByRole("button", { name: "Grid" }).click();
   await expect(page).toHaveURL(/view=grid/);
   await page.clock.setFixedTime(duringGammaDayOne);
-  await page.clock.runFor("05:00");
+  // Just under the 5-minute REFRESH_INTERVAL_MS in kiosk.tsx: a full 5:00
+  // fires KioskController's router.refresh(), which can race a subsequent
+  // navigation in the test and trip the console-error guard.
+  await page.clock.runFor("04:59");
 }
 
 test("kiosk mode draws a now line and auto-scrolls it into view", async ({
@@ -52,5 +55,41 @@ test("kiosk mode draws a now line and auto-scrolls it into view", async ({
 
 test("without the kiosk parameter there is no now line", async ({ page }) => {
   await openGammaScheduleDuringEvent(page, "/Conference-Gamma");
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+});
+
+test("kiosk mode persists via cookie after navigating without the parameter", async ({
+  page,
+}) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma?kiosk=1");
+  await expect(page.getByTestId("now-line")).toBeInViewport();
+
+  // Neither link below carries ?kiosk=1, yet the display should stay in
+  // kiosk mode: the cookie set on the first load should carry it through.
+  await page.getByRole("link", { name: "Proposals" }).click();
+  await page.getByRole("link", { name: "View Schedule" }).click();
+  await expect(page).toHaveURL(/\/Conference-Gamma$/);
+
+  await expect(page.getByTestId("now-line")).toBeInViewport();
+});
+
+test("?kiosk=0 clears the cookie and leaves kiosk mode", async ({ page }) => {
+  await openGammaScheduleDuringEvent(page, "/Conference-Gamma?kiosk=1");
+  await expect(page.getByTestId("now-line")).toBeInViewport();
+
+  // Leave via a client-side link first and wait for it to settle: a hard
+  // page.goto right after kiosk mode was active risks getting aborted by an
+  // in-flight fetch (NS_BINDING_ABORTED) — see memory
+  // e2e-nav-abort-after-admin-save.
+  await page.getByRole("link", { name: "Proposals" }).click();
+  await expect(
+    page.getByRole("heading", { name: /Session Proposals/ })
+  ).toBeVisible();
+  await page.goto("/Conference-Gamma?kiosk=0");
+  await expect(page.getByTestId("now-line")).toHaveCount(0);
+
+  // A plain reload (no parameter at all) should stay out of kiosk mode too,
+  // proving the cookie was actually cleared rather than just overridden.
+  await page.goto("/Conference-Gamma");
   await expect(page.getByTestId("now-line")).toHaveCount(0);
 });


### PR DESCRIPTION
?kiosk=1 previously only applied to the exact page it was set on; any
link click dropped back to the normal view. ?kiosk=0 turns it back off.

<!-- jip:pushed-commit=4d33f2102a7565eb288e9677c408fa90999deb01 -->