### PR TITLE
Notify attendees of session deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Emails when a session is deleted**: hosts and RSVP'd attendees are now told when a session disappears, not only when it moves. It uses the same two settings attendees already have for session changes, so nobody has anything new to turn on
+
 ## [3.2.0] - 2026-07-29
 
 ### Added

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -73,11 +73,11 @@ export function SettingsForm({
           </p>
           <label className="flex items-center gap-2 text-sm text-gray-700">
             <input type="checkbox" {...form.register("rsvpChange")} />a session
-            I&rsquo;ve RSVP&rsquo;d to changes time or location
+            I&rsquo;ve RSVP&rsquo;d to changes time or location, or is deleted
           </label>
           <label className="flex items-center gap-2 text-sm text-gray-700">
             <input type="checkbox" {...form.register("hostChange")} />a session
-            I&rsquo;m hosting changes time or location
+            I&rsquo;m hosting changes time or location, or is deleted
           </label>
           <label className="flex items-center gap-2 text-sm text-gray-700">
             <input type="checkbox" {...form.register("cohostAdd")} />

--- a/app/actions/admin-sessions.ts
+++ b/app/actions/admin-sessions.ts
@@ -8,6 +8,8 @@ import { sessionSlotAlignmentError } from "@/utils/day-window";
 import {
   notifyCohostsAdded,
   notifySessionChanged,
+  notifySessionDeleted,
+  rsvpGuestIdsToNotify,
 } from "@/utils/notifications";
 import type { AdminActionResult } from "./admin-guests";
 
@@ -234,6 +236,8 @@ export async function adminDeleteSessionAction(input: {
   const session = await sessions.findById(input.id);
   if (!session) return { ok: false, error: "Session not found" };
 
+  const rsvpGuestIds = await rsvpGuestIdsToNotify(input.id);
+
   try {
     await sessions.delete(input.id);
   } catch {
@@ -241,5 +245,10 @@ export async function adminDeleteSessionAction(input: {
   }
 
   await revalidateEventPaths(session.eventId);
+  await notifySessionDeleted({
+    session,
+    rsvpGuestIds,
+    changedById: null,
+  });
   return { ok: true };
 }

--- a/app/api/delete-session/route.ts
+++ b/app/api/delete-session/route.ts
@@ -3,6 +3,10 @@ import { getRepositories } from "@/db/container";
 import { inSchedPhase } from "@/app/(site)/utils/events";
 import { requestNow } from "@/utils/dev-clock";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
+import {
+  notifySessionDeleted,
+  rsvpGuestIdsToNotify,
+} from "@/utils/notifications";
 
 export const dynamic = "force-dynamic"; // defaults to auto
 
@@ -35,6 +39,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const rsvpGuestIds = await rsvpGuestIdsToNotify(id);
+
   try {
     await repos.sessions.delete(id);
     console.log(`Deleted session: ${id}`);
@@ -43,5 +49,10 @@ export async function POST(req: NextRequest) {
     return Response.error();
   }
 
+  await notifySessionDeleted({
+    session,
+    rsvpGuestIds,
+    changedById: actor,
+  });
   return Response.json({ success: true });
 }

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -101,6 +101,6 @@ address, and you can unlock from there.
 ## Email settings
 
 If the event has email enabled, Settings also controls which notifications
-you get: when a session you host or RSVP'd to is moved, and when someone adds
-you as a co-host. Both are on by default and can be turned off
+you get: when a session you host or RSVP'd to is moved or deleted, and when
+someone adds you as a co-host. These are on by default and can be turned off
 independently.

--- a/docs/public/organizers/how-it-works.md
+++ b/docs/public/organizers/how-it-works.md
@@ -118,6 +118,7 @@ these are the only messages ever sent:
 | -------------------- | --------------------------------------------------------------------- | ------------------------------- |
 | **Login code**       | An attendee who asked to protect or unlock their name                 | None — it's requested on demand |
 | **Session moved**    | Hosts and RSVP'd attendees, when a session's time or location changes | Per-attendee, in their settings |
+| **Session deleted**  | Hosts and RSVP'd attendees, when their session is deleted             | Per-attendee, in their settings |
 | **Added as co-host** | Attendees newly added as a co-host of a session                       | Per-attendee, in their settings |
 | **Test email**       | One guest, from the admin Users page                                  | n/a                             |
 

--- a/emails/session-deleted.tsx
+++ b/emails/session-deleted.tsx
@@ -1,0 +1,43 @@
+import type { EmailMessage } from "@/utils/mailer";
+import { EmailMarkdown } from "@/emails/markdown";
+
+// Sent to hosts and RSVP'd guests when a session is deleted. Time and
+// location come preformatted, and describe the session as it was; the link
+// goes to the schedule, since the session itself is gone.
+export function sessionDeletedEmail(props: {
+  recipient: "host" | "attendee";
+  title: string;
+  description: string;
+  time: string;
+  location: string;
+  eventUrl: string;
+}): EmailMessage {
+  return {
+    subject: `Session deleted: ${props.title}`,
+    body: (
+      <>
+        <h1>{props.title}</h1>
+        <p>
+          {props.recipient === "host" ? (
+            <>A session you&rsquo;re hosting</>
+          ) : (
+            <>A session you RSVP&rsquo;d to</>
+          )}{" "}
+          has been deleted.
+        </p>
+        <p>
+          <strong>Time:</strong> {props.time}
+        </p>
+        <p>
+          <strong>Location:</strong> {props.location}
+        </p>
+        {props.description && (
+          <EmailMarkdown>{props.description}</EmailMarkdown>
+        )}
+        <p>
+          <a href={props.eventUrl}>View the schedule</a>
+        </p>
+      </>
+    ),
+  };
+}

--- a/tests/integration/admin-sessions.test.ts
+++ b/tests/integration/admin-sessions.test.ts
@@ -1017,6 +1017,45 @@ describe("adminDeleteSessionAction", () => {
     expect(await repos.locations.findById(loc.id)).toBeDefined();
   });
 
+  it("emails hosts and RSVP'd attendees after deletion", async () => {
+    vi.stubEnv("SITE_URL", "https://site.example");
+    const repos = getRepositories();
+    const event = await createEvent();
+    const host = await createGuest({
+      name: "Host",
+      email: "host@test.example",
+    });
+    const attendee = await createGuest({
+      name: "Attendee",
+      email: "attendee@test.example",
+    });
+    const session = await createSession(event.id, {
+      title: "Workshop",
+      hostIds: [host.id],
+    });
+    await repos.rsvps.create({
+      sessionId: session.id,
+      guestId: attendee.id,
+    });
+    vi.mocked(sendMail).mockReset();
+
+    const result = await adminDeleteSessionAction({ id: session.id });
+    expect(result.ok).toBe(true);
+
+    const recipients = vi.mocked(sendMail).mock.calls.map((call) => call[0].to);
+    expect(recipients.sort()).toEqual([
+      "attendee@test.example",
+      "host@test.example",
+    ]);
+    expect(
+      vi
+        .mocked(sendMail)
+        .mock.calls.every(([message]) =>
+          message.subject.startsWith("Session deleted:")
+        )
+    ).toBe(true);
+  });
+
   it("revalidates the public event layout so attendees see the removal", async () => {
     const event = await createEvent();
     const session = await createSession(event.id);

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -30,6 +30,7 @@ import { POST as addPOST } from "@/app/api/add-session/route";
 import { POST } from "@/app/api/delete-session/route";
 import type { SessionParams } from "@/app/api/session-form-utils";
 import type { Day, Guest, Location } from "@/db/repositories/interfaces";
+import { sendMail } from "@/utils/mailer";
 
 const VALID_SECRET = "0123456789abcdef0123456789abcdef";
 
@@ -177,6 +178,58 @@ describe("POST /api/delete-session", () => {
 
     const after = await getRepositories().rsvps.listByGuest(attendee.id);
     expect(after).toHaveLength(0);
+  });
+
+  it("emails other hosts and RSVP'd attendees after deletion", async () => {
+    vi.stubEnv("SITE_URL", "https://site.example");
+    const event = await createEvent({ phase: "scheduling" });
+    const deletingHost = await createGuest({
+      name: "Deleting Host",
+      email: "deleting@test.example",
+      eventId: event.id,
+    });
+    const otherHost = await createGuest({
+      name: "Other Host",
+      email: "other-host@test.example",
+      eventId: event.id,
+    });
+    const attendee = await createGuest({
+      name: "Attendee",
+      email: "attendee@test.example",
+    });
+    const location = await createLocation();
+    const day = await createDay(event.id);
+    const sessionId = await createScheduledSession(
+      event.id,
+      deletingHost,
+      location,
+      day,
+      { hosts: [deletingHost, otherHost] }
+    );
+    await getRepositories().rsvps.create({
+      sessionId,
+      guestId: attendee.id,
+    });
+    vi.mocked(sendMail).mockReset();
+
+    const res = await POST(
+      makeDeleteReq(sessionId, { editorGuestId: deletingHost.id })
+    );
+    expect(res.ok).toBe(true);
+
+    const recipients = vi.mocked(sendMail).mock.calls.map((call) => call[0].to);
+    expect(recipients.sort()).toEqual([
+      "attendee@test.example",
+      "other-host@test.example",
+    ]);
+    expect(recipients).not.toContain("deleting@test.example");
+    expect(
+      vi
+        .mocked(sendMail)
+        .mock.calls.every(([message]) =>
+          message.subject.startsWith("Session deleted:")
+        )
+    ).toBe(true);
   });
 
   it("rejects a non-host attempting to delete", async () => {

--- a/tests/integration/notifications.test.tsx
+++ b/tests/integration/notifications.test.tsx
@@ -27,6 +27,7 @@ import {
   notifyCohostsAdded,
   notifyGuest,
   notifySessionChanged,
+  notifySessionDeleted,
 } from "@/utils/notifications";
 
 const MESSAGE = {
@@ -332,6 +333,106 @@ describe("notifySessionChanged", () => {
       "new-host@test.example",
       "rsvper@test.example",
     ]);
+  });
+});
+
+describe("notifySessionDeleted", () => {
+  beforeAll(() => setupTestDb());
+
+  beforeEach(() => {
+    resetTestDb();
+    vi.mocked(sendMail).mockReset();
+    vi.stubEnv("SITE_URL", "https://site.example");
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function renderWithoutComments(body: ReactElement): Promise<string> {
+    return (await render(body)).replace(/<!--.*?-->/g, "");
+  }
+
+  it("emails hosts and RSVP'd attendees that the session was deleted", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const room = await createLocation({ name: "Room A" });
+    const host = await createGuest({ email: "host@test.example" });
+    const attendee = await createGuest({ email: "attendee@test.example" });
+    const session = await createSession(event.id, {
+      title: "Fun Workshop",
+      description: "A *hands-on* session.",
+      hostIds: [host.id],
+      locationIds: [room.id],
+      startTime: new Date("2026-08-01T10:00:00Z"),
+      endTime: new Date("2026-08-01T11:00:00Z"),
+    });
+
+    await notifySessionDeleted({
+      session,
+      rsvpGuestIds: [attendee.id],
+      changedById: null,
+    });
+
+    expect(sendMail).toHaveBeenCalledTimes(2);
+    const messages = vi.mocked(sendMail).mock.calls.map((call) => call[0]);
+    const hostMessage = messages.find((m) => m.to === "host@test.example");
+    const attendeeMessage = messages.find(
+      (m) => m.to === "attendee@test.example"
+    );
+    expect(hostMessage?.subject).toBe("Session deleted: Fun Workshop");
+    expect(attendeeMessage?.subject).toBe("Session deleted: Fun Workshop");
+
+    const hostHtml = await renderWithoutComments(hostMessage!.body);
+    const attendeeHtml = await renderWithoutComments(attendeeMessage!.body);
+    expect(hostHtml).toContain("A session you");
+    expect(hostHtml).toContain("hosting");
+    expect(attendeeHtml).toContain("A session you RSVP");
+    expect(hostHtml).toContain("has been deleted");
+    expect(attendeeHtml).toContain("has been deleted");
+    expect(hostHtml).toContain("A <em>hands-on</em> session.");
+    expect(hostHtml).toContain("Saturday 1 August, 10:10");
+    expect(hostHtml).toContain("Room A");
+    expect(hostHtml).toContain(`href="https://site.example/${event.slug}"`);
+  });
+
+  it("uses hostChange and rsvpChange settings for deletion recipients", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const optedOutHost = await createGuest({
+      email: "host-off@test.example",
+      emailSettings: {
+        hostChange: false,
+        rsvpChange: true,
+        cohostAdd: true,
+      },
+    });
+    const optedOutAttendee = await createGuest({
+      email: "rsvp-off@test.example",
+      emailSettings: {
+        hostChange: true,
+        rsvpChange: false,
+        cohostAdd: true,
+      },
+    });
+    const optedInAttendee = await createGuest({
+      email: "rsvp-on@test.example",
+      emailSettings: {
+        hostChange: false,
+        rsvpChange: true,
+        cohostAdd: false,
+      },
+    });
+    const session = await createSession(event.id, {
+      hostIds: [optedOutHost.id],
+    });
+
+    await notifySessionDeleted({
+      session,
+      rsvpGuestIds: [optedOutAttendee.id, optedInAttendee.id],
+      changedById: null,
+    });
+
+    expect(sendMail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendMail).mock.calls[0][0].to).toBe(
+      "rsvp-on@test.example"
+    );
   });
 });
 

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -4,6 +4,7 @@ import type { EmailSettings, Session } from "@/db/repositories/interfaces";
 import { sendMail, type EmailMessage } from "@/utils/mailer";
 import { siteUrl } from "@/utils/site-url";
 import { sessionChangedEmail } from "@/emails/session-changed";
+import { sessionDeletedEmail } from "@/emails/session-deleted";
 import { cohostAddedEmail } from "@/emails/cohost-added";
 import { getStartTimePlusBreak } from "@/utils/utils";
 
@@ -104,23 +105,123 @@ async function notifySessionChangedUnsafe({
     recipient: "attendee",
   });
 
+  await notifySessionRecipients({
+    hostIds: after.hosts.map((host) => host.id),
+    rsvpGuestIds: (await rsvps.listBySession(after.id)).map(
+      (rsvp) => rsvp.guestId
+    ),
+    changedById,
+    hostMessage,
+    attendeeMessage,
+  });
+}
+
+// The guests to tell about a session's deletion, to be called *before*
+// deleting it: the delete cascades to its RSVP rows, so afterwards there is
+// nobody left to look up. Pass the result to notifySessionDeleted.
+//
+// Never throws: failing to find the recipients must not fail the deletion.
+export async function rsvpGuestIdsToNotify(
+  sessionId: string
+): Promise<string[]> {
+  try {
+    const rsvps = await getRepositories().rsvps.listBySession(sessionId);
+    return rsvps.map((rsvp) => rsvp.guestId);
+  } catch (err) {
+    console.error(
+      `Failed to load deletion notification recipients for session ${sessionId}:`,
+      err
+    );
+    return [];
+  }
+}
+
+// Email the session's hosts and RSVP'd guests (who have opted in) after a
+// deletion. `rsvpGuestIds` comes from rsvpGuestIdsToNotify, called before the
+// deletion.
+//
+// Never throws: notification failures must not make a successful deletion
+// look unsuccessful.
+export async function notifySessionDeleted(args: {
+  session: Session;
+  rsvpGuestIds: string[];
+  changedById: string | null;
+}): Promise<void> {
+  try {
+    await notifySessionDeletedUnsafe(args);
+  } catch (err) {
+    console.error("Failed to send session-deleted notifications:", err);
+  }
+}
+
+async function notifySessionDeletedUnsafe({
+  session,
+  rsvpGuestIds,
+  changedById,
+}: {
+  session: Session;
+  rsvpGuestIds: string[];
+  changedById: string | null;
+}): Promise<void> {
+  const event = await getRepositories().events.findById(session.eventId);
+  if (!event) return;
+
+  const base = siteUrl();
+  if (base === null) {
+    console.warn(
+      "SITE_URL is not set - not sending session deletion notifications"
+    );
+    return;
+  }
+  const messageProps = {
+    title: session.title,
+    description: session.description,
+    time: formatSessionTime(session, event.timezone, event.breakMinutes),
+    location: formatLocations(session),
+    eventUrl: `${base}/${event.slug}`,
+  };
+
+  await notifySessionRecipients({
+    hostIds: session.hosts.map((host) => host.id),
+    rsvpGuestIds,
+    changedById,
+    hostMessage: sessionDeletedEmail({
+      ...messageProps,
+      recipient: "host",
+    }),
+    attendeeMessage: sessionDeletedEmail({
+      ...messageProps,
+      recipient: "attendee",
+    }),
+  });
+}
+
+async function notifySessionRecipients({
+  hostIds,
+  rsvpGuestIds,
+  changedById,
+  hostMessage,
+  attendeeMessage,
+}: {
+  hostIds: string[];
+  rsvpGuestIds: string[];
+  changedById: string | null;
+  hostMessage: EmailMessage;
+  attendeeMessage: EmailMessage;
+}): Promise<void> {
   // Guards against telling anyone twice (or the editor at all), should a
   // guest ever be both host and RSVP'd.
   const done = new Set(changedById === null ? [] : [changedById]);
 
-  // We could exclude hosts who were already hosts before the change, since they
-  // also get an email for being added. But that email might not make it clear
-  // the session has changed, if they were previously RSVP'd; and they might
-  // have that email disabled but not this one.
-  for (const host of after.hosts) {
-    if (done.has(host.id)) continue;
-    done.add(host.id);
-    await tryNotifyGuest(host.id, "hostChange", hostMessage);
+  for (const hostId of hostIds) {
+    if (done.has(hostId)) continue;
+    done.add(hostId);
+    await tryNotifyGuest(hostId, "hostChange", hostMessage);
   }
-  for (const rsvp of await rsvps.listBySession(after.id)) {
-    if (done.has(rsvp.guestId)) continue;
-    done.add(rsvp.guestId);
-    await tryNotifyGuest(rsvp.guestId, "rsvpChange", attendeeMessage);
+  for (const guestId of rsvpGuestIds) {
+    if (done.has(guestId)) continue;
+    done.add(guestId);
+    await tryNotifyGuest(guestId, "rsvpChange", attendeeMessage);
   }
 }
 


### PR DESCRIPTION
Should fix issue #699 

I have run all applicable tests on my end. I also manually created and deleted sessions in the Docker container and it did send me an email about session deletion (expected behaviour).

I needed `SITE_URL` to reach the app when set in the Docker environment file, so I changed that, but it can be changed back.