### PR TITLE
fix: stop the phase-start tooltip being clipped by the proposal modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The "Scheduling will be enabled at …" note is no longer cut off**: on a proposal's page, hovering the greyed-out Schedule button showed a note that was clipped at the left edge of the window it opened in, so it started mid-word. It is now shown in full
 - **"Voting will be enabled at …" now shows the time on your own clock**: on the proposals list and a proposal's page, the note saying when voting or scheduling opens was given in the time zone of the machine running the site, so a site hosted abroad announced the wrong time. It now shows the time in your own time zone — useful when you are reading it weeks before travelling to the venue — and names that zone whenever it differs from the event's, the same way comment timestamps do
 
 ### Internal

--- a/app/(site)/hover-tooltip.tsx
+++ b/app/(site)/hover-tooltip.tsx
@@ -1,4 +1,9 @@
-import { ReactNode } from "react";
+"use client";
+
+import { ReactNode, useCallback, useRef, useState } from "react";
+
+// Distance from the trigger and from the viewport edges.
+const MARGIN = 8;
 
 export default function HoverTooltip(props: {
   children: ReactNode;
@@ -6,11 +11,42 @@ export default function HoverTooltip(props: {
   visible: boolean;
 }) {
   const { children, text, visible } = props;
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  // The tooltip is usually wider than what it describes, so an absolutely
+  // positioned one gets clipped by scrollable ancestors (e.g. the proposal
+  // modal). Position it fixed instead, measured on hover, and keep it inside
+  // the viewport.
+  const position = useCallback(() => {
+    const trigger = triggerRef.current;
+    const tooltip = tooltipRef.current;
+    if (!trigger || !tooltip) return;
+    const rect = trigger.getBoundingClientRect();
+    const centered = rect.left + rect.width / 2 - tooltip.offsetWidth / 2;
+    const maxLeft = window.innerWidth - tooltip.offsetWidth - MARGIN;
+    setPos({
+      left: Math.round(Math.max(MARGIN, Math.min(centered, maxLeft))),
+      top: Math.round(rect.top - tooltip.offsetHeight - MARGIN),
+    });
+  }, []);
+
   return (
-    <div className="relative inline-block group">
+    <div
+      ref={triggerRef}
+      className="relative inline-block group"
+      onMouseEnter={position}
+    >
       {children}
       {visible && (
-        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
+        <div
+          ref={tooltipRef}
+          style={{ left: pos?.left ?? 0, top: pos?.top ?? 0 }}
+          className={`fixed px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50 ${
+            pos ? "" : "invisible"
+          }`}
+        >
           {text}
         </div>
       )}


### PR DESCRIPTION
An absolutely positioned tooltip is wider than the button it describes, so
scrollable ancestors cut it off. Position it fixed and clamp it to the
viewport instead.

<!-- jip:pushed-commit=988195369f612f1da6bd896b2aac1ce552c19462 -->