### PR TITLE
fix: "Back to attendees" preserves pagination, search, and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Host RSVPs cleared on edit**: adding an attendee as a session host now removes their RSVP to that session, including when an organizer edits the session from the admin panel
 - **Hosts can no longer RSVP to their own session**: this was already prevented everywhere in the interface, but a direct request could still add the RSVP
 - **Alphabetical sorting ignores case**: attendee, session, and proposal lists now sort names and titles case-insensitively, so e.g. "bob" no longer sorts after "Zoe"
+- **"Back to attendees" keeps your place**: returning from an attendee's profile now goes back to the same page, search, and filter you were viewing, instead of resetting to the top of the list
 
 ### Internal
 

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -33,8 +33,13 @@ import {
 
 export default async function GuestProfilePage(props: {
   params: Promise<{ guestId: string }>;
+  searchParams: Promise<{ from?: string }>;
 }) {
   const { guestId } = await props.params;
+  const { from } = await props.searchParams;
+  // Only ever a query string appended to "/guests" (see attendee-list.tsx),
+  // so this can't become a redirect off-site even if `from` is tampered with.
+  const backHref = from ? `/guests?${from}` : "/guests";
   const repos = getRepositories();
 
   const [completeGuest, hostedSessions, proposals, rsvpdSessions, events] =
@@ -64,7 +69,7 @@ export default async function GuestProfilePage(props: {
     <div className="max-w-2xl mx-auto flex flex-col gap-8 px-4 sm:px-0">
       <div className="flex items-center justify-between gap-4">
         <Link
-          href="/guests"
+          href={backHref}
           className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
         >
           Back to attendees

--- a/app/(site)/guests/attendee-list.tsx
+++ b/app/(site)/guests/attendee-list.tsx
@@ -15,14 +15,22 @@ export type AttendeeRowData = Pick<
 
 function AttendeeRow({
   attendee: { id, avatarUrl, name, pronouns, basedIn, isHost },
+  listQueryString,
 }: {
   attendee: AttendeeRowData;
+  listQueryString: string;
 }) {
   // Fixed row shape (avatar, name, pronouns, based-in) so the list stays
   // consistent regardless of which optional profile fields are filled in.
+  const href = listQueryString
+    ? // Carries the list's current page/search/filter so the profile page's
+      // "Back to attendees" link can return to the same view instead of
+      // always resetting to page 1.
+      `/guests/${id}?from=${encodeURIComponent(listQueryString)}`
+    : `/guests/${id}`;
   return (
     <Link
-      href={`/guests/${id}`}
+      href={href}
       className="flex items-center gap-4 hover:bg-gray-50 rounded-md px-2"
     >
       <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
@@ -54,7 +62,10 @@ export function AttendeeList(props: {
   filter?: string;
   filters: { value: string; label: string }[];
 }) {
-  const { setParams } = useTableParams();
+  const { searchParams, setParams } = useTableParams();
+  // The raw query string (no leading "/guests?"), forwarded as `from` on
+  // each row link so the profile page can rebuild "/guests?<from>".
+  const listQueryString = searchParams.toString();
   const toolbar = (
     <div className="flex gap-2">
       {props.filters.map((f) => (
@@ -97,7 +108,9 @@ export function AttendeeList(props: {
         searchQuery={props.searchQuery}
         searchPlaceholder="Search names, languages, interests…"
         emptyMessage="No attendees match."
-        listItem={(u) => <AttendeeRow attendee={u} />}
+        listItem={(u) => (
+          <AttendeeRow attendee={u} listQueryString={listQueryString} />
+        )}
       />
     </div>
   );

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -307,3 +307,38 @@ test("shows an error on the edit page when no user is selected", async ({
     page.getByRole("heading", { name: /Edit profile/i })
   ).toHaveCount(0);
 });
+
+test("Back to attendees preserves pagination", async ({ page }) => {
+  await login(page);
+  await page.goto("/guests");
+
+  await page.getByRole("button", { name: "Next page" }).click();
+  await expect(page.getByText("Page 2 of 2")).toBeVisible();
+
+  // Seed data is 40 guests sorted alphabetically; "Mateo Quispe" is 26th,
+  // i.e. the first row of page 2.
+  await page.getByRole("link", { name: "Mateo Quispe" }).click();
+  await expect(page).toHaveURL(/\/guests\/[^/]+/);
+
+  await page.getByRole("link", { name: "Back to attendees" }).click();
+  await expect(page.getByText("Page 2 of 2")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Mateo Quispe" })).toBeVisible();
+});
+
+test("Back to attendees preserves the search query", async ({ page }) => {
+  await login(page);
+  await page.goto("/guests");
+
+  await page.getByLabel("Search").fill("Test");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(page.getByRole("link", { name: "Alice Test" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
+
+  await page.getByRole("link", { name: "Alice Test" }).click();
+  await expect(page).toHaveURL(/\/guests\/[^/]+/);
+
+  await page.getByRole("link", { name: "Back to attendees" }).click();
+  await expect(page.getByLabel("Search")).toHaveValue("Test");
+  await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Charlie Test" })).toBeVisible();
+});


### PR DESCRIPTION
<!-- jip:pushed-commit=ee8e4c07835f11e3f579868936affbd397c052d1 -->