### PR TITLE
refactor: split dev-only services out of docker-compose.yml

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -32,7 +32,3 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_SECURE=
-
-# Git commit hash baked into the footer at build time (optional)
-# Pass via: COMMIT_HASH=$(git rev-parse --short HEAD) docker compose up --build
-COMMIT_HASH=

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -57,7 +57,7 @@ jobs:
 
     services:
       # e2e tests send real email to mailpit (see CONTRIBUTING.md § Running
-      # tests). Same pinned image as docker-compose.yml.
+      # tests). Same pinned image as docker-compose.dev.yml.
       mailpit:
         image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
         ports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     services:
       # The mailer integration test sends real email to mailpit (see
       # CONTRIBUTING.md § Running tests). Same pinned image as
-      # docker-compose.yml.
+      # docker-compose.dev.yml.
       mailpit:
         image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
         ports:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ jj squash --from <commit> --to @ -m "message" -- <path>
   - `bun set-env.ts test bun x playwright test tests/e2e/proposals.spec.ts:42` (one test by line)
   - `bun set-env.ts test bun x playwright test -g "creates a proposal"` (by title substring)
 - Full test strategy and TDD rules are in [CONTRIBUTING.md § Testing](CONTRIBUTING.md#testing) — read it before writing any test
-- Before running tests for the first time in a session, check whether mailpit is running (`docker compose $(test -f .env.dev.local && echo --env-file .env.dev.local) ps mailpit` — matches the `--env-file` conditional in the `mailpit` Makefile target, since `.env.dev.local` can set a per-clone `COMPOSE_PROJECT_NAME`); if not, ask the user whether to start it (`make mailpit`)
+- Before running tests for the first time in a session, check whether mailpit is running (`docker compose -f docker-compose.dev.yml $(test -f .env.dev.local && echo --env-file .env.dev.local) ps mailpit` — mirrors the `mailpit` Makefile target, including its `--env-file` conditional, since `.env.dev.local` can set a per-clone `COMPOSE_PROJECT_NAME`); if not, ask the user whether to start it (`make mailpit`)
 
 ### Test tiers (short form)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **A simpler `docker-compose.yml` for self-hosting**: the file you copy to run SchellingBoard now describes only SchellingBoard itself. It used to also include a mail-catching tool that only developers of SchellingBoard need, and instructions for building the app from source rather than using the published image — both of which invited the question of whether you were supposed to run them. `.env.docker.example` also drops `COMMIT_HASH`, a setting that had no effect. Nothing to do if you already run it: your existing file and settings keep working
 - **Saving a form that has errors now says why, right where you clicked**: on longer forms — editing your profile, proposing a session, adding or editing a location — a summary of everything that needs fixing appears next to the Save button, instead of the page simply not moving because the message sits somewhere further up. Each entry is clickable and takes you to the field it belongs to, opening the "Languages", "Contact details" or "Conversation starters" section first if the field is hidden inside it
 
 ### Fixed
@@ -21,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Dev-only services moved to `docker-compose.dev.yml`, so `docker-compose.yml` is purely the deployment file self-hosters copy. `make mailpit` is unchanged; a bare `docker compose up mailpit` now needs `-f docker-compose.dev.yml`. `make docker-build` builds via `docker build`, since the deployment file no longer carries a build context, and tags only `:$VERSION` — `:latest` is now tagged in the release checklist next to the `major` and `major.minor` tags, so a build from an arbitrary working tree can't claim to be the newest release. That build now lives in `scripts/docker-build.sh`, which `make docker-build` and `scripts/e2e-docker.sh` both run, so the release build stays a cache hit of the image the E2E suite tested
+- `tests/unit/docker-compose-env.test.ts` guards the environment variables in `docker-compose.yml` against the Configuration reference and `.env.docker.example`. Nothing executes that file — its only user is a self-hoster — so a variable the app started needing could be documented and set in a `.env` yet never reach the container, with nothing to say why the feature was inert
 - `make test-e2e-docker` runs the E2E suite against a container built from the working tree, instead of the `next start` server the other E2E runs use — the only tier that exercises the image we actually publish, including its standalone build, its `/data` volume and its UTC clock. It is a step in the release checklist, between tagging and pushing the tag, and it is what found the time zone bug fixed above. See [CONTRIBUTING.md § Testing the Docker image](CONTRIBUTING.md#testing-the-docker-image)
 
 ## [3.2.0] - 2026-07-29

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,14 @@ openssl rand -base64 32
 
 `NEXT_PUBLIC_` variables are exposed to the browser; all others are server-side only.
 
+A new variable a self-hoster can set has to reach three files: the reference
+table above, `docker-compose.yml` (which forwards it into the container) and
+`.env.docker.example` (where they fill it in). Nothing runs `docker-compose.yml`
+— it is the one file here whose only user is a stranger — so
+`tests/unit/docker-compose-env.test.ts` compares the three and names whichever
+variable fell out of step. If a variable deliberately doesn't go through
+compose, record the reason in that test instead.
+
 ## Development Commands
 
 Run `make` to see all available commands:
@@ -128,9 +136,11 @@ first. Neither file is committed:
 | `.env.dev.local`  | `make dev`, `make mailpit`   | dev server port, mailpit's host ports, email        |
 | `.env.test.local` | `make test`, `make test-e2e` | email (opt-in, see [Running tests](#running-tests)) |
 
-Start mailpit with `make mailpit` rather than `docker compose up mailpit`: on its
-own, compose reads only a file literally named `.env`, so the make target points
-it at `.env.dev.local` instead. That keeps each clone's ports in one place.
+Start mailpit with `make mailpit` rather than a bare `docker compose up mailpit`:
+mailpit is defined in `docker-compose.dev.yml` (not in the `docker-compose.yml`
+self-hosters copy), and on its own compose reads only a file literally named
+`.env`, so the make target passes both `-f` and `--env-file .env.dev.local`. That
+keeps each clone's ports in one place.
 
 ### Example: two clones side by side
 
@@ -210,9 +220,12 @@ link back to the site; a stale value sends readers to the _other_ instance.
 `COMPOSE_PROJECT_NAME` only matters when two clones share a directory name —
 compose derives the project from the directory, so `~/a/sb` and `~/b/sb` would
 otherwise fight over a single mailpit container. Setting it is cheap insurance.
-Note that mailpit is behind a compose profile, so a bare `docker compose down`
-won't stop it; use `docker compose --profile dev down` (or just Ctrl-C the
-foreground `make mailpit`).
+Note that mailpit lives in its own compose file, so a bare `docker compose down`
+won't stop it; use the same two flags `make mailpit` passes —
+`docker compose -f docker-compose.dev.yml --env-file .env.dev.local down` —
+since without the env file compose looks for the container under the
+directory-derived project name instead. (Or just Ctrl-C the foreground
+`make mailpit`.)
 
 Some things need no attention: `DATABASE_URL` and `SB_UPLOADS_DIR` are relative
 paths, so each clone already gets its own database and uploads. E2E runs pick a
@@ -408,11 +421,11 @@ What it does, and why each piece is there:
 
 - **Picks a free port** and starts the container on it, then waits for
   `/api/health`.
-- **Builds `schellingboard/schellingboard:<version>`**, so a throwaway test
-  build never takes the place of the published
-  `schellingboard/schellingboard:latest` in `docker images`. The version is the
-  one `scripts/app-version.js` prints, which is also what `make docker-build`
-  passes as `APP_VERSION` and what the footer shows.
+- **Builds through `scripts/docker-build.sh`**, the script `make docker-build`
+  runs too — same build arguments, same `:<version>` tag, so the release build
+  is a cache hit of this one and what gets published is what was tested here.
+  The version is the one `scripts/app-version.js` prints, which is also what
+  the footer shows.
 - **Bind-mounts `.e2e-docker/`** (gitignored) as `/data`. Seeding runs on the
   host, as usual, and writes to the same SQLite file and uploads directory the
   container reads — so no seeding code has to exist inside the image. The
@@ -668,12 +681,19 @@ make clean
 make docker-build   # builds and locally tags :$VERSION
 docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MINOR
 docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:$MAJOR
+# omit if not the newest release
+docker tag schellingboard/schellingboard:$VERSION schellingboard/schellingboard:latest
 
 docker push schellingboard/schellingboard:$VERSION
 docker push schellingboard/schellingboard:$MINOR
 docker push schellingboard/schellingboard:$MAJOR
-docker push schellingboard/schellingboard:latest   # omit if not the newest release
+# omit if not the newest release
+docker push schellingboard/schellingboard:latest
 ```
+
+All four tags are set here rather than by `make docker-build`, which only ever
+tags `:$VERSION`: that target runs on any working tree, and `:latest` has to
+keep meaning the newest published release.
 
 `make docker-build` derives `$VERSION` with `scripts/app-version.js` (the nearest tag, via `jj` or `git`), so the release commit must already be tagged with the exact version (e.g. `v3.0.0`) before running it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY --from=oven/bun:1 /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-# Pass via --build-arg APP_VERSION=$(bun scripts/app-version.js)
+# Passed by scripts/docker-build.sh; empty builds show no version in the footer.
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 ENV BUILD_STANDALONE=1

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dev: dev-migrate-up install
 # (and COMPOSE_PROJECT_NAME), letting several clones run mailpit side by side.
 # The flag is conditional because compose errors out on a missing --env-file.
 mailpit:
-	docker compose $(if $(wildcard .env.dev.local),--env-file .env.dev.local,) up mailpit
+	docker compose -f docker-compose.dev.yml $(if $(wildcard .env.dev.local),--env-file .env.dev.local,) up mailpit
 
 build: install
 	bun x next build
@@ -171,10 +171,12 @@ docs-validate: install
 www:
 	bash scripts/build-www.sh
 
+# Builds the image to publish, tagged :$VERSION. The build itself lives in the
+# script because scripts/e2e-docker.sh has to run the identical one — see the
+# comment there. Not via `docker compose build`: docker-compose.yml is the
+# deployment file self-hosters copy and only names the published image.
 docker-build:
-	$(eval APP_VERSION := $(shell bun scripts/app-version.js))
-	APP_VERSION=$(APP_VERSION) docker compose build
-	docker tag schellingboard/schellingboard:latest schellingboard/schellingboard:$(APP_VERSION)
+	bash scripts/docker-build.sh
 
 # Deprecated aliases (hidden from help) — remove after a deprecation period.
 # They print a warning pointing to the new name, then run it.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,23 @@
+# Development-only services. Never part of a deployment — docker-compose.yml is
+# the file self-hosters copy, and keeping this one separate means they don't have
+# to wonder what mailpit is for.
+#
+# Start it with `make mailpit`, which points compose at `.env.dev.local`. Compose
+# reads only a file literally named `.env` on its own, and that is where each
+# clone keeps its own ports. See CONTRIBUTING.md#running-multiple-instances.
+services:
+  # Mailpit[1] receives email locally and shows it in a web UI. You need it to
+  # send email from a development app, and for the email tests.
+  #
+  # MAILPIT_SMTP_PORT/MAILPIT_UI_PORT let you run several instances of this
+  # project (separate clones or workspaces) on one machine without port clashes.
+  #
+  # [1]: https://mailpit.axllent.org/
+  mailpit:
+    # If you update this pin, update it in the CI service containers too:
+    # the `test` job in .github/workflows/ci.yml and the `test-e2e` job in
+    # .github/workflows/ci-e2e.yml.
+    image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025" # SMTP
+      - "${MAILPIT_UI_PORT:-8025}:8025" # web UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
+# Deployment file for self-hosting: copy this file and .env.docker.example into
+# the same directory, then `cp .env.docker.example .env` (compose reads only a
+# file literally named `.env`), fill it in and run `docker compose up -d`. See
+# https://docs.schellingboard.org/self-hosting/deployment/
 services:
   app:
     image: schellingboard/schellingboard
-    build:
-      context: .
-      args:
-        APP_VERSION: ${APP_VERSION:-}
     restart: unless-stopped
     ports:
       - "${HOST_PORT:-3000}:3000"
@@ -28,35 +28,6 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
-
-  # Mailpit[1] is a service that receives email locally and shows it in a web
-  # UI. You probably only need to run it if you want to send email from a
-  # development app.
-  #
-  # We give it a profile[2] so that plain `docker compose up` doesn't start it.
-  # You can do either
-  #
-  #     make mailpit                     # only starts mailpit (preferred)
-  #     docker compose --profile dev up  # starts `app` too
-  #
-  # MAILPIT_SMTP_PORT/MAILPIT_UI_PORT let you run multiple instances of this
-  # project (e.g. separate clones or workspaces) on the same machine without
-  # port clashes. Not relevant for production. `make mailpit` is preferred over
-  # `docker compose up mailpit` because it feeds compose the per-clone values
-  # from `.env.dev.local`, which compose does not read on its own. See
-  # CONTRIBUTING.md#running-multiple-instances.
-  #
-  # [1]: https://mailpit.axllent.org/
-  # [2]: https://docs.docker.com/compose/how-tos/profiles/
-  mailpit:
-    # If you update this pin, update it in .github/workflows/ci.yml too, for
-    # both `test` and `test-e2e`.
-    image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
-    profiles:
-      - dev
-    ports:
-      - "${MAILPIT_SMTP_PORT:-1025}:1025" # SMTP
-      - "${MAILPIT_UI_PORT:-8025}:8025" # web UI
 
 volumes:
   data:

--- a/scripts/app-version.js
+++ b/scripts/app-version.js
@@ -1,10 +1,10 @@
 // The version of the working tree, e.g. `v3.2.0` or `802a340f-dirty`.
 //
-// Three consumers, one definition, because they have to agree: next.config.js
+// Two consumers, one definition, because they have to agree: next.config.js
 // bakes it into the build as NEXT_PUBLIC_APP_VERSION (the footer shows it, see
-// utils/git.ts), and `make docker-build` and scripts/e2e-docker.sh both pass it
-// as the APP_VERSION build arg and use it as the image tag — so the release
-// build reuses the layers the E2E run built instead of compiling its own.
+// utils/git.ts), and scripts/docker-build.sh passes it as the APP_VERSION build
+// arg and uses it as the image tag — so the release build reuses the layers the
+// E2E run built instead of compiling its own.
 //
 // Run directly (`bun scripts/app-version.js`) to print it.
 import { execFileSync } from "child_process";

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build the image we publish, and print its name.
+#
+# Two callers, one build: `make docker-build` (the release build) and
+# scripts/e2e-docker.sh (the E2E run against the image). Building the same
+# thing is the point — the release build is meant to be a cache hit of the one
+# the suite already ran against, so what gets published is what was tested —
+# and that only holds as long as neither side grows a build flag the other
+# lacks. Keeping the command in one place is what keeps that true.
+#
+# Only the image reference goes to stdout, so a caller can capture it:
+#
+#     IMAGE="$(bash scripts/docker-build.sh)"
+#
+# The build's own output goes to stderr. BuildKit writes there anyway; the
+# redirect is for the legacy builder, which would otherwise land in the capture.
+#
+# APP_VERSION may be passed in by a caller that already knows it.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The version the UI displays is baked in at build time, so an empty
+# APP_VERSION builds an image nobody ships.
+APP_VERSION="${APP_VERSION:-$(bun scripts/app-version.js)}"
+# It is the tag too, so a leftover image says which tree it came from and
+# successive builds don't overwrite each other. Never :latest — that means the
+# newest published release, which the release checklist tags deliberately (see
+# CONTRIBUTING.md § Releasing a New Version).
+IMAGE="schellingboard/schellingboard:$APP_VERSION"
+
+docker build --build-arg "APP_VERSION=$APP_VERSION" -t "$IMAGE" . >&2
+
+printf '%s\n' "$IMAGE"

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -28,23 +28,17 @@ DATA_DIR="$PWD/.e2e-docker"
 CONTAINER="schellingboard-e2e-$$"
 
 # Build from the working tree unless the caller named an image (e.g. to run the
-# suite against a release image that was already built or pulled). The build
-# gets a local name of its own: `schellingboard/schellingboard:latest` is the
-# published release image, and a throwaway test build must not take its place.
+# suite against a release image that was already built or pulled).
 #
-# APP_VERSION comes from the same script `make docker-build` and next.config.js
-# use, for two reasons: the version the UI displays is baked in at build time,
-# so leaving it empty tests an image nobody ships; and passing the same value
-# makes the release build a cache hit of this one, so what gets published is
-# what was tested here. It is also the tag, so a leftover image says which tree
-# it came from and successive runs don't overwrite each other.
+# Through the same script `make docker-build` runs, so the release build is a
+# cache hit of this one and what gets published is what was tested here. That
+# guarantee is the reason the build command isn't inlined here.
 if [ -n "${IMAGE:-}" ]; then
   echo "==> Using existing image $IMAGE"
 else
-  APP_VERSION="$(bun scripts/app-version.js)"
-  IMAGE="schellingboard/schellingboard:$APP_VERSION"
-  echo "==> Building $IMAGE"
-  docker build --build-arg "APP_VERSION=$APP_VERSION" -t "$IMAGE" .
+  echo "==> Building the image"
+  IMAGE="$(bash scripts/docker-build.sh)"
+  echo "==> Built $IMAGE"
 fi
 
 # Playwright's own port picking is bypassed here (E2E_EXTERNAL_SERVER), so pick
@@ -85,7 +79,7 @@ env_args+=(-e "SITE_URL=$BASE_URL")
 # release check shouldn't fall over because a background service wasn't
 # started by hand. Ports come from .env.dev.local, the file `make mailpit`
 # feeds compose (see the note above that target).
-mailpit_compose=(docker compose)
+mailpit_compose=(docker compose -f docker-compose.dev.yml)
 if [ -f .env.dev.local ]; then
   mailpit_compose+=(--env-file .env.dev.local)
 fi

--- a/tests/unit/docker-compose-env.test.ts
+++ b/tests/unit/docker-compose-env.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+
+/**
+ * docker-compose.yml is the one file in the repository whose only user is a
+ * self-hoster: no target builds it, no test runs it. Its failure mode is
+ * silent — a variable the app has started reading is documented and set in the
+ * self-hoster's `.env`, but never reaches the container, so the feature just
+ * doesn't work and nothing says why. These are the cheapest checks that catch
+ * that, and they run with every `make test`.
+ */
+
+const ROOT = path.join(__dirname, "../..");
+
+function read(relative: string): string {
+  return readFileSync(path.join(ROOT, relative), "utf8");
+}
+
+/** Variables docker-compose.yml takes from the environment, `${LIKE_THIS}`. */
+function interpolatedVars(yaml: string): Set<string> {
+  return new Set(
+    [...yaml.matchAll(/\$\{([A-Z_][A-Z0-9_]*)/g)].map((m) => m[1])
+  );
+}
+
+/** Variables `.env.docker.example` offers, one `NAME=` per line. */
+function exampleVars(env: string): Set<string> {
+  return new Set([...env.matchAll(/^([A-Z_][A-Z0-9_]*)=/gm)].map((m) => m[1]));
+}
+
+/** Variables the Configuration reference lists, one per table row. */
+function documentedVars(markdown: string): Set<string> {
+  return new Set(
+    [...markdown.matchAll(/^\| `([A-Z_][A-Z0-9_]*)`/gm)].map((m) => m[1])
+  );
+}
+
+// Documented variables that deliberately do not reach the container through
+// compose. Adding a variable to the reference table means deciding which side
+// of this line it falls on.
+const NOT_PASSED_BY_COMPOSE: Record<string, string> = {
+  DATABASE_URL:
+    "the Dockerfile defaults it to /data/data.db, and compose sets that literally rather than from the environment",
+  SB_UPLOADS_DIR:
+    "the Dockerfile defaults it to /data/uploads, inside the volume",
+  SB_ENABLE_DEV_TOOLS:
+    "a staging/demo switch, deliberately not offered in a production deployment",
+};
+
+describe("docker-compose.yml stays in sync with its documentation", () => {
+  const compose = interpolatedVars(read("docker-compose.yml"));
+  const example = exampleVars(read(".env.docker.example"));
+  const documented = documentedVars(
+    read("docs/public/self-hosting/configuration.md")
+  );
+
+  it("offers exactly the variables it reads in .env.docker.example", () => {
+    // Both directions matter: a variable compose reads but the example omits
+    // is one nobody knows to set, and one the example offers but compose never
+    // reads is one that silently does nothing.
+    expect([...example].sort()).toEqual([...compose].sort());
+  });
+
+  it("passes through every documented variable, or says why not", () => {
+    const missing = [...documented].filter(
+      (name) => !compose.has(name) && !(name in NOT_PASSED_BY_COMPOSE)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("has no stale exemptions", () => {
+    const stale = Object.keys(NOT_PASSED_BY_COMPOSE).filter(
+      (name) => !documented.has(name) || compose.has(name)
+    );
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Self-hosters are told to copy docker-compose.yml and run it, so everything in
that file reads as something they might have to care about — including mailpit,
a mail catcher only this project's developers need, and a build section that
cannot work from a copy without the source tree (it only ever ran as a fallback
when the image pull failed, turning a registry hiccup into a confusing "no such
file: Dockerfile").

Mailpit moves to docker-compose.dev.yml, where the dev-only compose profile it
needed to hide behind is no longer necessary. The deployment file keeps only the
published image, so `make docker-build` now builds and tags with plain
`docker build` instead of `docker compose build`, and drops the separate
`docker tag` step. It tags only :$VERSION: that target runs on any working
tree, and :latest has to keep meaning the newest published release, so the
release checklist sets it alongside the major and major.minor tags.

That build command lands in scripts/docker-build.sh rather than in the target,
because scripts/e2e-docker.sh has to run the identical one: the release build
is meant to be a cache hit of the image the E2E suite tested, which stops being
true the moment one of two copies grows a flag the other lacks.

COMMIT_HASH goes too: nothing has read it for a while.

Leaving docker-compose.yml as the only file here that nothing builds, runs or
tests, whose sole user is a stranger — so a unit test now holds its environment
variables against the Configuration reference and .env.docker.example. Without
it, a variable the app started needing could be documented and dutifully set in
a self-hoster's .env, never reach the container, and leave no trace beyond a
feature that quietly does nothing.

<!-- jip:pushed-commit=f94d5f60db409e7a2bdc04a8ea895374fef110d3 -->