### PR TITLE
test: assert both comment permalinks exist before comparing them

### DIFF
--- a/tests/e2e/comments.spec.ts
+++ b/tests/e2e/comments.spec.ts
@@ -152,15 +152,10 @@ test("replies to a comment, collapses the thread, and permalinks to a reply", as
 
   // Each comment's timestamp links to that comment alone, parent and reply
   // getting distinct targets.
-  const parentPermalink = await modal
-    .getByRole("link", { name: /^\d/ })
-    .first()
-    .getAttribute("href");
-
-  const permalink = await modal
-    .getByRole("link", { name: /^\d/ })
-    .last()
-    .getAttribute("href");
+  const timestamps = modal.getByRole("link", { name: /^\d/ });
+  await expect(timestamps).toHaveCount(2);
+  const parentPermalink = await timestamps.first().getAttribute("href");
+  const permalink = await timestamps.last().getAttribute("href");
   expect(permalink).toMatch(/#comment-/);
   expect(permalink).not.toBe(parentPermalink);
 


### PR DESCRIPTION
first()/last() on a locator that matched fewer than two timestamps would
silently compare a link with itself.

<!-- jip:pushed-commit=aba25330e10249d54bc148932a11a123f87f6baf -->