### PR TITLE
feat: summarize form errors next to the submit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Comments on proposals**: attendees can discuss a proposal by leaving a comment on it. Replies are threaded and can be folded away; you can edit or delete your own comments, and link to any single comment. Deleting discards the text for good — there is no history and no undo.
 - **Emails when a session is deleted**: hosts and RSVP'd attendees are now told when a session disappears, not only when it moves. It uses the same two settings attendees already have for session changes, so nobody has anything new to turn on
 
+### Changed
+
+- **Saving a form that has errors now says why, right where you clicked**: on longer forms — editing your profile, proposing a session, adding or editing a location — a summary of everything that needs fixing appears next to the Save button, instead of the page simply not moving because the message sits somewhere further up. Each entry is clickable and takes you to the field it belongs to, opening the "Languages", "Contact details" or "Conversation starters" section first if the field is hidden inside it
+
 ## [3.2.0] - 2026-07-29
 
 ### Added

--- a/app/(site)/[eventSlug]/session-proposal-form.tsx
+++ b/app/(site)/[eventSlug]/session-proposal-form.tsx
@@ -22,6 +22,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { sessionProposalSchema } from "@/model/session";
 import { z } from "zod";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
+import { FormErrorSummary } from "@/app/components/form-error-summary";
 import { setActionErrors } from "@/utils/forms";
 
 export function SessionProposalForm(props: {
@@ -228,13 +229,7 @@ export function SessionProposalForm(props: {
           </span>
         </div>
 
-        {form.formState.errors.root && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
-            <p className="text-sm font-medium">
-              Error: {form.formState.errors.root.message}
-            </p>
-          </div>
-        )}
+        <FormErrorSummary form={form} />
 
         <button
           type="submit"

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -47,6 +47,7 @@ import { ArrowPathIcon, ChevronUpDownIcon } from "@heroicons/react/16/solid";
 import { MarkdownHint } from "@/app/(site)/markdown";
 import { containsIgnoringAccents } from "@/utils/utils";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
+import { FormErrorSummary } from "@/app/components/form-error-summary";
 import { setActionErrors } from "@/utils/forms";
 
 const profileFormSchema = profileSchema.extend({
@@ -117,8 +118,12 @@ export function ProfileForm({ guest }: { guest: Guest }) {
   });
   const avatar = avatarFileList === null ? null : avatarFileList?.[0];
   const [isDragging, setIsDragging] = useState(false);
+  // Field the error summary was last asked to jump to: the disclosure holding
+  // it has to open before the field can be seen or focused.
+  const [jumpTarget, setJumpTarget] = useState<string | null>(null);
   const canvas = useRef<HTMLCanvasElement>(null);
   const fileInput = useRef<HTMLInputElement>(null);
+  const avatarPicker = useRef<HTMLButtonElement>(null);
 
   const languageOptions = useMemo(() => languageSuggestions(), []);
 
@@ -254,6 +259,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                 : "border-gray-500"
             )}
             type="button"
+            ref={avatarPicker}
             {...avatarAreaController}
           >
             <Avatar
@@ -322,6 +328,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
               value={pronounController.field.value}
               onChange={pronounController.field.onChange}
               invalid={pronounController.fieldState.invalid}
+              fieldRef={pronounController.field.ref}
             />
             <span className="text-rose-400 text-sm">
               {form.formState.errors.pronouns?.message}
@@ -364,6 +371,8 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           title="Conversation starters"
           hint="Optional prompts that give people something to ask you about"
           defaultOpen={(guest.prompts ?? []).length > 0}
+          forceOpen={!!jumpTarget?.startsWith("prompts")}
+          onCollapse={() => setJumpTarget(null)}
         >
           {prompts.fields.map((field, i) => {
             const isCore = CORE_PROMPTS.includes(field.prompt);
@@ -424,6 +433,8 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           title="Languages"
           hint="Languages you're happy to talk in"
           defaultOpen={(guest.languages ?? []).length > 0}
+          forceOpen={!!jumpTarget?.startsWith("languages")}
+          onCollapse={() => setJumpTarget(null)}
         >
           {languages.fields.map((field, i) => (
             <div key={field.id} className="flex items-center gap-2">
@@ -441,6 +452,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                         value={f.value}
                         onChange={(v) => f.onChange(v ?? "")}
                         invalid={fieldState.invalid}
+                        fieldRef={f.ref}
                       />
                       {fieldState.error && (
                         <span className="text-rose-400 text-sm">
@@ -478,6 +490,8 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           title="Contact details"
           hint="Shown publicly on your profile — only add what you want visible"
           defaultOpen={(guest.contacts ?? []).length > 0}
+          forceOpen={!!jumpTarget?.startsWith("contacts")}
+          onCollapse={() => setJumpTarget(null)}
         >
           {contacts.fields.map((field, i) => (
             <div key={field.id} className="flex flex-col gap-1">
@@ -545,13 +559,15 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           </span>
         </DisclosureSection>
 
-        {form.formState.errors.root && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
-            <p className="text-sm font-medium">
-              Error: {form.formState.errors.root.message}
-            </p>
-          </div>
-        )}
+        <FormErrorSummary
+          form={form}
+          onJump={(name) => {
+            setJumpTarget(name);
+            // The picture's file input is hidden, so focus can't reach it:
+            // send the attendee to the picker that opens it instead.
+            if (name === "avatar") avatarPicker.current?.focus();
+          }}
+        />
 
         <button
           type="submit"
@@ -569,19 +585,29 @@ function DisclosureSection({
   title,
   hint,
   defaultOpen,
+  forceOpen = false,
+  onCollapse,
   children,
 }: PropsWithChildren<{
   title: string;
   hint: string;
   defaultOpen: boolean;
+  /** Reveals a field the error summary is jumping to. */
+  forceOpen?: boolean;
+  onCollapse?: () => void;
 }>) {
   // Controlled so React re-renders (e.g. form state changes) don't snap the
   // section back to its initial state after the user toggles it.
   const [open, setOpen] = useState(defaultOpen);
   return (
     <details
-      open={open}
-      onToggle={(e) => setOpen(e.currentTarget.open)}
+      open={open || forceOpen}
+      onToggle={(e) => {
+        setOpen(e.currentTarget.open);
+        // Drops the jump that forced this open, so closing it sticks. Only
+        // this section's own jump: another section's is none of its business.
+        if (!e.currentTarget.open && forceOpen) onCollapse?.();
+      }}
       className="rounded-md border border-gray-200 bg-white shadow-sm"
     >
       <summary className="cursor-pointer select-none px-4 py-3">
@@ -612,6 +638,7 @@ function FreeformCombobox({
   options,
   placeholder,
   filterOptions = false,
+  fieldRef,
 }: {
   id?: string;
   ariaLabel?: string;
@@ -622,6 +649,8 @@ function FreeformCombobox({
   placeholder?: string;
   /** Narrow the suggestion list to entries matching the typed text. */
   filterOptions?: boolean;
+  /** The controller's ref, so the error summary can focus this field. */
+  fieldRef?: (instance: HTMLInputElement | null) => void;
 }) {
   const mode = useRef<"navigation" | "typing">("navigation");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -664,7 +693,10 @@ function FreeformCombobox({
           )}
           id={id}
           aria-label={ariaLabel}
-          ref={inputRef}
+          ref={(el) => {
+            inputRef.current = el;
+            fieldRef?.(el);
+          }}
           placeholder={placeholder}
           onChange={(e) => {
             onChange(e.target.value);

--- a/app/admin/locations-manager.tsx
+++ b/app/admin/locations-manager.tsx
@@ -26,6 +26,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { locationSchema, updateLocationSchema } from "@/model/location";
 import { z } from "zod";
 import { setActionErrors } from "@/utils/forms";
+import { FormErrorSummary } from "@/app/components/form-error-summary";
 
 export type AdminLocation = {
   location: Location;
@@ -307,6 +308,8 @@ function LocationForm({
         </span>
       </div>
 
+      <FormErrorSummary form={form} />
+
       <div className="flex gap-2 items-baseline">
         <button
           type="submit"
@@ -323,11 +326,6 @@ function LocationForm({
         >
           Cancel
         </button>
-        {form.formState.errors.root && (
-          <p role="alert" className="text-sm text-red-600">
-            {form.formState.errors.root.message}
-          </p>
-        )}
       </div>
     </form>
   );

--- a/app/components/form-error-summary.tsx
+++ b/app/components/form-error-summary.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  UseFormReturn,
+  useFormState,
+} from "react-hook-form";
+
+type ErrorEntry = { name: string; message: string };
+
+const NON_FIELD_KEYS = new Set(["ref", "types"]);
+
+/**
+ * Flattens react-hook-form's nested error object into one entry per message,
+ * keyed by the field path (`contacts.0.label`) so it can be focused later.
+ */
+function errorEntries(errors: FieldErrors, path: string[] = []): ErrorEntry[] {
+  if (!errors || typeof errors !== "object") return [];
+  const message = (errors as { message?: unknown }).message;
+  if (typeof message === "string") {
+    return message ? [{ name: path.join("."), message }] : [];
+  }
+  return Object.entries(errors).flatMap(([key, value]) =>
+    NON_FIELD_KEYS.has(key)
+      ? []
+      : errorEntries(value as FieldErrors, [...path, key])
+  );
+}
+
+/** Errors on the form or a whole list, which no single input can be sent to. */
+function isFormLevel(name: string) {
+  return name === "root" || name.endsWith(".root");
+}
+
+/** "to fix" only where the person can act: a failed save isn't their doing. */
+function heading(entries: ErrorEntry[]) {
+  const count =
+    entries.length === 1 ? "is a problem" : `are ${entries.length} problems`;
+  return entries.some((e) => !isFormLevel(e.name))
+    ? `There ${count} to fix:`
+    : `There ${count}:`;
+}
+
+/**
+ * Every outstanding error, repeated next to the submit button. Long forms
+ * scroll the offending field out of sight — and disclosures can hide it
+ * altogether — so without this the only sign that submitting failed is that
+ * the page didn't move.
+ */
+export function FormErrorSummary<
+  TFieldValues extends FieldValues,
+  TContext,
+  TTransformedValues,
+>({
+  form,
+  onJump,
+}: {
+  form: UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+  /** Called before focusing, to reveal a field that is currently collapsed. */
+  onJump?: (name: string) => void;
+}) {
+  const { errors } = useFormState({ control: form.control });
+  const entries = errorEntries(errors);
+  if (entries.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md"
+    >
+      <p className="text-sm font-medium">{heading(entries)}</p>
+      <ul className="mt-1 ps-5 list-disc space-y-1 text-sm">
+        {entries.map(({ name, message }) => (
+          <li key={name}>
+            {isFormLevel(name) ? (
+              message
+            ) : (
+              <button
+                type="button"
+                className="text-start underline hover:text-red-900"
+                // Focusing scrolls the field into view; fields react-hook-form
+                // holds no ref for (custom inputs) simply don't move.
+                // setFocus defers by a tick, so onJump's re-render lands first.
+                onClick={() => {
+                  onJump?.(name);
+                  form.setFocus(name as FieldPath<TFieldValues>);
+                }}
+              >
+                {message}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -1563,20 +1563,24 @@ test.describe("Admin UI locations", () => {
     await region.getByRole("button", { name: "New location" }).click();
     await region.getByLabel("Capacity").fill("");
     await region.getByRole("button", { name: "Add location" }).click();
-    await expect(region.getByText("Name is required")).toBeVisible();
-    await expect(
-      region.getByText("Capacity must be a non-negative whole number")
-    ).toBeVisible();
+    // Each message shows twice: inline at its field, and in the summary by
+    // the submit button.
+    await expect(region.getByText("Name is required").first()).toBeVisible();
+    const problems = region.getByRole("alert");
+    await expect(problems).toContainText("Name is required");
+    await expect(problems).toContainText(
+      "Capacity must be a non-negative whole number"
+    );
 
     // A fractional capacity must produce the same message rather than the
     // browser's own step-mismatch bubble.
     await region.getByLabel("Name", { exact: true }).fill("Half a room");
     await region.getByLabel("Capacity").fill("1.5");
     await region.getByRole("button", { name: "Add location" }).click();
-    await expect(region.getByText("Name is required")).toBeHidden();
-    await expect(
-      region.getByText("Capacity must be a non-negative whole number")
-    ).toBeVisible();
+    await expect(region.getByText("Name is required")).toHaveCount(0);
+    await expect(problems).toContainText(
+      "Capacity must be a non-negative whole number"
+    );
 
     await region.getByRole("button", { name: "Cancel" }).click();
   });
@@ -1671,8 +1675,9 @@ test.describe("Admin UI locations", () => {
       buffer: await makeImage(800, 800),
     });
     await region.getByRole("button", { name: "Add location" }).click();
+    // Reported inline and repeated in the summary by the submit button.
     await expect(
-      page.getByText("Image must have a 4:3 aspect ratio (got 800×800)")
+      page.getByText("Image must have a 4:3 aspect ratio (got 800×800)").first()
     ).toBeVisible();
 
     // A valid 4:3 image is accepted and shown in the list

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -12,6 +12,26 @@ async function selectCurrentUser(page: import("@playwright/test").Page) {
   await page.getByRole("option", { name: /Alice Test/i }).click();
 }
 
+/**
+ * Opens one of the optional profile sections, which sit behind expandable
+ * disclosures. Already-filled sections start open — on a retry the profile
+ * saved by the previous attempt is what loads — so only closed summaries are
+ * clicked. Retried as a whole: a toggle that lands before hydration is undone
+ * by React, since the disclosure's open state is controlled.
+ */
+async function ensureSectionOpen(
+  page: import("@playwright/test").Page,
+  title: string,
+  probe: import("@playwright/test").Locator
+) {
+  await expect(async () => {
+    if (!(await probe.isVisible())) {
+      await page.getByText(title, { exact: true }).click();
+    }
+    await expect(probe).toBeVisible({ timeout: 1000 });
+  }).toPass();
+}
+
 async function makeImage(width: number, height: number): Promise<Buffer> {
   return sharp({
     create: { width, height, channels: 3, background: { r: 90, g: 60, b: 30 } },
@@ -177,31 +197,23 @@ test.describe("Edit profile", () => {
 
     await page.getByLabel("Based in").fill("Berlin");
 
-    // The optional sections sit behind expandable disclosures. A retry of
-    // this test runs against the profile saved by the previous attempt:
-    // filled sections then start open and contain the saved rows, so only
-    // click closed summaries and clear leftover rows before adding new ones.
-    const ensureSectionOpen = async (
-      title: string,
-      probe: import("@playwright/test").Locator
-    ) => {
-      if (!(await probe.isVisible())) {
-        await page.getByText(title, { exact: true }).click();
-      }
-      await expect(probe).toBeVisible();
-    };
     await ensureSectionOpen(
+      page,
       "Conversation starters",
       page.getByLabel("Ask me about")
     );
     await ensureSectionOpen(
+      page,
       "Languages",
       page.getByRole("button", { name: "Add language" })
     );
     await ensureSectionOpen(
+      page,
       "Contact details",
       page.getByRole("button", { name: "Add contact" })
     );
+    // A retry of this test runs against the profile saved by the previous
+    // attempt, so clear the rows it left behind before adding new ones.
     const leftoverRows = page.getByRole("button", { name: "Remove" });
     while ((await leftoverRows.count()) > 0) {
       await leftoverRows.first().click();
@@ -326,6 +338,76 @@ test.describe("Edit profile", () => {
       page.locator("strong", { hasText: "hello world" })
     ).toBeVisible();
   });
+});
+
+test("summarizes validation errors next to the Save button", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Alpha/proposals");
+
+  await selectCurrentUser(page);
+  await page.getByRole("link", { name: "Attendees", exact: true }).click();
+  await page.getByRole("link", { name: /Edit profile/i }).click();
+
+  // Languages sits in a disclosure far above the Save button, so a bad value
+  // there is the case where an inline message alone tells the attendee
+  // nothing about why saving did nothing.
+  const addLanguage = page.getByRole("button", { name: "Add language" });
+  await ensureSectionOpen(page, "Languages", addLanguage);
+  await addLanguage.click();
+  const language = page.getByRole("combobox", { name: "Language" }).last();
+  await language.fill("x".repeat(60));
+  await page.keyboard.press("Escape");
+  // Collapsed, the inline message would be hidden entirely.
+  await page.getByText("Languages", { exact: true }).click();
+  await expect(addLanguage).toBeHidden();
+
+  await page.getByRole("button", { name: /^Save$/ }).click();
+
+  // Next.js' route announcer is an alert too, hence the filter.
+  const summary = page.getByRole("alert").filter({ hasText: /problem/ });
+  await expect(summary).toContainText(
+    "Keep language names under 50 characters"
+  );
+  await expect(summary).toBeInViewport();
+  await expect(page).toHaveURL(/\/guests\/edit$/);
+
+  // Nothing shifted under the attendee: the section is still collapsed until
+  // the summary entry is used, which reopens it and focuses the field.
+  await expect(addLanguage).toBeHidden();
+  await summary.getByRole("button", { name: /Keep language names/ }).click();
+  await expect(addLanguage).toBeVisible();
+  await expect(language).toBeFocused();
+});
+
+test("sends a rejected picture back to the picker that chose it", async ({
+  page,
+}) => {
+  await login(page);
+  await page.goto("/Conference-Alpha/proposals");
+
+  await selectCurrentUser(page);
+  await page.getByRole("link", { name: "Attendees", exact: true }).click();
+  await page.getByRole("link", { name: /Edit profile/i }).click();
+
+  // hidden inputs aren't interactable through `getByLabel` in playwright
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "tiny.png",
+    mimeType: "image/png",
+    buffer: await makeImage(100, 100),
+  });
+  await page.getByRole("button", { name: /^Save$/ }).click();
+
+  const summary = page.getByRole("alert").filter({ hasText: /problem/ });
+  await expect(summary).toContainText("Image is too small");
+
+  // The file input behind the picture is hidden, so nothing can be focused
+  // there: the jump has to land on the visible picker instead.
+  await summary.getByRole("button", { name: /Image is too small/ }).click();
+  await expect(
+    page.getByRole("button", { name: /Change profile picture/ })
+  ).toBeFocused();
 });
 
 test("shows an error on the edit page when no user is selected", async ({


### PR DESCRIPTION
On a long form the only sign that saving failed was the page not moving:
the message sat somewhere further up, or inside a collapsed section where
it could not be seen at all. Every outstanding error is now repeated by
the button, each entry jumping to — and revealing — the field it belongs to.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=f52ea7fc098da33cf6dbf3a34aff742c980fb380 -->