### PR TITLE
feat: search attendees across contacts and prompt questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- **Attendee search now looks at the whole profile**: searching the attendee directory also matches the contact details attendees chose to publish (handles, usernames, websites, and the service they belong to) and the prompt questions themselves, not only their answers — so knowing someone's handle is enough to find them. Private email addresses are never searched; they are not part of a profile
+
 ### Internal
 
 - The seed data gives Conference Gamma four more proposals: two hosted by Hana Kobayashi, whose profile is the most complete of the seeded guests, and two with no host yet. Both cases were previously only reachable through the random host assignment, which made them awkward to point a screenshot at

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -175,7 +175,12 @@ that you can be at most five minutes late, but doesn't block your RSVP.
 Every attendee gets a profile page with their bio, proposals, and the sessions
 they're hosting — click any name wherever it appears to see it. Click their
 profile photo to see it enlarged. The attendee directory lets you search
-everyone at the event and see who's hosting a session at a glance.
+everyone at the event and see who's hosting a session at a glance. Search
+covers everything on a profile — names, pronouns, bios, languages, where
+someone is based, prompts and their answers, and any contact details they
+published — so a remembered handle, a service name like "Signal", or a shared
+interest is enough to find someone. Your private email address is never part
+of a profile and is never searched.
 
 ![Searchable attendee directory with avatars, bios, and Session host badges](../screenshots/attendees.webp)
 

--- a/tests/unit/attendee-search.test.ts
+++ b/tests/unit/attendee-search.test.ts
@@ -98,17 +98,61 @@ describe("searchAttendees", () => {
     expect(result.map((r) => r.name).sort()).toEqual(["Alice", "Bob"]);
   });
 
-  it("does not match contact values", () => {
-    // Contacts are shown on the profile, but searching them invites scraping
-    // and matches nothing a directory scanner is looking for.
+  it("matches public contact values and their labels", () => {
     const rows = [
       attendee({
         name: "Alice",
-        contacts: [{ type: "email", value: "secret-handle@example.com" }],
+        contacts: [{ type: "telegram", value: "@alice_in_wonderland" }],
       }),
+      attendee({
+        name: "Bob",
+        contacts: [
+          { type: "other", label: "Mastodon", value: "@bob@example.social" },
+        ],
+      }),
+      attendee({ name: "Carol" }),
     ];
 
-    expect(searchAttendees(rows, "secret-handle")).toEqual([]);
+    expect(searchAttendees(rows, "wonderland").map((r) => r.name)).toEqual([
+      "Alice",
+    ]);
+    expect(searchAttendees(rows, "mastodon").map((r) => r.name)).toEqual([
+      "Bob",
+    ]);
+    // Built-in types carry no stored label; the profile prints the type's
+    // name, so that is what has to match.
+    expect(searchAttendees(rows, "telegram").map((r) => r.name)).toEqual([
+      "Alice",
+    ]);
+  });
+
+  it("matches the prompt question, not just its answer", () => {
+    const rows = [
+      attendee({
+        name: "Alice",
+        prompts: [{ prompt: "Looking for", answer: "a climbing partner" }],
+      }),
+      attendee({ name: "Bob" }),
+    ];
+
+    expect(searchAttendees(rows, "looking for").map((r) => r.name)).toEqual([
+      "Alice",
+    ]);
+  });
+
+  it("ranks a name match above a contact match", () => {
+    const rows = [
+      attendee({
+        name: "Zoe",
+        contacts: [{ type: "discord", value: "kim#1234" }],
+      }),
+      attendee({ name: "Kim" }),
+    ];
+
+    expect(searchAttendees(rows, "kim").map((r) => r.name)).toEqual([
+      "Kim",
+      "Zoe",
+    ]);
   });
 
   it("orders ties within a rank tier by name", () => {

--- a/utils/attendee-search.ts
+++ b/utils/attendee-search.ts
@@ -1,4 +1,5 @@
 import type { Attendee } from "@/db/repositories/interfaces";
+import { CONTACT_TYPE_LABELS } from "@/model/guest";
 import { containsIgnoringAccents, equalsIgnoringAccents } from "./utils";
 
 // Rank tiers, higher wins. Exact declared-language matches must beat
@@ -14,14 +15,21 @@ function rank(attendee: Attendee, query: string): number {
   const languages = attendee.languages ?? [];
   if (languages.some((l) => equalsIgnoringAccents(l, query))) return STRUCTURED;
 
-  // Contacts are deliberately not searched: matching them serves scrapers,
-  // not people scanning the directory.
+  // Every public profile field, including contacts — someone who knows a
+  // handle should find its owner. The private system email is not part of
+  // Attendee and so can never be matched here.
   const freeText = [
     attendee.basedIn,
     attendee.pronouns,
     attendee.aboutMe,
     ...languages,
-    ...(attendee.prompts ?? []).map((p) => p.answer),
+    ...(attendee.prompts ?? []).flatMap((p) => [p.prompt, p.answer]),
+    ...(attendee.contacts ?? []).flatMap((c) => [
+      // The label the profile prints: stored only for "other" contacts, the
+      // type's name for the rest.
+      (c.type === "other" && c.label) || CONTACT_TYPE_LABELS[c.type],
+      c.value,
+    ]),
   ];
   if (freeText.some((t) => t && containsIgnoringAccents(t, query)))
     return FREE_TEXT;


### PR DESCRIPTION
The directory search skipped published contact details and the prompt
questions, so knowing someone's handle was not enough to find them.
Contacts are opt-in public profile data; the private system email is not
part of Attendee and stays unsearchable.

Closes #760

<!-- jip:pushed-commit=0a5331bf06a2c12cc3e65e4379c177f1b3a350b9 -->