### PR TITLE
fix: sort names and titles case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Host RSVPs cleared on edit**: adding an attendee as a session host now removes their RSVP to that session, including when an organizer edits the session from the admin panel
 - **Hosts can no longer RSVP to their own session**: this was already prevented everywhere in the interface, but a direct request could still add the RSVP
+- **Alphabetical sorting ignores case**: attendee, session, and proposal lists now sort names and titles case-insensitively, so e.g. "bob" no longer sorts after "Zoe"
 
 ### Internal
 

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -150,7 +150,7 @@ export function ProposalTable({
         const hostNamesStr = (hosts: SessionProposal["hosts"]) =>
           hosts
             .map((h) => h.name)
-            .sort()
+            .sort((x, y) => x.localeCompare(y))
             .join("");
         cmp = hostNamesStr(a.hosts).localeCompare(hostNamesStr(b.hosts));
       }

--- a/app/(site)/[eventSlug]/view-session/view-session.tsx
+++ b/app/(site)/[eventSlug]/view-session/view-session.tsx
@@ -85,7 +85,7 @@ export function ViewSession(props: {
       ? null
       : optimisticRsvps
           .flatMap((rsvp) => guestMap.get(rsvp.guestId) ?? [])
-          .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+          .sort((a, b) => a.name.localeCompare(b.name));
 
   const location = locations.find((loc) => loc.id === session.locations[0]?.id);
 

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -130,7 +130,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .where(where)
       // id as tiebreaker: name is not unique, and without a deterministic
       // order LIMIT/OFFSET pagination can duplicate or skip rows.
-      .orderBy(schema.guests.name, schema.guests.id)
+      .orderBy(sql`${schema.guests.name} collate nocase`, schema.guests.id)
       .limit(opts.limit)
       .offset(opts.offset)
       .all()
@@ -166,7 +166,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
         .from(schema.guests)
         .where(opts.host ? isHostExpr : undefined)
         // id as tiebreaker so equal names keep a deterministic order.
-        .orderBy(schema.guests.name, schema.guests.id)
+        .orderBy(sql`${schema.guests.name} collate nocase`, schema.guests.id)
         .all()
         .map((row) => ({ ...row, isHost: Boolean(row.isHost) }) as Attendee)
     );
@@ -191,7 +191,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
         eq(schema.eventGuests.eventId, schema.events.id)
       )
       .where(inArray(schema.eventGuests.guestId, guestIds))
-      .orderBy(schema.events.name, schema.events.id)
+      .orderBy(sql`${schema.events.name} collate nocase`, schema.events.id)
       .all();
     for (const row of rows) {
       result.get(row.guestId)?.push({ id: row.eventId, name: row.eventName });
@@ -247,7 +247,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
       .where(where)
       // id as tiebreaker: name is not unique, and without a deterministic
       // order LIMIT/OFFSET pagination can duplicate or skip rows.
-      .orderBy(schema.guests.name, schema.guests.id)
+      .orderBy(sql`${schema.guests.name} collate nocase`, schema.guests.id)
       .limit(opts.limit)
       .offset(opts.offset)
       .all()

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -91,7 +91,10 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .where(where)
       // id as tiebreaker: name is not unique, and without a deterministic
       // order LIMIT/OFFSET pagination can duplicate or skip rows.
-      .orderBy(schema.locations.name, schema.locations.id)
+      .orderBy(
+        sql`${schema.locations.name} collate nocase`,
+        schema.locations.id
+      )
       .limit(opts.limit)
       .offset(opts.offset)
       .all()

--- a/db/repositories/sqlite/session-proposals.ts
+++ b/db/repositories/sqlite/session-proposals.ts
@@ -192,7 +192,10 @@ export class SqliteSessionProposalsRepository implements SessionProposalsReposit
       .where(where)
       // id as tiebreaker: title is not unique, and without a deterministic
       // order LIMIT/OFFSET pagination can duplicate or skip rows.
-      .orderBy(schema.sessionProposals.title, schema.sessionProposals.id)
+      .orderBy(
+        sql`${schema.sessionProposals.title} collate nocase`,
+        schema.sessionProposals.id
+      )
       .limit(opts.limit)
       .offset(opts.offset)
       .all();

--- a/db/repositories/sqlite/sessions.ts
+++ b/db/repositories/sqlite/sessions.ts
@@ -237,7 +237,7 @@ export class SqliteSessionsRepository implements SessionsRepository {
       .where(where)
       // id as tiebreaker: title is not unique, and without a deterministic
       // order LIMIT/OFFSET pagination can duplicate or skip rows.
-      .orderBy(schema.sessions.title, schema.sessions.id)
+      .orderBy(sql`${schema.sessions.title} collate nocase`, schema.sessions.id)
       .limit(opts.limit)
       .offset(opts.offset)
       .all();


### PR DESCRIPTION
SQLite's default collation and a couple of client-side comparisons
were case-sensitive, so e.g. "bob" sorted after "Zoe" in attendee,
session, and proposal lists.

<!-- jip:pushed-commit=d757356180fb484a49ac46f4d408c63dc41aabfb -->