### PR TITLE
fix: show phase start times in the reader's own time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Saving a form that has errors now says why, right where you clicked**: on longer forms — editing your profile, proposing a session, adding or editing a location — a summary of everything that needs fixing appears next to the Save button, instead of the page simply not moving because the message sits somewhere further up. Each entry is clickable and takes you to the field it belongs to, opening the "Languages", "Contact details" or "Conversation starters" section first if the field is hidden inside it
 
+### Fixed
+
+- **"Voting will be enabled at …" now shows the time on your own clock**: on the proposals list and a proposal's page, the note saying when voting or scheduling opens was given in the time zone of the machine running the site, so a site hosted abroad announced the wrong time. It now shows the time in your own time zone — useful when you are reading it weeks before travelling to the venue — and names that zone whenever it differs from the event's, the same way comment timestamps do
+
 ## [3.2.0] - 2026-07-29
 
 ### Added

--- a/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
@@ -16,6 +16,7 @@ import {
   inProposalPhase,
 } from "@/app/(site)/utils/events";
 import { EventContext, UserContext } from "@/app/(site)/context";
+import { useLocalZone } from "@/utils/hooks";
 import type { Event } from "@/db/repositories/interfaces";
 
 export function ProposalActionBar({
@@ -27,19 +28,20 @@ export function ProposalActionBar({
 }) {
   const { user: currentUserId } = useContext(UserContext);
   const { now } = useContext(EventContext);
+  const localZone = useLocalZone();
   const votingEnabled = !!currentUserId && inVotingPhase(event, now);
 
   let votingDisabledText = "";
   if (inSchedPhase(event, now)) {
     votingDisabledText = `The voting phase is over`;
   } else if (inProposalPhase(event, now)) {
-    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart)}`;
+    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart, event.timezone, localZone)}`;
   } else if (!currentUserId) {
     votingDisabledText = "Select a user first";
   }
 
   const schedEnabled = inSchedPhase(event, now);
-  const schedDisabledText = `Scheduling ${dateStartDescription(event.schedulingPhaseStart)}`;
+  const schedDisabledText = `Scheduling ${dateStartDescription(event.schedulingPhaseStart, event.timezone, localZone)}`;
 
   return (
     <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center mb-6">

--- a/app/(site)/[eventSlug]/proposals/proposal-comments.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-comments.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -20,6 +14,7 @@ import {
   deleteComment,
   updateComment,
 } from "../comment-actions";
+import { useLocalZone } from "@/utils/hooks";
 import { formatInLocalZone } from "@/utils/utils";
 
 type CommentNode = Comment & { replies: CommentNode[] };
@@ -39,19 +34,6 @@ function buildTree(comments: Comment[]): CommentNode[] {
     }
   }
   return roots;
-}
-
-// The server can't know the viewer's zone, so the first paint uses the event's
-// and swaps to local after mount — rendering local time directly would not
-// survive hydration.
-const subscribeToNothing = () => () => {};
-
-function useLocalZone(): string | null {
-  return useSyncExternalStore(
-    subscribeToNothing,
-    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
-    () => null
-  );
 }
 
 // The highlight has to be rendered rather than poked onto the node with

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -23,6 +23,7 @@ import {
   inProposalPhase,
 } from "@/app/(site)/utils/events";
 import type { Event } from "@/db/repositories/interfaces";
+import { useLocalZone } from "@/utils/hooks";
 import { formatDuration, durationMinusBreak } from "@/utils/utils";
 
 import { VotingButtons } from "./voting-buttons";
@@ -71,6 +72,7 @@ export function ProposalTable({
   );
   const { user: currentUserId } = useContext(UserContext);
   const { votes, proposalVoteEmoji } = useContext(VotesContext);
+  const localZone = useLocalZone();
   const router = useRouter();
   // Derived: filter only applies when a user is selected. Hidden from data
   // and UI when logged out, without discarding the selection.
@@ -99,12 +101,13 @@ export function ProposalTable({
   if (inSchedPhase(event, now)) {
     votingDisabledText = `The voting phase is over`;
   } else if (inProposalPhase(event, now)) {
-    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart)}`;
+    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart, event.timezone, localZone)}`;
   } else if (!currentUserId) {
     votingDisabledText = "Select a user first";
   }
   const schedDisabledText =
-    "Scheduling " + dateStartDescription(event.schedulingPhaseStart);
+    "Scheduling " +
+    dateStartDescription(event.schedulingPhaseStart, event.timezone, localZone);
 
   function updateResultFilter(newFilter: Filter) {
     setPage(1);

--- a/app/(site)/[eventSlug]/proposals/view-proposal.tsx
+++ b/app/(site)/[eventSlug]/proposals/view-proposal.tsx
@@ -23,6 +23,7 @@ import { ProposalComments } from "./proposal-comments";
 import { VotingButtons } from "@/app/(site)/[eventSlug]/proposals/voting-buttons";
 import { VoteChoice } from "@/app/(site)/votes";
 import { DateTime } from "luxon";
+import { useLocalZone } from "@/utils/hooks";
 import { TIME_FORMAT } from "@/utils/utils";
 import { viewSessionLinkFromElsewhere } from "../modal-nav";
 
@@ -45,6 +46,7 @@ export function ViewProposal(props: {
   const { user: currentUserId } = useContext(UserContext);
   const { proposalVoteEmoji, votes } = useContext(VotesContext);
   const { now } = useContext(EventContext);
+  const localZone = useLocalZone();
   const router = useRouter();
 
   const canEdit = () => {
@@ -69,11 +71,11 @@ export function ViewProposal(props: {
   const schedEnabled = inSchedPhase(event, now);
   let votingDisabledText = "";
   if (!inVotingPhase(event, now)) {
-    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart)}`;
+    votingDisabledText = `Voting ${dateStartDescription(event.votingPhaseStart, event.timezone, localZone)}`;
   } else if (!currentUserId) {
     votingDisabledText = "Select a user first";
   }
-  const schedDisabledText = `Scheduling ${dateStartDescription(event.schedulingPhaseStart)}`;
+  const schedDisabledText = `Scheduling ${dateStartDescription(event.schedulingPhaseStart, event.timezone, localZone)}`;
 
   const sessions = (proposal.sessionIds || [])
     .map((sesId) => allSessions.find((s) => s.id === sesId))

--- a/app/(site)/utils/events.ts
+++ b/app/(site)/utils/events.ts
@@ -1,4 +1,5 @@
 import type { Event } from "@/db/repositories/interfaces";
+import { formatInLocalZone } from "@/utils/utils";
 
 /**
  * Represents the different phases an event can be in
@@ -117,17 +118,23 @@ export function hasPhases(event: Event): boolean {
   return !!(proposalPhaseStart || votingPhaseStart || schedulingPhaseStart);
 }
 
-export function dateStartDescription(date?: Date): string {
-  if (date) {
-    const dateText = date.toLocaleString("en-GB", {
-      month: "numeric",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    return "will be enabled on " + dateText;
-  } else {
+/**
+ * Describes when a phase opens, in the reader's own timezone: attendees often
+ * read this weeks before travelling to the venue, so what they need is when
+ * voting or scheduling opens on *their* clock, not the venue's.
+ *
+ * Both zones are parameters rather than read ambiently — formatting in the
+ * process's own zone made a UTC container disagree with the visitor's browser
+ * about the same instant (#734). Pass `localZone` from `useLocalZone`, which
+ * is null until mount.
+ */
+export function dateStartDescription(
+  date: Date | undefined,
+  eventZone: string,
+  localZone: string | null
+): string {
+  if (!date) {
     return "is not enabled";
   }
+  return `will be enabled at ${formatInLocalZone(date, eventZone, localZone)}`;
 }

--- a/tests/unit/event-phases.test.ts
+++ b/tests/unit/event-phases.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { EventPhase, getCurrentPhase } from "@/app/(site)/utils/events";
+import {
+  EventPhase,
+  dateStartDescription,
+  getCurrentPhase,
+} from "@/app/(site)/utils/events";
 import type { Event } from "@/db/repositories/interfaces";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -128,5 +132,31 @@ describe("getCurrentPhase with implicit phase ends", () => {
 
       expect(getCurrentPhase(event, NOW())).toBe(EventPhase.VOTING);
     });
+  });
+});
+
+// Only what this wrapper adds to formatInLocalZone, which
+// tests/unit/comment-time.test.ts covers on its own: that both zones reach it
+// and neither is taken from whatever zone the process runs in (#734).
+describe("dateStartDescription", () => {
+  // 01:30 on 27 June in Berlin, 19:30 on 26 June in New York.
+  const instant = new Date("2026-06-26T23:30:00.000Z");
+
+  it("uses the event's zone before the viewer's is known", () => {
+    expect(dateStartDescription(instant, "Europe/Berlin", null)).toBe(
+      "will be enabled at 01:30 - 27 Jun"
+    );
+  });
+
+  it("shows the viewer's own time and names the zone when it differs", () => {
+    expect(
+      dateStartDescription(instant, "Europe/Berlin", "America/New_York")
+    ).toMatch(/^will be enabled at 19:30 - 26 Jun \S/);
+  });
+
+  it("still reports an unset date as not enabled", () => {
+    expect(dateStartDescription(undefined, "Europe/Berlin", null)).toBe(
+      "is not enabled"
+    );
   });
 });

--- a/utils/hooks.ts
+++ b/utils/hooks.ts
@@ -1,7 +1,28 @@
-import { useEffect, useLayoutEffect, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 export const useSafeLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+const subscribeToNothing = () => () => {};
+
+/**
+ * The viewer's IANA timezone, or null on the server and during the first
+ * hydration pass — the server can't know it, so rendering it directly would
+ * not survive hydration. Pass it to `formatInLocalZone`, which falls back to
+ * the event's zone until the swap happens.
+ */
+export function useLocalZone(): string | null {
+  return useSyncExternalStore(
+    subscribeToNothing,
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+    () => null
+  );
+}
 
 export const useScreenWidth = () => {
   const [screenWidth, setScreenWidth] = useState(0);


### PR DESCRIPTION
The "Voting will be enabled on …" banner formatted in whatever zone the
process happened to run in. A UTC container and a visitor elsewhere therefore
rendered different text for the same instant — React reports that as a
hydration error — and a self-hosted instance announced phase times in the
server's zone rather than in anyone's local one.

Phase starts now go through formatInLocalZone, the helper the comment
timestamps already use: the event's zone for the server-rendered first paint,
swapped to the reader's once mounted, naming that zone only when the two
differ. Unlike the venue's schedule, "when does voting open" is a question
about the reader's own clock — they are often still weeks from travelling — so
the reader's zone is the useful one.

useLocalZone moves out of proposal-comments.tsx into utils/hooks.ts now that
four components need it.

Invisible to `make test-e2e`, where the server and the browser share the
developer's zone; surfaced by running the suite against the Docker image.

issue #734

<!-- jip:pushed-commit=2d8609028f7148ee443a9a27286544fa3d36b934 -->