### PR TITLE
fix: disambiguate password fields for browser password managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Saved passwords no longer get mixed up**: browsers couldn't tell this site's different passwords apart — the site password, the organizer password, and each attendee's own password all looked like the same login — so a saved password could be overwritten or offered in the wrong place. Each is now saved as its own entry
+
 ## [3.1.0] - 2026-07-24
 
 ### Added

--- a/app/(site)/auth/reset/page.tsx
+++ b/app/(site)/auth/reset/page.tsx
@@ -29,7 +29,11 @@ export default async function AuthResetPage({
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
       <h1 className="text-2xl font-bold">Set a password for {guest.name}</h1>
-      <ResetPasswordForm guestId={guest.id} token={token} />
+      <ResetPasswordForm
+        guestId={guest.id}
+        guestName={guest.name}
+        token={token}
+      />
     </div>
   );
 }

--- a/app/(site)/auth/reset/reset-password-form.tsx
+++ b/app/(site)/auth/reset/reset-password-form.tsx
@@ -2,14 +2,17 @@
 import { useState } from "react";
 import Link from "next/link";
 import { setPasswordWithTokenAction } from "@/app/actions/user-auth";
+import { PasswordManagerHint } from "@/app/password-manager-hint";
 
 // Sets a new password from a reset link. Grants no session, so on success it
 // points the guest at the home page to log in with the password they just set.
 export function ResetPasswordForm({
   guestId,
+  guestName,
   token,
 }: {
   guestId: string;
+  guestName: string;
   token: string;
 }) {
   const [newPassword, setNewPassword] = useState("");
@@ -68,6 +71,7 @@ export function ResetPasswordForm({
         Choose a new password. You&apos;ll use it to switch to your name from
         now on.
       </p>
+      <PasswordManagerHint username={guestName} />
       <label
         htmlFor="reset-new-password"
         className="text-sm font-medium text-gray-700"

--- a/app/(site)/guest-login-form.tsx
+++ b/app/(site)/guest-login-form.tsx
@@ -5,6 +5,7 @@ import {
   requestLoginCodeAction,
   requestPasswordLinkAction,
 } from "@/app/actions/user-auth";
+import { PasswordManagerHint } from "@/app/password-manager-hint";
 
 // Credential prompt for switching to a protected guest: accepts either the
 // permanent password or an emailed single-use login code in one field, with a
@@ -101,6 +102,7 @@ export function GuestLoginForm({
         {guestName} has protected their account. Enter their password, or use a
         single-use code emailed to them. Forgot the password? Reset it instead.
       </p>
+      <PasswordManagerHint username={guestName} />
       <label
         htmlFor="guest-credential"
         className="text-sm font-medium text-gray-700"

--- a/app/(site)/login/page.tsx
+++ b/app/(site)/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { Input } from "@/app/input";
+import { PasswordManagerHint } from "@/app/password-manager-hint";
 import clsx from "clsx";
 import { useActionState } from "react";
 import { loginAction } from "@/app/actions/auth";
@@ -35,15 +36,17 @@ function LoginForm() {
 
       <form className="mt-8 space-y-6" action={formAction}>
         <input type="hidden" name="redirect" value={redirectTo} />
+        <PasswordManagerHint username="Site Password" />
 
         <div>
-          <label htmlFor="password" className="sr-only">
+          <label htmlFor="site-password" className="sr-only">
             Password
           </label>
           <Input
-            id="password"
-            name="password"
+            id="site-password"
+            name="site-password"
             type="password"
+            autoComplete="current-password"
             required
             placeholder="Enter password"
             error={!!state?.error}

--- a/app/(site)/settings/account-security.tsx
+++ b/app/(site)/settings/account-security.tsx
@@ -6,6 +6,7 @@ import {
   disableProtectionAction,
   requestPasswordLinkAction,
 } from "@/app/actions/user-auth";
+import { PasswordManagerHint } from "@/app/password-manager-hint";
 
 type Mode = "password" | "disable";
 
@@ -23,9 +24,11 @@ const inputClass =
  */
 export function AccountSecurity({
   guestId,
+  guestName,
   authProtected,
 }: {
   guestId: string;
+  guestName: string;
   authProtected: boolean;
 }) {
   const router = useRouter();
@@ -175,6 +178,7 @@ export function AccountSecurity({
               ? "Enter your current password and choose a new one."
               : "Enter your current password to turn off protection. This also removes your password."}
           </p>
+          <PasswordManagerHint username={guestName} />
           <label
             htmlFor="security-current-password"
             className="text-sm font-medium text-gray-700"

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -45,6 +45,7 @@ export default async function SettingsPage() {
       <div className="max-w-2xl mx-auto w-full px-4 sm:px-0">
         <AccountSecurity
           guestId={guest.id}
+          guestName={guest.name}
           authProtected={guest.authProtected ?? false}
         />
       </div>

--- a/app/actions/admin-auth.ts
+++ b/app/actions/admin-auth.ts
@@ -14,7 +14,7 @@ export async function adminLoginAction(
   prevState: { error: string } | null,
   formData: FormData
 ) {
-  const password = formData.get("password") as string;
+  const password = formData.get("admin-password") as string;
   const redirectTo = safeRedirectPath(
     formData.get("redirect") as string,
     "/admin"

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -18,7 +18,7 @@ export async function loginAction(
   prevState: { error?: string; redirectTo?: string } | null,
   formData: FormData
 ) {
-  const password = formData.get("password") as string;
+  const password = formData.get("site-password") as string;
   const redirectTo = safeRedirectPath(formData.get("redirect") as string, "/");
 
   if (!isPasswordProtectionEnabled()) {

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { Input } from "@/app/input";
+import { PasswordManagerHint } from "@/app/password-manager-hint";
 import clsx from "clsx";
 import { useActionState } from "react";
 import { adminLoginAction } from "../../actions/admin-auth";
@@ -23,15 +24,17 @@ function AdminLoginForm() {
 
       <form className="mt-8 space-y-6" action={formAction}>
         <input type="hidden" name="redirect" value={redirectTo} />
+        <PasswordManagerHint username="Admin Password" />
 
         <div>
-          <label htmlFor="password" className="sr-only">
+          <label htmlFor="admin-password" className="sr-only">
             Password
           </label>
           <Input
-            id="password"
-            name="password"
+            id="admin-password"
+            name="admin-password"
             type="password"
+            autoComplete="current-password"
             required
             placeholder="Enter admin password"
             error={!!state?.error}

--- a/app/password-manager-hint.tsx
+++ b/app/password-manager-hint.tsx
@@ -1,0 +1,27 @@
+/**
+ * A hidden, read-only username field to sit next to a password input.
+ *
+ * Browsers key a saved credential on the username field of the form the
+ * password was typed into. This app has several distinct passwords on one
+ * origin — the site password, the admin password, and one per protected guest
+ * — so without a username the password manager treats them as the same
+ * credential and mixes them up or overwrites the saved entry. Naming which
+ * credential is being entered makes each one save as its own entry.
+ *
+ * The name is user-visible — password managers list it as the username of the
+ * saved entry — so pass something readable ("Site Password", a guest's name).
+ */
+export function PasswordManagerHint({ username }: { username: string }) {
+  return (
+    <input
+      type="text"
+      name="username"
+      autoComplete="username"
+      value={username}
+      readOnly
+      aria-hidden="true"
+      tabIndex={-1}
+      className="hidden"
+    />
+  );
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -3,7 +3,9 @@ import { Page, expect } from "@playwright/test";
 const DEFAULT_PASSWORD = process.env.TEST_PASSWORD || "testtest";
 
 export async function login(page: Page, password: string = DEFAULT_PASSWORD) {
-  const passwordInput = page.locator('input[name="password"]').first();
+  // Exact: other forms label their fields "Current password", "New password"
+  // or "Password or emailed code", which a substring match would also pick up.
+  const passwordInput = page.getByLabel("Password", { exact: true });
   if (!(await passwordInput.isVisible())) {
     await page.goto("/");
   }


### PR DESCRIPTION
Site login, admin login, and per-guest password forms all shared
name="password"/no autocomplete, so browsers couldn't tell them apart
and would mix up or overwrite saved credentials. Add autocomplete
hints and a hidden username decoy field per form so each gets saved
as a distinct entry.

<!-- jip:pushed-commit=e52fe54fda626c06894d07a1b0b3791d589433f3 -->