### PR TITLE
fix: bound login-code guesses without handing out cheap lockouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
-- **Login attempts are now rate limited**: repeated wrong passwords (site password, admin password, or an attendee's name password) temporarily block further attempts, so passwords can no longer be guessed by brute force. An attendee locked out this way can still sign in with an emailed one-time code
+- **Login attempts are now rate limited**: repeated wrong passwords (site password, admin password, or an attendee's name password) temporarily block further attempts, so passwords can no longer be guessed by brute force. An attendee locked out this way can still sign in with an emailed one-time code, and the message they see says so
+- **Emailed codes and reset links are harder to knock out**: entering wrong codes against an attendee's name used to use up the code or reset link that attendee had just been emailed after only ten tries, locking them out of their own name. Reset links can no longer be used up this way at all; a login code now takes ten times as many wrong tries, is unaffected by a mistyped password, and an attendee whose code was used up is told so and can request a new one a minute later
 - Framing the site in other pages is now blocked (clickjacking protection), along with other standard browser hardening headers
 
 ## [3.1.0] - 2026-07-24

--- a/app/(site)/guest-login-form.tsx
+++ b/app/(site)/guest-login-form.tsx
@@ -55,7 +55,7 @@ export function GuestLoginForm({
       if (result.ok) {
         setInfo("Code sent — check your email");
       } else if (result.throttled) {
-        setInfo("A recently emailed code is still valid — check your inbox");
+        setInfo(result.error);
       } else {
         setError(result.error);
       }
@@ -76,9 +76,7 @@ export function GuestLoginForm({
       if (result.ok) {
         setInfo("Reset link sent — check your email to set a new password");
       } else if (result.throttled) {
-        setInfo(
-          "A recently emailed reset link is still valid — check your inbox"
-        );
+        setInfo(result.error);
       } else {
         setError(result.error);
       }

--- a/app/(site)/settings/account-security.tsx
+++ b/app/(site)/settings/account-security.tsx
@@ -52,7 +52,7 @@ export function AccountSecurity({
       if (result.ok) {
         setInfo("Check your email for a link to set your password");
       } else if (result.throttled) {
-        setInfo("A recently emailed link is still valid — check your inbox");
+        setInfo(result.error);
       } else {
         setError(result.error);
       }

--- a/app/actions/user-auth.ts
+++ b/app/actions/user-auth.ts
@@ -12,11 +12,13 @@ import {
 } from "@/utils/auth";
 import {
   AUTH_CODE_VALID_MINUTES,
+  MAX_CODE_ATTEMPTS,
   RESET_TOKEN_VALID_MINUTES,
   generateAuthCode,
   generateAuthCodeSalt,
   generateResetToken,
   hashAuthCode,
+  isAuthCodeShaped,
   normalizeAuthCode,
   hashUserPassword,
   verifyUserPassword,
@@ -34,7 +36,6 @@ import { authPasswordResetEmail } from "@/emails/auth-password-reset";
 import { authSecurityChangedEmail } from "@/emails/auth-security-changed";
 
 const REQUEST_THROTTLE_SECONDS = 60;
-const MAX_CODE_ATTEMPTS = 10;
 
 export type UserAuthResult =
   | { ok: true }
@@ -59,9 +60,9 @@ async function setAuthenticatedIdentity(guestId: string): Promise<void> {
 
 /**
  * Returns the guest's active token of `purpose` if `input` matches it, or null
- * otherwise — counting a failed guess so the token dies after too many tries.
- * The caller is responsible for consuming a returned token: matching alone
- * changes nothing, so a match never replays.
+ * otherwise — counting a failed guess at a login code so it dies after
+ * MAX_CODE_ATTEMPTS tries. The caller is responsible for consuming a returned
+ * token: matching alone changes nothing, so a match never replays.
  *
  * Login codes are hand-typed, so case and stray whitespace are forgiven; reset
  * tokens travel only inside a link and are matched verbatim.
@@ -77,29 +78,58 @@ async function matchToken(
   const candidate =
     purpose === "login" ? normalizeAuthCode(input) : input.trim();
   if (hashAuthCode(candidate, active.salt) === active.codeHash) return active;
+  // Only login codes are metered. A reset token carries 256 bits, so guessing
+  // it is infeasible and counting the guesses buys nothing — while retiring it
+  // after a bounded number of tries would hand anyone who knows a guest id a
+  // way to knock out the link that guest was just emailed.
+  if (purpose !== "login") return null;
+  // A login code shares one input field with the permanent password, so only
+  // input that could have been a code counts as a guess at it — otherwise a
+  // guest fumbling their password would burn the code they were emailed.
+  if (!isAuthCodeShaped(candidate)) return null;
   await authCodes.recordFailedAttempt(active.id);
+  if (active.attempts + 1 === MAX_CODE_ATTEMPTS) {
+    console.warn(
+      `Login code of guest ${guestId} hit the guess cap — retiring it`
+    );
+  }
   return null;
 }
 
 /**
- * True when a token of `purpose` was emailed within the throttle window and is
- * still valid — the UI treats this as "check your inbox", not an error.
+ * The token of `purpose` emailed within the throttle window, if one is still
+ * valid. Null means a fresh one should be emailed.
+ *
+ * A login code whose guess cap is spent still counts as recently issued:
+ * replacing it on demand would let anyone who knows a guest name mint a new
+ * code (and a new guess budget, and a new email to that guest) every
+ * MAX_CODE_ATTEMPTS tries, which is both an unbounded oracle again and an inbox
+ * flood. The guest waits out the window instead, and is told the code is spent
+ * rather than sent to their inbox for one that can no longer work.
  */
 async function recentlyIssued(
   guestId: string,
   purpose: AuthCodePurpose,
   now: Date
-): Promise<boolean> {
+): Promise<AuthCode | null> {
   const existing = await getRepositories().authCodes.findActive(
     guestId,
     purpose,
     now
   );
-  return (
-    !!existing &&
-    now.getTime() - existing.createdAt.getTime() <
+  if (
+    !existing ||
+    now.getTime() - existing.createdAt.getTime() >=
       REQUEST_THROTTLE_SECONDS * 1000
-  );
+  ) {
+    return null;
+  }
+  return existing;
+}
+
+/** Whether `token` has no guesses left, so only a replacement can help. */
+function isSpent(token: AuthCode): boolean {
+  return token.attempts >= MAX_CODE_ATTEMPTS;
 }
 
 /** Emails the guest a single-use login code (link + typeable code). */
@@ -119,13 +149,22 @@ export async function requestLoginCodeAction(
   }
 
   const now = new Date();
-  if (await recentlyIssued(guestId, "login", now)) {
-    return {
-      ok: false,
-      throttled: true,
-      error:
-        "A code was emailed to you moments ago — check your inbox and spam folder",
-    };
+  const recent = await recentlyIssued(guestId, "login", now);
+  if (recent) {
+    // A spent code is not `throttled`: nothing usable is waiting in the inbox,
+    // so this is a plain failure rather than reassurance.
+    return isSpent(recent)
+      ? {
+          ok: false,
+          error:
+            "Too many wrong codes were entered, so the one you were emailed is used up — ask for a new one in a minute",
+        }
+      : {
+          ok: false,
+          throttled: true,
+          error:
+            "A code was emailed to you moments ago — check your inbox and spam folder",
+        };
   }
 
   const code = generateAuthCode();
@@ -228,9 +267,16 @@ export async function requestPasswordLinkAction(
  *
  * The password path is rate limited per guest: after too many failures the
  * password is refused for a while even if right. The emailed-code path stays
- * open (codes have their own attempt cap and die after MAX_CODE_ATTEMPTS), so
- * an attacker hammering someone's password can never lock the real person
- * out — they can always get in by proving inbox access.
+ * open, so an attacker hammering someone's password can't lock the real person
+ * out — they get in by proving inbox access. Guessing at the code instead costs
+ * its owner only a wait, since a spent code is replaced once the request
+ * throttle lapses (see MAX_CODE_ATTEMPTS and recentlyIssued) — not nothing,
+ * though: an attacker willing to keep spending 100 guesses a minute can hold
+ * the code path shut for as long as they keep it up. Countering that needs
+ * defences this app doesn't have (a CAPTCHA, a real IP reputation store); the
+ * reset link, which is never metered, stays open meanwhile. Both escape hatches
+ * need a configured mailer; without one the password lockout is the whole
+ * story.
  */
 export async function loginAsGuestAction(
   guestId: string,
@@ -256,9 +302,18 @@ export async function loginAsGuestAction(
     return { ok: true };
   }
   recordLoginFailure("guest", guestId);
+  if (!passwordBlocked) {
+    return { ok: false, error: "Wrong password or code" };
+  }
+  // The generic lockout message would be a lie here: only the *password* is
+  // refused, and an emailed code gets in throughout — which is the whole point
+  // of the lockout not being an account lockout. Say so, unless this server
+  // can't send the mail that would make it true.
   return {
     ok: false,
-    error: passwordBlocked ? TOO_MANY_ATTEMPTS_ERROR : "Wrong password or code",
+    error: isMailerConfigured()
+      ? "Too many failed attempts — the password won't work for a few minutes, but a code emailed to you still will"
+      : TOO_MANY_ATTEMPTS_ERROR,
   };
 }
 

--- a/tests/e2e/user-auth.spec.ts
+++ b/tests/e2e/user-auth.spec.ts
@@ -249,7 +249,9 @@ test("forgot password: reset it via an emailed link", async ({ page }) => {
   await ahmadOption.click();
   const before2 = await emailCount(RESET_SUBJECT, AHMAD_EMAIL);
   await page.getByRole("button", { name: /forgot your password/i }).click();
-  await expect(page.getByText(/reset link sent|still valid/i)).toBeVisible();
+  await expect(
+    page.getByText(/reset link sent|emailed to you moments ago/i)
+  ).toBeVisible();
   const link2 = await newestResetLink(AHMAD_EMAIL, before2 + 1);
   await page.goto(link2);
   await page.getByLabel(/new password/i).fill(AHMAD_NEW_PASSWORD);

--- a/tests/integration/user-auth-actions.test.ts
+++ b/tests/integration/user-auth-actions.test.ts
@@ -43,7 +43,7 @@ import { createGuest } from "../helpers/factories";
 import { getRepositories } from "@/db/container";
 import { sendMail, isMailerConfigured } from "@/utils/mailer";
 import { readGuestCookie, GUEST_COOKIE_NAME } from "@/utils/auth";
-import { hashUserPassword } from "@/utils/user-credentials";
+import { MAX_CODE_ATTEMPTS, hashUserPassword } from "@/utils/user-credentials";
 import {
   MAX_LOGIN_FAILURES_PER_CLIENT,
   resetLoginRateLimiter,
@@ -59,6 +59,11 @@ import {
 } from "@/app/actions/user-auth";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
+
+// A wrong login code that is nonetheless a well-formed one: right length, and
+// only alphabet characters (no I, O, 0 or 1). Guesses that *can't* be codes
+// are deliberately not counted as attempts against one.
+const CODE_SHAPED_JUNK = "ABCDEFGH";
 
 async function lastEmail(): Promise<{
   to: string;
@@ -254,13 +259,75 @@ describe("user auth actions", () => {
       expect(result.ok).toBe(false);
     });
 
-    it("locks the code after too many failed attempts", async () => {
+    it("an outstanding code survives a burst of wrong guesses", async () => {
+      // Wrong guesses must not cheaply cost the person holding the code their
+      // way in: anyone who knows a guest name can submit junk, so retiring the
+      // code after a handful handed them a lockout of the one path meant to
+      // always work.
       const { guest, code } = await protectedGuestWithCode();
-      for (let i = 0; i < 10; i++) {
-        await loginAsGuestAction(guest.id, "WRONGONE");
+      for (let i = 0; i < MAX_CODE_ATTEMPTS - 1; i++) {
+        expect((await loginAsGuestAction(guest.id, CODE_SHAPED_JUNK)).ok).toBe(
+          false
+        );
       }
-      const result = await loginAsGuestAction(guest.id, code);
-      expect(result.ok).toBe(false);
+      expect((await loginAsGuestAction(guest.id, code)).ok).toBe(true);
+      expect(await currentUserId()).toBe(guest.id);
+    });
+
+    it("retires the code once the guess cap is reached", async () => {
+      // Guessing still has to be bounded: without a cap the code is an
+      // unlimited online oracle, and ~40 bits is not enough for that.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { guest, code } = await protectedGuestWithCode();
+      for (let i = 0; i < MAX_CODE_ATTEMPTS; i++) {
+        await loginAsGuestAction(guest.id, CODE_SHAPED_JUNK);
+      }
+      expect((await loginAsGuestAction(guest.id, code)).ok).toBe(false);
+      // Worth noticing in the log, once.
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    it("a used-up code can be replaced, and says so meanwhile", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-18T12:00:00Z"));
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { guest } = await protectedGuestWithCode();
+      for (let i = 0; i < MAX_CODE_ATTEMPTS; i++) {
+        await loginAsGuestAction(guest.id, CODE_SHAPED_JUNK);
+      }
+      // Within the throttle window the guest is told the code is spent rather
+      // than being sent to their inbox for a code that no longer works. Not
+      // `throttled`: that flag means "a valid code is already in your inbox",
+      // which the UI shows as reassurance — this is a plain failure.
+      const spent = await requestLoginCodeAction(guest.id);
+      expect(spent.ok).toBe(false);
+      if (!spent.ok) {
+        expect(spent.throttled).toBeFalsy();
+        expect(spent.error).toMatch(/used up|wrong/i);
+      }
+      expect(vi.mocked(sendMail)).toHaveBeenCalledTimes(1);
+      // ...and a minute later a fresh code arrives and works.
+      vi.setSystemTime(new Date("2026-07-18T12:01:01Z"));
+      expect((await requestLoginCodeAction(guest.id)).ok).toBe(true);
+      const { code: fresh } = await lastSentEmail();
+      expect((await loginAsGuestAction(guest.id, fresh)).ok).toBe(true);
+      warn.mockRestore();
+    });
+
+    it("counts code guesses, not wrong passwords, as attempts", async () => {
+      const { guest, code } = await protectedGuestWithCode();
+      const { authCodes } = getRepositories();
+      const attempts = async () =>
+        (await authCodes.findActive(guest.id, "login", new Date()))?.attempts;
+
+      for (let i = 0; i < 3; i++) {
+        await loginAsGuestAction(guest.id, "not the password");
+      }
+      expect(await attempts()).toBe(0);
+      await loginAsGuestAction(guest.id, CODE_SHAPED_JUNK);
+      expect(await attempts()).toBe(1);
+      expect((await loginAsGuestAction(guest.id, code)).ok).toBe(true);
     });
 
     it("logs in with the permanent password", async () => {
@@ -295,6 +362,35 @@ describe("user auth actions", () => {
       const { code } = await lastSentEmail();
       expect((await loginAsGuestAction(guest.id, code)).ok).toBe(true);
       expect(await currentUserId()).toBe(guest.id);
+    });
+
+    it("the lockout message points at the code path it leaves open", async () => {
+      const guest = await createGuest();
+      await getRepositories().guests.setAuthProtection(guest.id, {
+        authProtected: true,
+        passwordHash: await hashUserPassword("hunter2 forever"),
+      });
+      for (let i = 0; i < MAX_LOGIN_FAILURES_PER_CLIENT; i++) {
+        await loginAsGuestAction(guest.id, "wrong");
+      }
+      const blocked = await loginAsGuestAction(guest.id, "hunter2 forever");
+      expect(blocked.ok).toBe(false);
+      if (!blocked.ok) expect(blocked.error).toMatch(/code/i);
+    });
+
+    it("does not promise a code in the lockout message without a mailer", async () => {
+      vi.mocked(isMailerConfigured).mockReturnValue(false);
+      const guest = await createGuest();
+      await getRepositories().guests.setAuthProtection(guest.id, {
+        authProtected: true,
+        passwordHash: await hashUserPassword("hunter2 forever"),
+      });
+      for (let i = 0; i < MAX_LOGIN_FAILURES_PER_CLIENT; i++) {
+        await loginAsGuestAction(guest.id, "wrong");
+      }
+      const blocked = await loginAsGuestAction(guest.id, "hunter2 forever");
+      expect(blocked.ok).toBe(false);
+      if (!blocked.ok) expect(blocked.error).not.toMatch(/code/i);
     });
 
     it("a lockout for one guest does not affect another", async () => {
@@ -418,6 +514,28 @@ describe("user auth actions", () => {
           )
         ).ok
       ).toBe(false);
+    });
+
+    it("a reset link survives any number of wrong tokens", async () => {
+      // A reset token carries 256 bits, so guessing it is infeasible and
+      // counting the guesses buys nothing — while retiring it after a bounded
+      // number of tries would hand anyone who knows a guest id a way to knock
+      // out the link that guest was just emailed.
+      const { guest, token } = await guestWithResetToken();
+      for (let i = 0; i < MAX_CODE_ATTEMPTS + 1; i++) {
+        expect(
+          (await setPasswordWithTokenAction(guest.id, "nope", "long enough")).ok
+        ).toBe(false);
+      }
+      expect(
+        (
+          await setPasswordWithTokenAction(
+            guest.id,
+            token,
+            "correct horse battery"
+          )
+        ).ok
+      ).toBe(true);
     });
 
     it("rejects a too-short password without consuming the token", async () => {

--- a/utils/user-credentials.ts
+++ b/utils/user-credentials.ts
@@ -12,6 +12,17 @@ import {
 
 export const AUTH_CODE_LENGTH = 8;
 export const AUTH_CODE_VALID_MINUTES = 10;
+// Wrong guesses retire an emailed login code, because it is otherwise an
+// unmetered online oracle and its ~40 bits don't cover that alone: the server
+// will serve thousands of guesses a second, so an uncapped code faces millions
+// of tries within its life. The cap is deliberately high (and matches NIST SP
+// 800-63B's limit for one-time codes), because retiring a code is also how an
+// attacker denies it to its owner — anyone can guess against a name they know,
+// so a low cap made shutting the emailed-code path, the path that must survive
+// a password lockout, cheap. See matchToken and recentlyIssued in
+// app/actions/user-auth.ts for the two halves of that balance. Reset tokens are
+// deliberately *not* metered — see matchToken.
+export const MAX_CODE_ATTEMPTS = 100;
 // Password-reset links live longer than login codes: the recipient may open
 // the mail on another device and still needs time to choose a new password.
 export const RESET_TOKEN_VALID_MINUTES = 30;
@@ -30,6 +41,18 @@ export function generateAuthCode(): string {
 /** Forgives case and stray whitespace in a hand-typed code. */
 export function normalizeAuthCode(input: string): string {
   return input.replace(/\s/g, "").toUpperCase();
+}
+
+/**
+ * Whether a normalized string could be a login code at all. Lets a caller
+ * whose one input field accepts either credential tell a wrong password apart
+ * from a wrong code. Never a substitute for comparing against the real code.
+ */
+export function isAuthCodeShaped(normalized: string): boolean {
+  return (
+    normalized.length === AUTH_CODE_LENGTH &&
+    [...normalized].every((char) => AUTH_CODE_ALPHABET.includes(char))
+  );
 }
 
 // Password-reset tokens travel only inside a link, never typed by hand, so


### PR DESCRIPTION
A 10-guess cap meant anyone who knows a guest name could spam junk into
the login field and burn that guest's outstanding code in 10 cheap
requests, repeatedly — shutting the emailed-token path that exists
precisely so a password lockout can never lock the real person out.
Removing the cap is not the answer either: measured against this app's
own DB path a code faces ~3.2M guesses within its 10-minute life, and
~40 bits does not cover an unmetered oracle.

So: raise the cap to 100 (NIST SP 800-63B's limit for one-time codes),
stop counting input that could not be a code — a fumbled password no
longer burns the code sharing its input field — and tell a guest whose
code was used up that it is spent, so they replace it after the request
throttle instead of retyping a dead one. Guessing now costs its owner a
wait rather than their way in, and stays bounded at 100 per code.

Reset tokens stop being metered at all: at 256 bits they can't be
guessed, so counting the guesses only ever handed an attacker a way to
retire someone's reset link. That leaves one escape hatch nobody can
knock out.

The password lockout also stops claiming more than it does: "try again
in a few minutes" read as an account lockout, when only the password is
refused and an emailed code gets in throughout. It now says that — but
only where a mailer makes it true.

<!-- jip:pushed-commit=db956aaa0fa38369520a589f11b7a164aeb1f83f -->