### PR TITLE
test: wait for the filtered list before clicking an admin session row

### DIFF
--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1396,9 +1396,13 @@ test.describe("Admin UI sessions", () => {
 
     await sessions.getByRole("button", { name: "Create", exact: true }).click();
 
-    // Search for the unique title so pagination cannot hide the new row.
+    // Search for the unique title so pagination cannot hide the new row. Wait
+    // for the single-result list to commit before clicking into the row: the
+    // list is sorted by title, so the row moves when the search commits, and a
+    // click straddling that reflow is swallowed (mouseup lands elsewhere).
     await sessions.getByRole("searchbox", { name: "Search" }).fill(title);
     await sessions.getByRole("button", { name: "Search" }).click();
+    await expect(sessions.getByRole("listitem")).toHaveCount(1);
     const row = sessions.getByRole("listitem").filter({ hasText: title });
     await expect(row).toBeVisible();
     await expect(row).toContainText("blocker");

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -116,13 +116,24 @@ test("a full session blocks further RSVPs when the event enforces capacity", asy
     .getByRole("navigation", { name: "Event sections" })
     .getByRole("link", { name: "Sessions" })
     .click();
-  await page.getByRole("searchbox").fill(sessionTitle);
-  await page.getByRole("button", { name: "Search" }).click();
-  await page.getByRole("button", { name: `Edit ${sessionTitle}` }).click();
-  await page.getByLabel("Capacity").fill("1");
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  const sessionsRegion = page.getByRole("region", { name: "Sessions" });
+  await sessionsRegion.getByRole("searchbox").fill(sessionTitle);
+  await sessionsRegion.getByRole("button", { name: "Search" }).click();
+  // Wait for the single-result list to commit before clicking Edit. The list is
+  // sorted by title, so unfiltered the new session sits near the bottom and the
+  // matching row jumps to the top when the search commits. A click whose
+  // mousedown and mouseup straddle that reflow is swallowed: mouseup lands on
+  // another element, so no click event fires and the edit form never opens.
+  await expect(sessionsRegion.getByRole("listitem")).toHaveCount(1);
+  await sessionsRegion
+    .getByRole("button", { name: `Edit ${sessionTitle}` })
+    .click();
+  await sessionsRegion.getByLabel("Capacity").fill("1");
+  await sessionsRegion
+    .getByRole("button", { name: "Save", exact: true })
+    .click();
   await expect(
-    page.getByRole("button", { name: `Edit ${sessionTitle}` })
+    sessionsRegion.getByRole("button", { name: `Edit ${sessionTitle}` })
   ).toBeVisible();
   // Saving triggers a router.refresh. A document navigation started while its
   // RSC fetch is in flight is aborted by Firefox (NS_BINDING_ABORTED), and


### PR DESCRIPTION
Clicking Edit/Delete right after submitting the sessions search was flaky:
the list is sorted by title, so the matching row jumps position when the
search commits. A click whose mousedown and mouseup straddle that reflow
is dropped by the browser (mouseup lands on another element, so no click
event fires) and the edit form never opens.

<!-- jip:pushed-commit=a824fb5e13eb2e9efd80d4eb1b0e174878eaf698 -->