### PR TITLE
feat: Enlarge a guest's profile picture on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Documentation website**: the attendee guide and the organizer and self-hosting documentation now live at [docs.schellingboard.org](https://docs.schellingboard.org), searchable and readable on a phone. A version selector lets you read the documentation for the release you're actually running, rather than whatever is newest
 - **Help link in the footer**: every page, including `/admin`, now links to the documentation next to "Report a Bug". On narrow phones the footer wraps onto a second line instead of squeezing the links together
 - **A logo**: SchellingBoard now has one — two schedule grid lines crossing at a single filled slot. It appears on [schellingboard.org](https://schellingboard.org) and [docs.schellingboard.org](https://docs.schellingboard.org), and replaces the generic calendar icon that used to show in the browser tab and on a phone home screen
+- **Bigger profile photos**: on an attendee's page, click their profile picture to see it enlarged; press Escape, tap outside it, or use the close button to dismiss
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Documentation website**: the attendee guide and the organizer and self-hosting documentation now live at [docs.schellingboard.org](https://docs.schellingboard.org), searchable and readable on a phone. A version selector lets you read the documentation for the release you're actually running, rather than whatever is newest
 - **Help link in the footer**: every page, including `/admin`, now links to the documentation next to "Report a Bug". On narrow phones the footer wraps onto a second line instead of squeezing the links together
 - **A logo**: SchellingBoard now has one — two schedule grid lines crossing at a single filled slot. It appears on [schellingboard.org](https://schellingboard.org) and [docs.schellingboard.org](https://docs.schellingboard.org), and replaces the generic calendar icon that used to show in the browser tab and on a phone home screen
-- **Bigger profile photos**: on an attendee's page, click their profile picture to see it enlarged; press Escape, tap outside it, or use the close button to dismiss
+- **Bigger profile photos**: on an attendee's page, click their profile picture to see it enlarged; press Escape, tap outside it, or use the close button to dismiss. Profile pictures are now kept at a higher resolution so the enlarged view stays sharp — photos uploaded before this release keep their old, smaller size until the attendee uploads a new one. Small pictures are never blown up: one uploaded at, say, 300×300 is still stored at 300×300, and a long, flat one that can't be cropped to a square of at least 256×256 is now refused with an explanation instead of being stretched
 
 ### Changed
 

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -23,7 +23,7 @@ import { CORE_PROMPTS } from "@/model/prompt-pool";
 import { eventNameToSlug } from "@/utils/utils";
 import { sanitizeGuest } from "@/utils/guests";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
-import { Avatar } from "../avatar";
+import { ZoomableAvatar } from "../zoomable-avatar";
 import { Markdown } from "@/app/(site)/markdown";
 import { ComponentType, JSX, PropsWithChildren, SVGProps } from "react";
 import {
@@ -84,7 +84,10 @@ export default async function GuestProfilePage(props: {
       </div>
 
       <header className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <Avatar name={guest.name} image={guest.avatarUrl ?? undefined} />
+        <ZoomableAvatar
+          name={guest.name}
+          image={guest.avatarUrl ?? undefined}
+        />
         <div className="flex flex-col gap-2">
           <h1 className="text-3xl font-bold">{guest.name}</h1>
           {(guest.pronouns || isSessionHost) && (

--- a/app/(site)/guests/avatar.tsx
+++ b/app/(site)/guests/avatar.tsx
@@ -31,6 +31,10 @@ export function Avatar({
   onClick?: MouseEventHandler<HTMLDivElement>;
 }) {
   const dimensions = size === "lg" ? "h-28 w-28 text-3xl" : "h-12 w-12 text-sm";
+  // Matches the box above (h-28 = 112px, h-12 = 48px). Stored avatars are up to
+  // 1024px, so declaring the displayed size is what keeps next/image's 2x
+  // srcset entry at a thumbnail-sized rendition instead of a 640px one.
+  const renderedSize = size === "lg" ? 112 : 48;
 
   return (
     <div
@@ -48,8 +52,8 @@ export function Avatar({
           className="w-full h-full object-cover"
           src={image}
           alt={`Profile avatar of ${name}`}
-          width="256"
-          height="256"
+          width={renderedSize}
+          height={renderedSize}
         />
       ) : (
         initials(name) || "?"

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -17,6 +17,7 @@ import { Avatar } from "../avatar";
 import type { Guest } from "@/db/repositories/interfaces";
 import { CONTACT_TYPES } from "@/db/repositories/interfaces";
 import { resizeImage } from "@/utils/images-client";
+import { AVATAR_MAX_SIZE } from "@/utils/avatar-image-constraints";
 import clsx from "clsx";
 import {
   Controller,
@@ -166,7 +167,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
     // So this operation doesn't block the submission
     if (profile.avatar) {
       try {
-        const resized = await resize(profile.avatar, 256);
+        const resized = await resize(profile.avatar, AVATAR_MAX_SIZE);
         if ("error" in resized) {
           form.setError("avatar", { message: resized.error });
           return;

--- a/app/(site)/guests/zoomable-avatar.tsx
+++ b/app/(site)/guests/zoomable-avatar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Avatar } from "@/app/(site)/guests/avatar";
+import { Modal } from "@/app/(site)/modals";
+
+/**
+ * An {@link Avatar} that, when it has an uploaded image, can be clicked to open a
+ * larger view of that image. Initials placeholders (no image) render as a plain,
+ * non-interactive Avatar — there is nothing to enlarge.
+ */
+export function ZoomableAvatar({
+  name,
+  image,
+}: {
+  name: string;
+  image?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (!image) {
+    return <Avatar name={name} />;
+  }
+
+  return (
+    <>
+      {/* w-fit: as a flex item the button would otherwise stretch to the full
+          width of a stacked (mobile) header, well past the round photo.
+          focus-visible, not focus: closing the modal restores focus here, so a
+          plain :focus ring would linger around the photo after a mouse user
+          dismissed the enlarged view. Keyboard users still get the ring. */}
+      <button
+        type="button"
+        aria-label={`Enlarge photo of ${name}`}
+        className="w-fit rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+        onClick={() => setOpen(true)}
+      >
+        <Avatar name={name} image={image} />
+      </button>
+      {/* z-40 so the enlarged photo (and its dismiss-on-outside-click backdrop)
+          covers the fixed nav bar, which is z-30. */}
+      <Modal open={open} setOpen={setOpen} zIndex="z-40">
+        {/* User-uploaded image of arbitrary dimensions: serve it directly
+            (unoptimized) and bound it to the viewport so tall/wide photos stay
+            fully visible. */}
+        <Image
+          src={image}
+          alt={`Enlarged profile picture of ${name}`}
+          className="mx-auto h-auto w-full max-h-[80vh] object-contain"
+          width={0}
+          height={0}
+          sizes="100vw"
+          unoptimized
+        />
+      </Modal>
+    </>
+  );
+}

--- a/app/(site)/guests/zoomable-avatar.tsx
+++ b/app/(site)/guests/zoomable-avatar.tsx
@@ -4,6 +4,10 @@ import { useState } from "react";
 import Image from "next/image";
 import { Avatar } from "@/app/(site)/guests/avatar";
 import { Modal } from "@/app/(site)/modals";
+import {
+  AVATAR_ENLARGED_MAX_CSS_PX,
+  AVATAR_MAX_SIZE,
+} from "@/utils/avatar-image-constraints";
 
 /**
  * An {@link Avatar} that, when it has an uploaded image, can be clicked to open a
@@ -41,17 +45,18 @@ export function ZoomableAvatar({
       {/* z-40 so the enlarged photo (and its dismiss-on-outside-click backdrop)
           covers the fixed nav bar, which is z-30. */}
       <Modal open={open} setOpen={setOpen} zIndex="z-40">
-        {/* User-uploaded image of arbitrary dimensions: serve it directly
-            (unoptimized) and bound it to the viewport so tall/wide photos stay
-            fully visible. */}
+        {/* Avatars are stored as squares of at most AVATAR_MAX_SIZE, so the
+            width/height below give the right aspect ratio and let next/image
+            serve a rendition that fits the screen. maxWidth caps the displayed
+            size: past this the image would be upscaled and look soft. */}
         <Image
           src={image}
           alt={`Enlarged profile picture of ${name}`}
           className="mx-auto h-auto w-full max-h-[80vh] object-contain"
-          width={0}
-          height={0}
-          sizes="100vw"
-          unoptimized
+          style={{ maxWidth: AVATAR_ENLARGED_MAX_CSS_PX }}
+          width={AVATAR_MAX_SIZE}
+          height={AVATAR_MAX_SIZE}
+          sizes={`(max-width: ${AVATAR_ENLARGED_MAX_CSS_PX}px) 100vw, ${AVATAR_ENLARGED_MAX_CSS_PX}px`}
         />
       </Modal>
     </>

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -47,9 +47,9 @@ Proposing and voting close once scheduling starts.
 ## Attendee directory & profiles
 
 Every attendee gets a profile page with their bio, proposals, and the sessions
-they're hosting — click any name wherever it appears to see it. The attendee
-directory lets you search everyone at the event and see who's hosting a session
-at a glance.
+they're hosting — click any name wherever it appears to see it. Click their
+profile photo to see it enlarged. The attendee directory lets you search
+everyone at the event and see who's hosting a session at a glance.
 
 ![Searchable attendee directory with avatars, bios, and Session host badges](../screenshots/attendees.webp)
 

--- a/tests/e2e/profile-picture-zoom.spec.ts
+++ b/tests/e2e/profile-picture-zoom.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "./helpers/fixtures";
+import { login } from "./helpers/auth";
+
+// Charlie Test is seeded with an uploaded photo and no other spec edits their
+// profile, so this never races profile.spec.ts, which resets Alice's avatar.
+const GUEST = "Charlie Test";
+
+test("enlarges and dismisses a guest's profile picture on their detail page", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/guests");
+  await page.getByRole("link", { name: GUEST }).click();
+  await expect(
+    page.getByRole("heading", { level: 1, name: GUEST })
+  ).toBeVisible();
+  const profileUrl = page.url();
+
+  const trigger = page.getByRole("button", {
+    name: `Enlarge photo of ${GUEST}`,
+  });
+  const enlarged = page.getByAltText(`Enlarged profile picture of ${GUEST}`);
+
+  // Closed by default.
+  await expect(enlarged).toHaveCount(0);
+
+  // Click the photo → the enlarged view opens.
+  await trigger.click();
+  await expect(enlarged).toBeVisible();
+
+  // Escape closes it, and we stay on the same detail page.
+  await page.keyboard.press("Escape");
+  await expect(enlarged).toBeHidden();
+  expect(page.url()).toBe(profileUrl);
+
+  // The visible Close control closes it.
+  await trigger.click();
+  await expect(enlarged).toBeVisible();
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(enlarged).toBeHidden();
+
+  // Clicking outside the image (top-left corner) closes it.
+  await trigger.click();
+  await expect(enlarged).toBeVisible();
+  await page.mouse.click(5, 5);
+  await expect(enlarged).toBeHidden();
+
+  // The photo is back to normal for a mouse user: closing restores focus to
+  // the trigger, which must not leave a ring drawn around the avatar.
+  // Tailwind draws the ring as a box-shadow, and the restore is async.
+  const ring = () => trigger.evaluate((el) => getComputedStyle(el).boxShadow);
+  await expect.poll(ring).toBe("none");
+
+  // Keyboard: closing put focus back on the trigger, but in mouse modality, so
+  // step off it and back to land there the way a keyboard user would —
+  // tabbing, unlike a programmatic focus(), counts as keyboard interaction.
+  // Now the ring must show: it is the only cue to where focus sits.
+  const isFocused = () =>
+    trigger.evaluate((el) => el === document.activeElement);
+  await expect.poll(isFocused).toBe(true);
+  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.press("Tab");
+  await expect.poll(isFocused).toBe(true);
+  await expect.poll(ring).not.toBe("none");
+  await page.keyboard.press("Enter");
+  await expect(enlarged).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(enlarged).toBeHidden();
+
+  // On a phone the header stacks vertically. The trigger must still hug the
+  // photo: stretched to the row's width it would swallow taps aimed at the
+  // empty space beside the avatar and draw a full-width focus ring.
+  const width = 375;
+  const height = 667;
+  await page.setViewportSize({ width, height });
+  const photo = page.getByAltText(`Profile avatar of ${GUEST}`);
+  const photoBox = await photo.boundingBox();
+  const triggerBox = await trigger.boundingBox();
+  expect(triggerBox!.width).toBeLessThanOrEqual(photoBox!.width + 1);
+
+  // The enlarged image stays fully within a phone screen.
+  await trigger.click();
+  await expect(enlarged).toBeVisible();
+  const box = await enlarged.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(height + 1);
+});

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -111,7 +111,27 @@ describe("updateProfileAction", () => {
     expect(fs.existsSync(imagePath)).toBe(true);
   });
 
-  it("resizes avatar to 256 and keeps extension", async () => {
+  it("resizes a large avatar to 1024 and keeps extension", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    const result = await updateProfileAction({
+      name: "New Name",
+      aboutMe: "Hello there",
+      avatar: await createImageFile(2048, 2048, "avatar.png"),
+    });
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    expect(fs.existsSync(imagePath)).toBe(true);
+    const imageMetadata = await sharp(fs.readFileSync(imagePath)).metadata();
+    expect(imageMetadata).toMatchObject({
+      width: 1024,
+      height: 1024,
+      format: "png",
+    });
+  });
+
+  it("never upscales an avatar smaller than 1024", async () => {
     const guest = await createGuest({ name: "Old" });
     cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
     const result = await updateProfileAction({
@@ -122,13 +142,23 @@ describe("updateProfileAction", () => {
     expect(result).toEqual({ ok: true });
     const updated = await getRepositories().guests.findById(guest.id);
     const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
-    expect(fs.existsSync(imagePath)).toBe(true);
     const imageMetadata = await sharp(fs.readFileSync(imagePath)).metadata();
-    expect(imageMetadata).toMatchObject({
-      width: 256,
-      height: 256,
-      format: "png",
+    expect(imageMetadata).toMatchObject({ width: 512, height: 512 });
+  });
+
+  it("crops a non-square avatar to its shorter side rather than upscaling", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    const result = await updateProfileAction({
+      name: "New Name",
+      aboutMe: "Hello there",
+      avatar: await createImageFile(900, 400, "avatar.png"),
     });
+    expect(result).toEqual({ ok: true });
+    const updated = await getRepositories().guests.findById(guest.id);
+    const imagePath = path.join(uploadsDir, "avatars", `${updated?.id}.png`);
+    const imageMetadata = await sharp(fs.readFileSync(imagePath)).metadata();
+    expect(imageMetadata).toMatchObject({ width: 400, height: 400 });
   });
 
   it("saves basedIn, prompts, languages, and contacts", async () => {
@@ -252,6 +282,19 @@ describe("updateProfileAction", () => {
       name: "New Name",
       aboutMe: "Hello there",
       avatar: await createImageFile(128, 128, "avatar.png"),
+    });
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  // The square crop can't be bigger than the shorter side, so a wide-but-flat
+  // image would otherwise be stored below the 256px minimum.
+  it("rejects a wide image whose shorter side is below the minimum", async () => {
+    const guest = await createGuest({ name: "Old" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    const result = await updateProfileAction({
+      name: "New Name",
+      aboutMe: "Hello there",
+      avatar: await createImageFile(2000, 100, "avatar.png"),
     });
     expect(result).toMatchObject({ ok: false });
   });

--- a/tests/integration/verified-guest-reads.test.ts
+++ b/tests/integration/verified-guest-reads.test.ts
@@ -36,6 +36,9 @@ vi.mock("@/app/(site)/guests/edit/profile-form", () => ({
 vi.mock("@/app/(site)/guests/attendee-list", () => ({
   AttendeeList: () => "ATTENDEE_LIST_STUB",
 }));
+vi.mock("@/app/(site)/guests/zoomable-avatar", () => ({
+  ZoomableAvatar: () => "ZOOMABLE_AVATAR_STUB",
+}));
 
 import { setupTestDb, resetTestDb } from "../helpers/db";
 import { createGuest } from "../helpers/factories";

--- a/tests/unit/zoomable-avatar.test.tsx
+++ b/tests/unit/zoomable-avatar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// The enlarged view itself is E2E-tested; stubbing it keeps this test off the
+// modals module and the whole client-context tree it imports.
+vi.mock("@/app/(site)/modals", () => ({ Modal: () => null }));
+
+import { ZoomableAvatar } from "@/app/(site)/guests/zoomable-avatar";
+
+describe("ZoomableAvatar", () => {
+  it("makes an uploaded photo clickable", () => {
+    const html = renderToStaticMarkup(
+      <ZoomableAvatar name="Amara Okafor" image="/media/avatars/amara.webp" />
+    );
+    expect(html).toContain("Enlarge photo of Amara Okafor");
+  });
+
+  it("leaves an initials placeholder non-interactive", () => {
+    const html = renderToStaticMarkup(<ZoomableAvatar name="Amara Okafor" />);
+    expect(html).not.toContain("<button");
+    expect(html).toContain("AO");
+  });
+});

--- a/utils/avatar-image-constraints.ts
+++ b/utils/avatar-image-constraints.ts
@@ -1,0 +1,28 @@
+// Client-safe constraints for avatar images. Validation itself lives in
+// images.ts, which is server-only (it uses sharp and fs).
+
+export const MIN_AVATAR_WIDTH = 256;
+
+// Avatars are stored at one size and downscaled on the fly by next/image for
+// the small round thumbnails, so this only has to satisfy the largest use:
+// the enlarged view, at AVATAR_ENLARGED_MAX_CSS_PX on a 2x screen.
+export const AVATAR_MAX_SIZE = 1024;
+
+/**
+ * Widest the enlarged view displays an avatar, in CSS pixels. Half of
+ * {@link AVATAR_MAX_SIZE}, so a 2x screen fills exactly the stored pixels and
+ * anything wider would start upscaling them. Change one and the other follows.
+ */
+export const AVATAR_ENLARGED_MAX_CSS_PX = AVATAR_MAX_SIZE / 2;
+
+/**
+ * Side length of a square cover-crop that never upscales the source: a crop
+ * can't be wider than the shorter side of what it is cut from.
+ */
+export function coverSquareSize(
+  maxSize: number,
+  width: number,
+  height: number
+): number {
+  return Math.min(maxSize, width, height);
+}

--- a/utils/images-client.ts
+++ b/utils/images-client.ts
@@ -1,4 +1,5 @@
 import "client-only";
+import { coverSquareSize } from "@/utils/avatar-image-constraints";
 
 function drawCover(
   ctx: CanvasRenderingContext2D,
@@ -57,8 +58,12 @@ export async function resizeImage(
 ): Promise<{ blob: Blob } | { error: string }> {
   const bitmap = await createImageBitmap(file);
 
-  canvas.width = maxSize;
-  canvas.height = maxSize;
+  // Never upscale here either: otherwise a small upload would arrive at the
+  // server already enlarged, and the server could no longer tell.
+  const size = coverSquareSize(maxSize, bitmap.width, bitmap.height);
+
+  canvas.width = size;
+  canvas.height = size;
 
   const ctx = canvas.getContext("2d")!;
 

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -7,6 +7,11 @@ import {
   MIN_IMAGE_WIDTH,
   REQUIRED_ASPECT_RATIO,
 } from "@/utils/location-image-constraints";
+import {
+  AVATAR_MAX_SIZE,
+  MIN_AVATAR_WIDTH,
+  coverSquareSize,
+} from "@/utils/avatar-image-constraints";
 import { uploadsDir } from "@/utils/uploads-dir";
 
 // Images are stored on the filesystem under SB_UPLOADS_DIR
@@ -170,7 +175,7 @@ const CONTENT_TYPES: Record<string, string> = {
 export class AvatarImageResourceRepository extends BaseImageResourceRepository<string> {
   override directory = "avatars";
 
-  override minImageWidth = 256;
+  override minImageWidth = MIN_AVATAR_WIDTH;
 
   protected override getEndpoint(filename: string): string {
     return `/media/avatars/${filename}`;
@@ -186,7 +191,23 @@ export class AvatarImageResourceRepository extends BaseImageResourceRepository<s
       return decodeResult;
     }
 
-    return { ok: decodeResult.ok.resize(256, 256, { fit: "cover" }) };
+    // Crop to a square without ever enlarging: upscaling invents no detail and
+    // only costs bytes, so a small upload stays at its own size.
+    const size = coverSquareSize(
+      AVATAR_MAX_SIZE,
+      metadata.width,
+      metadata.height
+    );
+
+    // The base check only looks at the width, which a flat panorama passes
+    // while its square crop lands well under the minimum.
+    if (size < MIN_AVATAR_WIDTH) {
+      return {
+        error: `Image is too small (min ${MIN_AVATAR_WIDTH}×${MIN_AVATAR_WIDTH}px)`,
+      };
+    }
+
+    return { ok: decodeResult.ok.resize(size, size, { fit: "cover" }) };
   }
 }
 


### PR DESCRIPTION
Click an attendee's uploaded photo on their detail page to open a
larger view; dismiss with Escape, a click outside, or the close
button. Initials-placeholder avatars stay non-interactive since
there's nothing to enlarge.

closes #690

<!-- jip:pushed-commit=030f26055f2a224209d692b13dafeb30edf35fca -->