### PR TITLE
test: fix flaky password salt test using a 2-char password

### DIFF
--- a/tests/unit/user-auth.test.ts
+++ b/tests/unit/user-auth.test.ts
@@ -86,9 +86,12 @@ describe("user passwords", () => {
   });
 
   it("salts hashes (same password, different hash)", async () => {
-    const a = await hashUserPassword("pw");
-    const b = await hashUserPassword("pw");
+    // Long enough that the hash accidentally containing the password by
+    // chance is negligible (~1e-11), unlike a short password such as "pw".
+    const password = "correct horse battery staple";
+    const a = await hashUserPassword(password);
+    const b = await hashUserPassword(password);
     expect(a).not.toBe(b);
-    expect(a).not.toContain("pw");
+    expect(a).not.toContain(password);
   });
 });


### PR DESCRIPTION
"pw" is short enough that the base64 hash can contain it by chance
(~1.6% failure rate per the fermi estimate). Use a longer test
password to make that negligible.

fixes #661

<!-- jip:pushed-commit=87f8e12e6ed1b9dd03a8af9ebeb9e89d2120fdaa -->