### PR TITLE
feat: make per-user RSVP lists private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - **Kiosk mode stays on while browsing**: opening a schedule with `?kiosk=1` used to only stay in kiosk mode on that exact page — clicking any link (e.g. to Proposals) dropped back to the normal view. It now stays on across the whole site until turned off with `?kiosk=0`
+- **RSVPs are private to each attendee**: a profile no longer lists the sessions that person is going to — you can still see who's coming on each session's own details, but their RSVPs are no longer gathered together on their profile, and only they can pull up their own full list. When scheduling, a host who is already busy at the chosen time still triggers a clash warning, but it now just says they're busy at that time rather than naming the session they're attending
 - **Settings separated from the public profile**: email notification preferences moved from the profile edit page to the dedicated Settings page, so private preferences are clearly apart from what other attendees can see
 - **Your name is always visible**: the attendee you're acting as now shows as a chip in the header on every page — proposals, voting, and schedule — so it's always clear who "you" are, and you can switch attendee from there (handy for a shared device)
 - **Attendee list shows location, not bio**: rows on the attendees page now show each person's pronouns and where they're based instead of a preview of their bio

--- a/app/(site)/[eventSlug]/clash-actions.ts
+++ b/app/(site)/[eventSlug]/clash-actions.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { getRepositories } from "@/db/container";
+import type { Session } from "@/db/repositories/interfaces";
+import { getStartTimePlusBreak } from "@/utils/utils";
+import { newEmptySession, sessionsOverlap } from "../session_utils";
+
+// A schedule clash for one host, computed server-side so a host's private
+// RSVPs never reach the client. Hosting a session is public, so those clashes
+// name the session; RSVP'd sessions are private, so those only report that the
+// host is "busy" for the overlapping interval — never which session.
+export type HostClash = {
+  hostName: string;
+  kind: "hosting" | "busy";
+  // Only set for hosting clashes (public); null for busy/RSVP clashes.
+  title: string | null;
+  // ISO strings; `start` is break-adjusted for display, matching the schedule.
+  start: string;
+  end: string;
+};
+
+export async function detectHostClashes(input: {
+  eventId: string;
+  hostIds: string[];
+  start: string; // ISO — candidate session start
+  end: string; // ISO — candidate session end
+  excludeSessionId?: string | null;
+}): Promise<HostClash[]> {
+  const { eventId, hostIds, start, end, excludeSessionId } = input;
+  if (hostIds.length === 0) return [];
+
+  const repos = getRepositories();
+  const event = await repos.events.findById(eventId);
+  if (!event) return [];
+  const breakMinutes = event.breakMinutes;
+
+  // sessionsOverlap skips a session whose id matches the candidate's, which is
+  // how the session being edited is excluded from clashing with itself.
+  const candidate: Session = {
+    ...newEmptySession(eventId),
+    id: excludeSessionId ?? "",
+    startTime: new Date(start),
+    endTime: new Date(end),
+  };
+
+  const inEventAndOverlapping = (ses: Session) =>
+    ses.eventId === eventId &&
+    ses.startTime != null &&
+    ses.endTime != null &&
+    sessionsOverlap(ses, candidate);
+
+  const clashes: HostClash[] = [];
+
+  for (const hostId of hostIds) {
+    const guest = await repos.guests.findById(hostId);
+    if (!guest) continue;
+
+    const [hosted, rsvpd] = await Promise.all([
+      repos.sessions.listHostedByGuest(hostId),
+      repos.sessions.listRsvpdByGuest(hostId),
+    ]);
+
+    const hostingClashes = hosted.filter(inEventAndOverlapping);
+    const hostingIds = new Set(hostingClashes.map((s) => s.id));
+
+    for (const ses of hostingClashes) {
+      clashes.push({
+        hostName: guest.name,
+        kind: "hosting",
+        title: ses.title,
+        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
+        end: ses.endTime!.toISOString(),
+      });
+    }
+
+    // A host RSVP'ing to a session they also host is already reported above.
+    for (const ses of rsvpd.filter(inEventAndOverlapping)) {
+      if (hostingIds.has(ses.id)) continue;
+      clashes.push({
+        hostName: guest.name,
+        kind: "busy",
+        title: null,
+        start: getStartTimePlusBreak(ses, breakMinutes).toISO()!,
+        end: ses.endTime!.toISOString(),
+      });
+    }
+  }
+
+  return clashes;
+}

--- a/app/(site)/[eventSlug]/layout-content.tsx
+++ b/app/(site)/[eventSlug]/layout-content.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { EventProviderWrapper } from "./event-provider-wrapper";
 import type { DayWithSessions } from "@/app/(site)/context";
+import { verifiedCurrentUser } from "@/utils/acting-guest";
 
 export async function EventLayoutContent({
   eventSlug,
@@ -18,7 +19,10 @@ export async function EventLayoutContent({
   }
 
   const cookieStore = await cookies();
-  const currentUser = cookieStore.get("user")?.value;
+  // Verified, not the raw `user` cookie: a guest's RSVP list is private, so a
+  // forged plain cookie naming a protected guest must not seed their RSVPs
+  // into the SSR payload.
+  const currentUser = await verifiedCurrentUser(cookieStore);
 
   const [days, sessions, locations, guests, rsvps] = await Promise.all([
     repos.days.listByEvent(event.id),

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -10,7 +10,6 @@ import { SelectHosts } from "@/app/select-hosts";
 import {
   convertParamDateTime,
   dateOnDay,
-  getStartTimePlusBreak,
   formatDuration,
   durationMinusBreak,
   TIME_FORMAT,
@@ -24,14 +23,14 @@ import type {
   Guest,
   Location,
   Session,
-  Rsvp,
   SessionProposal,
 } from "@/db/repositories/interfaces";
 import { ConfirmDeletionModal } from "../modals";
 import { UserContext } from "../context";
-import { sessionsOverlap, newEmptySession } from "../session_utils";
+import { newEmptySession } from "../session_utils";
 import { buildSessionInterval } from "@/app/api/session-form-utils";
 import { revalidateEvent } from "./session-actions";
+import { detectHostClashes, type HostClash } from "./clash-actions";
 import { MarkdownHint } from "@/app/(site)/markdown";
 
 interface ErrorResponse {
@@ -200,61 +199,53 @@ export function SessionForm(props: {
     };
   }
 
-  const [hostRSVPs, setHostRSVPs] = useState<Record<string, Rsvp[]>>({});
-  const [isFetchingRSVPs, setIsFetchingRSVPs] = useState(false);
+  // Clash detection runs on the server (see clash-actions): a host's RSVP'd
+  // sessions are private, so the client never receives them — the server only
+  // reports that the host is "busy" for the overlapping interval.
+  const [hostClashes, setHostClashes] = useState<HostClash[]>([]);
+  const [isCheckingClashes, setIsCheckingClashes] = useState(false);
+
+  const hostIdsKey = hosts.map((h) => h.id).join(",");
+  const candidateStart = dummySession.startTime?.getTime();
+  const candidateEnd = dummySession.endTime?.getTime();
 
   useEffect(() => {
-    const fetchRSVPs = async () => {
-      setIsFetchingRSVPs(true);
-      const entries = await Promise.all(
-        hosts.map(async (host) => {
-          const res = await fetch(`/api/rsvps?user=${host.id}`);
-          const rsvps = (await res.json()) as Rsvp[];
-          return [host.id, rsvps] as const;
-        })
-      );
-
-      setHostRSVPs(Object.fromEntries(entries));
-      setIsFetchingRSVPs(false);
+    let cancelled = false;
+    const check = async () => {
+      if (!candidateStart || !candidateEnd || !hostIdsKey) {
+        setHostClashes((prev) => (prev.length === 0 ? prev : []));
+        return;
+      }
+      setIsCheckingClashes(true);
+      try {
+        const clashes = await detectHostClashes({
+          eventId: event.id,
+          hostIds: hostIdsKey.split(","),
+          start: new Date(candidateStart).toISOString(),
+          end: new Date(candidateEnd).toISOString(),
+          excludeSessionId: sessionID ?? null,
+        });
+        if (!cancelled) setHostClashes(clashes);
+      } catch (error) {
+        console.error("Error detecting clashes:", error);
+      } finally {
+        if (!cancelled) setIsCheckingClashes(false);
+      }
     };
-
-    void fetchRSVPs();
-  }, [hosts]);
-
-  const clashes = hosts.map((host) => {
-    const sessionClashes = sessions.filter(
-      (ses) =>
-        ses.hosts.some((h) => h.id === host.id) &&
-        sessionsOverlap(ses, dummySession)
-    );
-    const rsvpClashes = (hostRSVPs[host.id] || [])
-      .map((rsvp) => sessions.find((ses) => ses.id === rsvp.sessionId))
-      .filter((ses): ses is Session => ses !== undefined)
-      .filter((ses) => sessionsOverlap(ses, dummySession));
-
-    return {
-      id: host.id,
-      sessionClashes,
-      rsvpClashes,
+    void check();
+    return () => {
+      cancelled = true;
     };
+  }, [event.id, hostIdsKey, candidateStart, candidateEnd, sessionID]);
+
+  const clashErrors = hostClashes.map((clash) => {
+    const formatTime = (iso: string) =>
+      DateTime.fromISO(iso).setZone(timezone).toFormat(TIME_FORMAT);
+    const interval = `from ${formatTime(clash.start)} to ${formatTime(clash.end)}`;
+    return clash.kind === "hosting"
+      ? `${clash.hostName} is hosting ${clash.title} ${interval}`
+      : `${clash.hostName} is busy ${interval}`;
   });
-  const clashErrors = clashes
-    .map((hostClashes) => {
-      const { id, sessionClashes, rsvpClashes } = hostClashes;
-      const hostName = hosts.find((host) => host.id === id)!.name;
-      const formatTime = (d: DateTime) =>
-        d.setZone(timezone).toFormat(TIME_FORMAT);
-      const displayInterval = (ses: Session) =>
-        `from ${formatTime(getStartTimePlusBreak(ses, event.breakMinutes))} to ${formatTime(DateTime.fromJSDate(ses.endTime ?? new Date()))}`;
-      const sessionErrors = sessionClashes.map(
-        (ses) => `${hostName} is hosting ${ses.title} ${displayInterval(ses)}`
-      );
-      const rsvpErrors = rsvpClashes.map(
-        (ses) => `${hostName} is attending ${ses.title} ${displayInterval(ses)}`
-      );
-      return sessionErrors.concat(rsvpErrors);
-    })
-    .flat();
 
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -539,7 +530,7 @@ export function SessionForm(props: {
           !locationId ||
           !day ||
           !effectiveDuration ||
-          isFetchingRSVPs ||
+          isCheckingClashes ||
           isSubmitting
         }
         onClick={() => void Submit()}

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -43,14 +43,12 @@ export default async function GuestProfilePage(props: {
   const backHref = from ? `/guests?${from}` : "/guests";
   const repos = getRepositories();
 
-  const [completeGuest, hostedSessions, proposals, rsvpdSessions, events] =
-    await Promise.all([
-      repos.guests.findById(guestId),
-      repos.sessions.listHostedByGuest(guestId),
-      repos.sessionProposals.listByHost(guestId),
-      repos.sessions.listRsvpdByGuest(guestId),
-      repos.events.list(),
-    ]);
+  const [completeGuest, hostedSessions, proposals, events] = await Promise.all([
+    repos.guests.findById(guestId),
+    repos.sessions.listHostedByGuest(guestId),
+    repos.sessionProposals.listByHost(guestId),
+    repos.events.list(),
+  ]);
 
   if (!completeGuest) {
     return <p className="text-gray-600">Profile not found.</p>;
@@ -179,16 +177,6 @@ export default async function GuestProfilePage(props: {
           key: p.id,
           label: p.title,
           item: { eventSlug: eventIdToSlug(p.eventId), id: p.id },
-        }))}
-        LinkType={ProposalLink}
-      />
-
-      <ProfileList
-        title="Going to"
-        items={rsvpdSessions.map((s) => ({
-          key: s.id,
-          label: s.title,
-          item: { eventSlug: eventIdToSlug(s.eventId), id: s.id },
         }))}
         LinkType={ProposalLink}
       />

--- a/app/api/rsvps/route.ts
+++ b/app/api/rsvps/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRepositories } from "@/db/container";
+import { isRequestVerifiedAsGuest } from "@/utils/acting-guest";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +17,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "user or session parameter is required" },
       { ...NO_STORE, status: 400 }
+    );
+  }
+
+  // A guest's full RSVP list is private to that guest (aggregating it across
+  // sessions is exposing). Per-session RSVPs stay openly readable — they are
+  // displayed to everyone in the session details.
+  if (user && !(await isRequestVerifiedAsGuest(request, user))) {
+    return NextResponse.json(
+      { error: "This user's RSVPs are private" },
+      { ...NO_STORE, status: 403 }
     );
   }
 

--- a/app/api/votes/route.ts
+++ b/app/api/votes/route.ts
@@ -20,8 +20,9 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Votes are private to their owner once the guest is protected; RSVPs
-  // stay openly readable (they are displayed per session).
+  // Votes are private to their owner once the guest is protected — as is a
+  // guest's per-user RSVP list (see app/api/rsvps). Only the per-session RSVP
+  // list stays openly readable.
   if (!(await isRequestVerifiedAsGuest(request, user))) {
     return NextResponse.json(
       { error: "This user's votes are private" },

--- a/tests/integration/host-clashes.test.ts
+++ b/tests/integration/host-clashes.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createEvent, createGuest, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { detectHostClashes } from "@/app/(site)/[eventSlug]/clash-actions";
+
+// A host's own hosted sessions are public, so a clash may name them; the
+// sessions a host merely RSVP'd to are private, so a clash must only report
+// that they are "busy" at that time — never which session.
+describe("detectHostClashes", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  const T = (h: number, m = 0) => new Date(Date.UTC(2030, 0, 1, h, m, 0));
+
+  it("reports a hosting clash and names the (public) session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest();
+    await createSession(event.id, {
+      title: "Their talk",
+      hostIds: [host.id],
+      startTime: T(10),
+      endTime: T(11),
+    });
+
+    const clashes = await detectHostClashes({
+      eventId: event.id,
+      hostIds: [host.id],
+      start: T(10, 30).toISOString(),
+      end: T(11, 30).toISOString(),
+    });
+
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].kind).toBe("hosting");
+    expect(clashes[0].title).toBe("Their talk");
+  });
+
+  it("reports an RSVP clash as 'busy' without leaking the session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest();
+    const secret = await createSession(event.id, {
+      title: "Secret RSVP session",
+      startTime: T(10),
+      endTime: T(11),
+    });
+    await getRepositories().rsvps.create({
+      sessionId: secret.id,
+      guestId: host.id,
+    });
+
+    const clashes = await detectHostClashes({
+      eventId: event.id,
+      hostIds: [host.id],
+      start: T(10, 30).toISOString(),
+      end: T(11, 30).toISOString(),
+    });
+
+    expect(clashes).toHaveLength(1);
+    expect(clashes[0].kind).toBe("busy");
+    expect(clashes[0].title).toBeNull();
+    expect(JSON.stringify(clashes)).not.toContain("Secret RSVP session");
+  });
+
+  it("returns nothing when the candidate slot does not overlap", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest();
+    await createSession(event.id, {
+      title: "Earlier",
+      hostIds: [host.id],
+      startTime: T(9),
+      endTime: T(10),
+    });
+
+    const clashes = await detectHostClashes({
+      eventId: event.id,
+      hostIds: [host.id],
+      start: T(10).toISOString(),
+      end: T(11).toISOString(),
+    });
+
+    expect(clashes).toEqual([]);
+  });
+
+  it("does not clash a session being edited with itself", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest();
+    const editing = await createSession(event.id, {
+      title: "Editing",
+      hostIds: [host.id],
+      startTime: T(10),
+      endTime: T(11),
+    });
+
+    const clashes = await detectHostClashes({
+      eventId: event.id,
+      hostIds: [host.id],
+      start: T(10).toISOString(),
+      end: T(11).toISOString(),
+      excludeSessionId: editing.id,
+    });
+
+    expect(clashes).toEqual([]);
+  });
+});

--- a/tests/integration/layout-content-rsvp-privacy.test.ts
+++ b/tests/integration/layout-content-rsvp-privacy.test.ts
@@ -1,0 +1,114 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// The event layout preloads the current guest's RSVP list into the SSR
+// payload. That list is private to the guest (see /api/rsvps and
+// tests/integration/verified-guest-reads.test.ts), so it must be seeded from
+// the *verified* current user — a forgeable plain `user` cookie naming a
+// protected guest must not leak their RSVPs into the server-rendered page.
+
+const cookieJar = new Map<string, string>();
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => {
+        const value = cookieJar.get(name);
+        return value === undefined ? undefined : { name, value };
+      },
+    }),
+}));
+
+// Capture the rsvps handed to the client provider without rendering the heavy
+// client tree it wraps.
+const captured: { rsvps?: unknown[] } = {};
+vi.mock("@/app/(site)/[eventSlug]/event-provider-wrapper", () => ({
+  EventProviderWrapper: ({
+    eventContextValue,
+  }: {
+    eventContextValue: { rsvps: unknown[] };
+  }) => {
+    captured.rsvps = eventContextValue.rsvps;
+    return "PROVIDER_STUB";
+  },
+}));
+
+import { setupTestDb, resetTestDb } from "../helpers/db";
+import { createGuest, createEvent, createSession } from "../helpers/factories";
+import { getRepositories } from "@/db/container";
+import { createUserAuthCookie, USER_AUTH_COOKIE_NAME } from "@/utils/auth";
+
+const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+async function protectGuest(guestId: string): Promise<void> {
+  await getRepositories().guests.setAuthProtection(guestId, {
+    authProtected: true,
+    passwordHash: null,
+  });
+}
+
+async function renderLayout(eventSlug: string): Promise<void> {
+  const { EventLayoutContent } =
+    await import("@/app/(site)/[eventSlug]/layout-content");
+  renderToStaticMarkup(await EventLayoutContent({ eventSlug, children: null }));
+}
+
+describe("event layout seeds RSVPs from the verified guest", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    cookieJar.clear();
+    captured.rsvps = undefined;
+    vi.stubEnv("AUTH_SECRET", VALID_SECRET);
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("does not seed a protected guest's RSVPs without a verified session", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const session = await createSession(event.id);
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+    await protectGuest(guest.id);
+
+    // Forged plain cookie only — no verified user-auth cookie.
+    cookieJar.set("user", guest.id);
+
+    await renderLayout(event.slug);
+
+    expect(captured.rsvps).toEqual([]);
+  });
+
+  it("seeds RSVPs for a verified protected guest", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const session = await createSession(event.id);
+    await getRepositories().rsvps.create({
+      sessionId: session.id,
+      guestId: guest.id,
+    });
+    await protectGuest(guest.id);
+
+    cookieJar.set("user", guest.id);
+    cookieJar.set(
+      USER_AUTH_COOKIE_NAME,
+      (await createUserAuthCookie(guest.id)).value
+    );
+
+    await renderLayout(event.slug);
+
+    expect(captured.rsvps).toHaveLength(1);
+  });
+});

--- a/tests/integration/user-auth-enforcement.test.ts
+++ b/tests/integration/user-auth-enforcement.test.ts
@@ -38,6 +38,7 @@ import { POST as toggleRsvp } from "@/app/api/toggle-rsvp/route";
 import { POST as addVote } from "@/app/api/add-vote/route";
 import { POST as deleteVote } from "@/app/api/delete-vote/route";
 import { GET as getVotes } from "@/app/api/votes/route";
+import { GET as getRsvps } from "@/app/api/rsvps/route";
 import { updateProfileAction } from "@/app/actions/profile";
 import { updateEmailSettingsAction } from "@/app/actions/settings";
 
@@ -208,6 +209,48 @@ describe("write enforcement for protected guests", () => {
       );
       expect(verified.ok).toBe(true);
       expect(await verified.json()).toHaveLength(1);
+    });
+  });
+
+  describe("GET /api/rsvps", () => {
+    async function setup() {
+      const event = await createEvent({ phase: "scheduling" });
+      const guest = await createGuest({ eventId: event.id });
+      const session = await createSession(event.id);
+      await getRepositories().rsvps.create({
+        sessionId: session.id,
+        guestId: guest.id,
+      });
+      return { guest, session };
+    }
+
+    it("hides a protected guest's RSVPs from unverified readers", async () => {
+      const { guest } = await setup();
+      await protectGuest(guest.id);
+
+      const unverified = await getRsvps(
+        new NextRequest(`http://test/api/rsvps?user=${guest.id}`)
+      );
+      expect(unverified.status).toBe(403);
+
+      const verified = await getRsvps(
+        new NextRequest(`http://test/api/rsvps?user=${guest.id}`, {
+          headers: { cookie: await authCookieHeader(guest.id) },
+        })
+      );
+      expect(verified.ok).toBe(true);
+      expect(await verified.json()).toHaveLength(1);
+    });
+
+    it("still lists RSVPs per session without auth", async () => {
+      const { guest, session } = await setup();
+      await protectGuest(guest.id);
+
+      const res = await getRsvps(
+        new NextRequest(`http://test/api/rsvps?session=${session.id}`)
+      );
+      expect(res.ok).toBe(true);
+      expect(await res.json()).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
Aggregating a person's RSVPs across sessions is exposing, so a profile no
longer lists the sessions they're attending, /api/rsvps?user= is now self-only
(like /api/votes), and host clash detection moved server-side to report only
that a host is "busy" at a time — never which session they RSVP'd to.
Per-session RSVP lists stay public.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- jip:pushed-commit=8d1e883046188773a8d3d3fa179bdb3660fa4504 -->