### PR TITLE
Update .gitignore to ignore spec-kit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ www-site/
 # Build config assembled by scripts/build-docs.sh from docmd.config.json plus
 # the versions it reconstructs from git tags.
 .docmd.build.json
+
+# Spec-Kit for Claude
+.specify/
+.claude/skills/speckit-*/


### PR DESCRIPTION
Supersedes #729 

I use spec-kit to help me with adding features, but don't want to enable it for all devs by default.