### PR TITLE
test: run the E2E suite against the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ tests
 .github
 coverage
 site
+.e2e-docker

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ data.*.db-journal
 /uploads
 /uploads-test
 
+# Database and uploads bind-mounted into the container by
+# `make test-e2e-docker` (see CONTRIBUTING.md § Testing the Docker image)
+/.e2e-docker
+
 # Nix
 flake.nix
 flake.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ jj squash --from <commit> --to @ -m "message" -- <path>
 ### Test tiers (short form)
 
 - **E2E** (Playwright): important user workflows only — quality over quantity
+- **E2E against the Docker image** (`make test-e2e-docker`): the same suite against a container. Not part of `make precommit` — run it before a release and after touching the `Dockerfile`, the standalone build, or anything path-, upload- or migration-related. The container runs in UTC, so it catches dates formatted in the ambient time zone; format in the event's zone
 - **Integration** (Vitest, real DB): high coverage of business logic via repositories/server actions
 - **Unit** (Vitest): only for complex isolated functions; never duplicate integration-test coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **"Voting will be enabled at …" now shows the time on your own clock**: on the proposals list and a proposal's page, the note saying when voting or scheduling opens was given in the time zone of the machine running the site, so a site hosted abroad announced the wrong time. It now shows the time in your own time zone — useful when you are reading it weeks before travelling to the venue — and names that zone whenever it differs from the event's, the same way comment timestamps do
 
+### Internal
+
+- `make test-e2e-docker` runs the E2E suite against a container built from the working tree, instead of the `next start` server the other E2E runs use — the only tier that exercises the image we actually publish, including its standalone build, its `/data` volume and its UTC clock. It is a step in the release checklist, between tagging and pushing the tag, and it is what found the time zone bug fixed above. See [CONTRIBUTING.md § Testing the Docker image](CONTRIBUTING.md#testing-the-docker-image)
+
 ## [3.2.0] - 2026-07-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,6 +331,7 @@ Every code change must follow red → green → refactor. **Do not skip or reord
 make test                # Run unit and integration tests (Vitest)
 make test-e2e            # Run E2E tests (headless)
 make test-e2e-headed     # Run E2E tests (headed, for local dev)
+make test-e2e-docker     # Run E2E tests against the production Docker image
 ```
 
 **Warning**: E2E tests reset the test database before each run. Do not run against production data.
@@ -379,6 +380,68 @@ Run against a different environment (e.g. dev database — still resets it):
 ```bash
 bun set-env.ts dev bun x playwright test
 ```
+
+### Testing the Docker image
+
+`make test-e2e` runs the suite against `next build && next start`, which is not
+what we ship. The image runs the standalone build as `node server.js`, as a
+different user, with the database, migrations and uploads on a mounted `/data`
+volume. `make test-e2e-docker` runs the same suite against a container built
+from the working tree, which is the only tier that covers that gap:
+
+```bash
+make test-e2e-docker                     # build the image, then run the suite against it
+IMAGE=schellingboard/schellingboard:v3.1.0 \
+  bun set-env.ts test bash scripts/e2e-docker.sh    # test an existing image instead of building
+
+# A subset, same arguments as `playwright test`:
+bun set-env.ts test bash scripts/e2e-docker.sh tests/e2e/proposals.spec.ts
+```
+
+It is not part of `make precommit` — it builds an image and takes a few
+minutes. Run it before a release (see
+[Releasing a New Version](#releasing-a-new-version)) and after changing the
+`Dockerfile`, the standalone build, or anything touching paths, uploads or
+migrations.
+
+What it does, and why each piece is there:
+
+- **Picks a free port** and starts the container on it, then waits for
+  `/api/health`.
+- **Builds `schellingboard/schellingboard:<version>`**, so a throwaway test
+  build never takes the place of the published
+  `schellingboard/schellingboard:latest` in `docker images`. The version is the
+  one `scripts/app-version.js` prints, which is also what `make docker-build`
+  passes as `APP_VERSION` and what the footer shows.
+- **Bind-mounts `.e2e-docker/`** (gitignored) as `/data`. Seeding runs on the
+  host, as usual, and writes to the same SQLite file and uploads directory the
+  container reads — so no seeding code has to exist inside the image. The
+  directory is deleted at the start of every run, since a stale database hides
+  exactly the failures this run looks for. Seeding migrates the database first,
+  so what the container's own migration run covers is that `drizzle/` shipped
+  and loads, not applying migrations to an empty database.
+- **Runs the container as your own uid** (`--user`), so the files it writes
+  into the bind mount don't end up owned by the image's uid 1001 and
+  unremovable. As a consequence `/app` isn't writable, so Next's image
+  optimizer gets a tmpfs for its cache — otherwise every optimized image logs
+  an `EACCES`.
+- **Starts mailpit if it isn't already running**, because once the mail
+  variables are set the email specs fail rather than skip. One it started
+  itself is stopped again afterwards, unless the run failed — then it is left
+  up, since its web UI is where a failing email test is diagnosed.
+- **Points `SITE_URL` and the SMTP host at the container's view of the host**
+  (`host.docker.internal`), so emails link back to the right port and reach
+  mailpit.
+
+Playwright starts no server of its own here: the script sets
+`E2E_EXTERNAL_SERVER=1` and `E2E_PORT`, and `playwright.config.ts` omits its
+`webServer` when it sees them.
+
+**The container runs in UTC.** That is what makes this tier worth having: with
+`next start`, the server and the browser share your machine's timezone, so a
+component that formats a date in the ambient zone renders identically on both
+sides and its hydration mismatch stays invisible. In the image it does not.
+Dates must be formatted in an explicit zone — the event's — never the process's.
 
 ### E2E conventions
 
@@ -552,7 +615,7 @@ what docmd produced.
 ## Releasing a New Version
 
 1. **Finalize the changelog** — in `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (no `v` prefix in the header) and add a fresh empty `## [Unreleased]` section above it. Update the compare links at the bottom of the file: the new version's link should point from the previous release's endpoint to the new tag (`vX.Y.Z`), and `[Unreleased]` should point from the new tag to `HEAD`. Commit and merge this like any other change.
-2. **Tag the resulting commit on `main`**. jj cannot push tags to a Git remote, so use `git` for this step:
+2. **Tag the resulting commit on `main`, locally for now**. jj cannot push tags to a Git remote, so use `git` for this step:
 
    ```bash
    VERSION=v3.0.0
@@ -561,12 +624,34 @@ what docmd produced.
 
    git fetch origin main
    git tag $VERSION origin/main
+   ```
+
+3. **Sanity-check the image that will be published** — build it from the tag and
+   run the E2E suite against a container. This is the last chance to catch a
+   fault that exists only in the packaged image (a file the standalone build
+   didn't copy, a path that resolves differently under `/data`, a date rendered
+   in the server's timezone rather than the event's) — no other test tier runs
+   the artifact we actually ship. See
+   [Testing the Docker image](#testing-the-docker-image).
+
+   ```bash
+   git checkout $VERSION
+   make test-e2e-docker
+   ```
+
+   The tag is still local at this point, so a failure costs nothing: fix it on
+   `main`, delete the tag (`git tag -d $VERSION`), and start again from step 1.
+
+4. **Push the tag**, which is the point of no return — it publishes the
+   documentation:
+
+   ```bash
    git push origin $VERSION
    ```
 
-3. **Publish the Docker images** — see below.
+5. **Publish the Docker images** — see below.
 
-Pushing the tag also publishes the documentation: the docs site rebuilds and
+Pushing the tag publishes the documentation: the docs site rebuilds and
 serves `docs/public/` as of that tag at its root. Docs are versioned per minor
 release, so `v3.2.1` republishes the `3.2` documentation.
 
@@ -580,7 +665,7 @@ For a release, push four tags: the full version, `major.minor`, `major`, and `la
 docker login
 git checkout $VERSION
 make clean
-make docker-build   # builds and locally tags :latest and :$VERSION (via git describe)
+make docker-build   # builds and locally tags :$VERSION
 docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MINOR
 docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MAJOR
 
@@ -590,7 +675,7 @@ docker push schellingboard/schellingboard:$MAJOR
 docker push schellingboard/schellingboard:latest   # omit if not the newest release
 ```
 
-`make docker-build` derives `$VERSION` from `git describe --tags`, so the release commit must already be tagged with the exact version (e.g. `v3.0.0`) before running it.
+`make docker-build` derives `$VERSION` with `scripts/app-version.js` (the nearest tag, via `jj` or `git`), so the release commit must already be tagged with the exact version (e.g. `v3.0.0`) before running it.
 
 ## Version Control
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# Pass via --build-arg APP_VERSION=$(git describe --tags --always --dirty)
+# Pass via --build-arg APP_VERSION=$(bun scripts/app-version.js)
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 ENV BUILD_STANDALONE=1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev mailpit build start lint typecheck lint-watch test test-unit test-integration test-watch test-coverage test-e2e test-e2e-headed format format-check precommit dev-migrate-up dev-migrate-status dev-migrate-create dev-db-seed install install-playwright clean clean-all docker-build check-and-format dev-db-reset test-e2e-ci docs docs-build docs-validate www
+.PHONY: help dev mailpit build start lint typecheck lint-watch test test-unit test-integration test-watch test-coverage test-e2e test-e2e-headed test-e2e-docker format format-check precommit dev-migrate-up dev-migrate-status dev-migrate-create dev-db-seed install install-playwright clean clean-all docker-build check-and-format dev-db-reset test-e2e-ci docs docs-build docs-validate www
 
 SHELL := /usr/bin/env bash
 
@@ -17,6 +17,7 @@ help:
 	@printf "  %-28s %s\n" "make test-integration"   "Run integration tests only"
 	@printf "  %-28s %s\n" "make test-e2e"           "Run E2E tests (headless)"
 	@printf "  %-28s %s\n" "make test-e2e-headed"    "Run E2E tests (headed, for local dev)"
+	@printf "  %-28s %s\n" "make test-e2e-docker"    "Run E2E tests against the Docker image"
 	@printf "  %-28s %s\n" "make test-watch"         "Run tests in watch mode"
 	@printf "  %-28s %s\n" "make test-coverage"      "Run tests with coverage"
 	@printf "\nLinting & Formatting:\n"
@@ -40,7 +41,7 @@ help:
 	@printf "  %-28s %s\n" "make install"            "Install dependencies"
 	@printf "  %-28s %s\n" "make install-playwright" "Install Playwright browsers"
 	@printf "\nDocker:\n"
-	@printf "  %-28s %s\n" "make docker-build"       "Build Docker image (tags with git describe output)"
+	@printf "  %-28s %s\n" "make docker-build"       "Build Docker image (tagged with the working tree's version)"
 	@printf "\nCleanup:\n"
 	@printf "  %-28s %s\n" "make clean"              "Remove dev and build artifacts as well as test output"
 	@printf "  %-28s %s\n" "make clean-all"          "Clean + remove node_modules"
@@ -99,6 +100,13 @@ test-e2e: install-playwright
 test-e2e-headed: install-playwright
 	bun set-env.ts test bun x playwright test --headed
 
+# Runs the suite against the production image instead of `next start` — the
+# release sanity check. Builds the image first unless IMAGE names one.
+# Through set-env.ts so the script inherits the test credentials it has to
+# hand to the container.
+test-e2e-docker: install-playwright
+	bun set-env.ts test bash scripts/e2e-docker.sh
+
 format: install
 	bun x prettier --write .
 
@@ -111,7 +119,7 @@ clean:
 	rm -rf .next
 	rm -f next-env.d.ts
 	rm -f data.db data.test.db
-	rm -rf playwright-report test-results
+	rm -rf playwright-report test-results .e2e-docker
 	rm -f tsconfig.tsbuildinfo
 	rm -rf site
 
@@ -164,7 +172,7 @@ www:
 	bash scripts/build-www.sh
 
 docker-build:
-	$(eval APP_VERSION := $(shell git describe --tags --always --dirty))
+	$(eval APP_VERSION := $(shell bun scripts/app-version.js))
 	APP_VERSION=$(APP_VERSION) docker compose build
 	docker tag schellingboard/schellingboard:latest schellingboard/schellingboard:$(APP_VERSION)
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,48 +1,4 @@
-import { execFileSync } from "child_process";
-
-/**
- * @param {string} file
- * @param {readonly string[]} args
- */
-function runQuiet(file, args) {
-  try {
-    return execFileSync(file, args, {
-      encoding: "utf-8",
-      cwd: process.cwd(),
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function getAppVersion() {
-  // Prefer jj: some workspaces (e.g. `jj workspace add`) have no `.git` dir,
-  // where git commands always fail. Fall back to git for devs without jj.
-  //
-  // Describe the parent, not `@`: `@` is usually an empty working-copy commit,
-  // so its own hash names nothing recognisable. A tag on the parent wins over
-  // its hash, so `jj new v3.1.0` reports "v3.1.0" — matching what `git
-  // describe --tags` gives below. `-dirty` marks actual local changes.
-  const jjVersion = runQuiet("jj", [
-    "log",
-    "-r",
-    "@",
-    "--no-graph",
-    "-T",
-    'parents.map(|p| if(p.tags(), p.tags().map(|t| t.name()).join("+"), ' +
-      'p.commit_id().short(8))).join("+") ++ if(!empty, "-dirty")',
-  ]);
-  if (jjVersion) return jjVersion;
-
-  const gitVersion = runQuiet("git", [
-    "describe",
-    "--tags",
-    "--always",
-    "--dirty",
-  ]);
-  return gitVersion ?? "unknown";
-}
+import { getAppVersion } from "./scripts/app-version.js";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,6 +47,16 @@ function findFreePort(): number {
   return port;
 }
 
+// `make test-e2e-docker` starts the production image itself and points this run
+// at it (see scripts/e2e-docker.sh), so no server may be started here — not even
+// on CI, where reuseExistingServer is off.
+const externalServer = process.env.E2E_EXTERNAL_SERVER === "1";
+if (externalServer && !process.env.E2E_PORT) {
+  throw new Error(
+    "E2E_EXTERNAL_SERVER=1 requires E2E_PORT — the port the running server listens on"
+  );
+}
+
 // This config module is re-evaluated in every Playwright worker process, so the
 // chosen port is frozen into E2E_PORT (inherited by workers) to keep baseURL and
 // the web server in agreement. E2E_PORT can also be set by hand to target an
@@ -130,12 +140,14 @@ export default defineConfig({
   /* Run a production build before starting the tests. Testing against
    * `next dev` is flaky: chunks are compiled on demand and parallel
    * workers can race, causing intermittent ChunkLoadErrors. */
-  webServer: {
-    command: `bun set-env.ts test "next build && next start -p ${port}"`,
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 180_000,
-  },
+  webServer: externalServer
+    ? undefined
+    : {
+        command: `bun set-env.ts test "next build && next start -p ${port}"`,
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+      },
 
   expect: { timeout: 10_000 },
 });

--- a/scripts/app-version.js
+++ b/scripts/app-version.js
@@ -1,0 +1,59 @@
+// The version of the working tree, e.g. `v3.2.0` or `802a340f-dirty`.
+//
+// Three consumers, one definition, because they have to agree: next.config.js
+// bakes it into the build as NEXT_PUBLIC_APP_VERSION (the footer shows it, see
+// utils/git.ts), and `make docker-build` and scripts/e2e-docker.sh both pass it
+// as the APP_VERSION build arg and use it as the image tag — so the release
+// build reuses the layers the E2E run built instead of compiling its own.
+//
+// Run directly (`bun scripts/app-version.js`) to print it.
+import { execFileSync } from "child_process";
+
+/**
+ * @param {string} file
+ * @param {readonly string[]} args
+ */
+function runQuiet(file, args) {
+  try {
+    return execFileSync(file, args, {
+      encoding: "utf-8",
+      cwd: process.cwd(),
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export function getAppVersion() {
+  // Prefer jj: some workspaces (e.g. `jj workspace add`) have no `.git` dir,
+  // where git commands always fail. Fall back to git for devs without jj.
+  //
+  // Describe the parent, not `@`: `@` is usually an empty working-copy commit,
+  // so its own hash names nothing recognisable. A tag on the parent wins over
+  // its hash, so `jj new v3.1.0` reports "v3.1.0" — matching what `git
+  // describe --tags` gives below. `-dirty` marks actual local changes.
+  const jjVersion = runQuiet("jj", [
+    "log",
+    "-r",
+    "@",
+    "--no-graph",
+    "-T",
+    'parents.map(|p| if(p.tags(), p.tags().map(|t| t.name()).join("+"), ' +
+      'p.commit_id().short(8))).join("+") ++ if(!empty, "-dirty")',
+  ]);
+  if (jjVersion) return jjVersion;
+
+  const gitVersion = runQuiet("git", [
+    "describe",
+    "--tags",
+    "--always",
+    "--dirty",
+  ]);
+  // Never empty: it is used as a Docker tag, which cannot be.
+  return gitVersion ?? "unknown";
+}
+
+if (import.meta.main) {
+  console.log(getAppVersion());
+}

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Run the E2E suite against the production Docker image.
+#
+# `make test-e2e` exercises a `next build && next start` server, which is not
+# what we ship: the image runs the standalone output as `node server.js`, with
+# migrations, uploads and the SQLite file on a mounted /data volume. Bugs that
+# only exist there (a file the standalone tracer failed to copy, a path that
+# resolves differently under a different working directory) are invisible to
+# every other test tier, which is why this is a release checklist item — see
+# CONTRIBUTING.md § Testing the Docker image.
+#
+# Run through set-env.ts (`make test-e2e-docker`) so the test credentials and
+# the optional mail variables are already in the environment; they are handed
+# to the container so the suite's logins work against it.
+#
+# Extra arguments are passed to `playwright test`, e.g.
+#
+#     bun set-env.ts test bash scripts/e2e-docker.sh tests/e2e/proposals.spec.ts
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The seed script refuses to touch an uploads directory outside the project
+# (a guard against wiping a real one), so the volume lives here rather than in
+# a temp directory. Gitignored, and left behind after a run for inspection.
+DATA_DIR="$PWD/.e2e-docker"
+# The PID keeps clones and workspaces from clashing over the container name.
+CONTAINER="schellingboard-e2e-$$"
+
+# Build from the working tree unless the caller named an image (e.g. to run the
+# suite against a release image that was already built or pulled). The build
+# gets a local name of its own: `schellingboard/schellingboard:latest` is the
+# published release image, and a throwaway test build must not take its place.
+#
+# APP_VERSION comes from the same script `make docker-build` and next.config.js
+# use, for two reasons: the version the UI displays is baked in at build time,
+# so leaving it empty tests an image nobody ships; and passing the same value
+# makes the release build a cache hit of this one, so what gets published is
+# what was tested here. It is also the tag, so a leftover image says which tree
+# it came from and successive runs don't overwrite each other.
+if [ -n "${IMAGE:-}" ]; then
+  echo "==> Using existing image $IMAGE"
+else
+  APP_VERSION="$(bun scripts/app-version.js)"
+  IMAGE="schellingboard/schellingboard:$APP_VERSION"
+  echo "==> Building $IMAGE"
+  docker build --build-arg "APP_VERSION=$APP_VERSION" -t "$IMAGE" .
+fi
+
+# Playwright's own port picking is bypassed here (E2E_EXTERNAL_SERVER), so pick
+# the port before starting the container: SITE_URL has to be baked into its
+# environment at startup, and the port is part of it.
+PORT="$(bun -e 'const s=require("net").createServer();s.listen(0,()=>{process.stdout.write(String(s.address().port));s.close();})')"
+BASE_URL="http://localhost:$PORT"
+
+# A stale database would hide exactly the failures this run is looking for
+# (a migration that never ran, an upload directory that is never created).
+rm -rf "$DATA_DIR"
+mkdir -p "$DATA_DIR"
+
+# Mail, when configured: the suite's mailpit runs on the host's localhost,
+# which inside the container means the host-gateway alias.
+to_container_host() {
+  printf '%s' "${1//localhost/host.docker.internal}" |
+    sed 's/127\.0\.0\.1/host.docker.internal/g'
+}
+
+env_args=()
+for var in SITE_PASSWORD ADMIN_PASSWORD AUTH_SECRET SB_ENABLE_DEV_TOOLS \
+  SMTP_FROM SMTP_PORT SMTP_USER SMTP_PASSWORD SMTP_SECURE; do
+  if [ -n "${!var:-}" ]; then
+    env_args+=(-e "$var=${!var}")
+  fi
+done
+for var in SMTP_URL SMTP_HOST; do
+  if [ -n "${!var:-}" ]; then
+    env_args+=(-e "$var=$(to_container_host "${!var}")")
+  fi
+done
+# Emails link back to the site, so point them at the container's host port.
+env_args+=(-e "SITE_URL=$BASE_URL")
+
+# Once the mail variables are set, the email specs fail rather than skip
+# (CONTRIBUTING.md § Running tests), so start mailpit if it isn't up — a
+# release check shouldn't fall over because a background service wasn't
+# started by hand. Ports come from .env.dev.local, the file `make mailpit`
+# feeds compose (see the note above that target).
+mailpit_compose=(docker compose)
+if [ -f .env.dev.local ]; then
+  mailpit_compose+=(--env-file .env.dev.local)
+fi
+started_mailpit=""
+mailpit_ready() { curl -fsS "$MAILPIT_API_URL/readyz" >/dev/null 2>&1; }
+
+container_started=""
+cleanup() {
+  status=$?
+  # Leave a self-started mailpit up after a failure: its web UI is where a
+  # failing email test is diagnosed.
+  if [ -n "$started_mailpit" ]; then
+    if [ "$status" -eq 0 ]; then
+      "${mailpit_compose[@]}" stop mailpit >/dev/null 2>&1 || true
+    else
+      echo "==> Leaving mailpit running for inspection ($MAILPIT_API_URL);" \
+        "stop it with: ${mailpit_compose[*]} stop mailpit" >&2
+    fi
+  fi
+  if [ -n "$container_started" ]; then
+    if [ "$status" -ne 0 ]; then
+      echo "==> Container logs (last 50 lines):" >&2
+      docker logs --tail 50 "$CONTAINER" >&2 2>&1 || true
+    fi
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+# Installed before mailpit is started, so an early exit still tidies up.
+trap cleanup EXIT
+
+if [ -n "${MAILPIT_API_URL:-}" ] && ! mailpit_ready; then
+  echo "==> Starting mailpit ($MAILPIT_API_URL is not answering)"
+  "${mailpit_compose[@]}" up -d mailpit
+  started_mailpit=1
+  for _ in $(seq 1 30); do
+    if mailpit_ready; then break; fi
+    sleep 1
+  done
+  if ! mailpit_ready; then
+    echo "mailpit did not answer at $MAILPIT_API_URL — do MAILPIT_UI_PORT" \
+      "(.env.dev.local) and MAILPIT_API_URL (.env.test.local) agree?" >&2
+    exit 1
+  fi
+fi
+
+# --user: the image's own uid (1001) would own the files it writes into the
+#   bind mount, leaving directories the host user cannot clean up afterwards.
+#   The app itself is uid-agnostic.
+# --tmpfs: consequence of the above — /app is owned by 1001, so Next's image
+#   optimizer cannot create its cache directory and every optimized image logs
+#   an unhandled EACCES. A writable tmpfs at that path keeps the run quiet.
+echo "==> Starting $CONTAINER on $BASE_URL"
+# Set before `docker run`, which leaves the container behind even when it fails
+# to start.
+container_started=1
+docker run -d \
+  --name "$CONTAINER" \
+  --user "$(id -u):$(id -g)" \
+  -p "127.0.0.1:$PORT:3000" \
+  -v "$DATA_DIR:/data" \
+  --tmpfs "/app/.next/cache:uid=$(id -u),gid=$(id -g)" \
+  --add-host host.docker.internal:host-gateway \
+  "${env_args[@]}" \
+  "$IMAGE" >/dev/null
+
+echo "==> Waiting for the container to become healthy"
+for _ in $(seq 1 120); do
+  if curl -fsS "$BASE_URL/api/health" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER")" != "true" ]; then
+    echo "Container exited before becoming healthy" >&2
+    exit 1
+  fi
+  sleep 1
+done
+if [ -z "${ready:-}" ]; then
+  echo "Container did not answer $BASE_URL/api/health within 120s" >&2
+  exit 1
+fi
+
+# Seeding (Playwright's globalSetup) writes to the same SQLite file and uploads
+# directory the container reads through the bind mount, so the suite gets its
+# usual test data without any seeding code inside the image.
+echo "==> Running E2E tests against the container"
+DATABASE_URL="file:$DATA_DIR/data.db" \
+  SB_UPLOADS_DIR="$DATA_DIR/uploads" \
+  E2E_EXTERNAL_SERVER=1 \
+  E2E_PORT="$PORT" \
+  bun x playwright test "$@"


### PR DESCRIPTION
`make test-e2e` exercises `next build && next start`, not the standalone
build we publish, so a fault living only in the packaged image — a file the
tracer didn't copy, a path that resolves differently under /data, the
container's UTC clock — could reach a release with every tier green.

Adds `make test-e2e-docker`, which builds the image, runs the suite against a
container, and slots into the release checklist between creating the tag and
pushing it, where a failure still costs nothing. Seeding stays on the host and
reaches the container through the /data bind mount, so no seeding code has to
ship in the image.

<!-- jip:pushed-commit=4c39ed9797a9e564d04a6dfd53dda2e45611b09d -->