### PR TITLE
feat: sort attendees by recently updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Sort the attendee directory by who edited their profile last**: a "Sort by" choice next to the filters switches the list between "Name (A–Z)" and "Recently updated", so it's easy to catch up on profiles that are new or have changed since you last looked. Each row shows when that profile was last edited ("updated 3 days ago"). Nothing recorded edit times before this version, so every profile that already has something in it is dated from the upgrade and they all rank together, ahead of the ones nobody has filled in — those show no date and come last. Real edit times build up from the upgrade onwards. While a search is active the list stays ordered by how well each profile matches, and the choice is unavailable
 - **Formatting and clickable links in the rest of your profile**: the answers to the conversation starters and your contact details now accept Markdown, like "About me" already did — so a link can be given a name (`[my blog](https://example.com)`), and a web address or email address pasted in plainly becomes clickable on its own
 
 ### Changed
 
+- **The attendee directory is wider on a large screen**: the list used the same narrow column as a form, which left the update times crowded against the names. On a phone the update time now sits under the name instead of beside it, and a "Session host" badge no longer squeezes the name into two lines
 - **Attendee search now looks at the whole profile**: searching the attendee directory also matches the contact details attendees chose to publish (handles, usernames, websites, and the service they belong to) and the prompt questions themselves, not only their answers — so knowing someone's handle is enough to find them. Private email addresses are never searched; they are not part of a profile
 
 ### Internal
 
 - Dependabot now keeps the mailpit image up to date. Its pin was repeated in `docker-compose.dev.yml` and in both CI workflows, and Dependabot cannot see a workflow's `services:` image ([dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819)), so CI now starts mailpit from the compose file and the pin has a single home. The image carries a tag as well as a digest, since a digest alone gives Dependabot no version to compare
+- Seeded guests with a profile now carry a last-edited date, spread over the past month, instead of all being undated — the seed writes guest rows directly, so nothing stamped them. "Recently updated" had nothing to sort in dev and demos
 - The seed data gives Conference Gamma four more proposals: two hosted by Hana Kobayashi, whose profile is the most complete of the seeded guests, and two with no host yet. Both cases were previously only reachable through the random host assignment, which made them awkward to point a screenshot at
 
 ## [3.3.1] - 2026-08-08

--- a/app/(site)/guests/attendee-list.tsx
+++ b/app/(site)/guests/attendee-list.tsx
@@ -4,6 +4,11 @@ import { Attendee } from "@/db/repositories/interfaces";
 import { DataTable, useTableParams } from "@/app/admin/data-table";
 import Link from "next/link";
 import { Avatar } from "@/app/(site)/guests/avatar";
+import {
+  ATTENDEE_SORTS,
+  AttendeeSort,
+  DEFAULT_ATTENDEE_SORT,
+} from "@/utils/attendee-search";
 
 // Rows are serialized into the page payload, so only the fields the row
 // actually renders may cross the server/client boundary — never the full
@@ -11,10 +16,13 @@ import { Avatar } from "@/app/(site)/guests/avatar";
 export type AttendeeRowData = Pick<
   Attendee,
   "id" | "name" | "avatarUrl" | "pronouns" | "basedIn" | "isHost"
->;
+> & {
+  // Already rendered ("3 days ago"), not a date: see the note in page.tsx.
+  profileUpdated: string | null;
+};
 
 function AttendeeRow({
-  attendee: { id, avatarUrl, name, pronouns, basedIn, isHost },
+  attendee: { id, avatarUrl, name, pronouns, basedIn, isHost, profileUpdated },
   listQueryString,
 }: {
   attendee: AttendeeRowData;
@@ -28,14 +36,21 @@ function AttendeeRow({
       // always resetting to page 1.
       `/guests/${id}?from=${encodeURIComponent(listQueryString)}`
     : `/guests/${id}`;
+  // Sorting by recency with no visible dates would be opaque. Narrow screens
+  // have no room for it beside the name, so it rides along under the name
+  // there and only moves out to the right edge from sm up.
+  const updated = profileUpdated && (
+    <span className="text-xs text-gray-400">updated {profileUpdated}</span>
+  );
   return (
     <Link
       href={href}
       className="flex items-center gap-4 hover:bg-gray-50 rounded-md px-2"
     >
       <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
-      <div className="flex flex-col gap-1">
-        <span className="font-medium text-gray-900 flex flex-row gap-2">
+      <div className="flex flex-col gap-1 min-w-0 flex-1">
+        {/* Wraps rather than squeezing the name to fit the badge beside it. */}
+        <span className="font-medium text-gray-900 flex flex-wrap items-center gap-x-2 gap-y-1">
           {name}
           {isHost && (
             <span className="w-fit rounded-full bg-rose-100 text-rose-700 text-xs font-semibold px-3 py-1">
@@ -43,12 +58,20 @@ function AttendeeRow({
             </span>
           )}
         </span>
-        {(pronouns || basedIn) && (
-          <span className="text-sm text-gray-500 line-clamp-1">
-            {[pronouns, basedIn].filter(Boolean).join(" · ")}
+        {(pronouns || basedIn || updated) && (
+          <span className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            {(pronouns || basedIn) && (
+              <span className="text-sm text-gray-500 line-clamp-1">
+                {[pronouns, basedIn].filter(Boolean).join(" · ")}
+              </span>
+            )}
+            <span className="sm:hidden">{updated}</span>
           </span>
         )}
       </div>
+      {updated && (
+        <span className="hidden shrink-0 self-start sm:block">{updated}</span>
+      )}
     </Link>
   );
 }
@@ -61,13 +84,16 @@ export function AttendeeList(props: {
   searchQuery: string;
   filter?: string;
   filters: { value: string; label: string }[];
+  sort: AttendeeSort;
 }) {
   const { searchParams, setParams } = useTableParams();
   // The raw query string (no leading "/guests?"), forwarded as `from` on
   // each row link so the profile page can rebuild "/guests?<from>".
   const listQueryString = searchParams.toString();
+  // A search is ranked by relevance, which an explicit sort would throw away.
+  const sortDisabled = props.searchQuery !== "";
   const toolbar = (
-    <div className="flex gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       {props.filters.map((f) => (
         <button
           key={f.value}
@@ -94,6 +120,38 @@ export function AttendeeList(props: {
           )}
         </button>
       ))}
+      <label
+        className="flex items-center gap-2 text-sm text-gray-600"
+        // On the label, not the select: browsers suppress pointer events on a
+        // disabled control, so a title there would never show a tooltip.
+        title={
+          sortDisabled ? "Search results are sorted by relevance" : undefined
+        }
+      >
+        Sort by
+        <select
+          value={props.sort}
+          disabled={sortDisabled}
+          onChange={(e) => {
+            setParams({
+              sort:
+                e.target.value === DEFAULT_ATTENDEE_SORT
+                  ? null
+                  : e.target.value,
+              page: null,
+            });
+          }}
+          // pr-9 clears the chevron the forms plugin paints in the right
+          // padding; a plain px-2 would let the longest option run under it.
+          className="pl-2 pr-9 py-1.5 text-sm rounded-md border border-gray-300 bg-white disabled:bg-gray-100 disabled:text-gray-400"
+        >
+          {ATTENDEE_SORTS.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </label>
     </div>
   );
   return (

--- a/app/(site)/guests/page.tsx
+++ b/app/(site)/guests/page.tsx
@@ -5,7 +5,13 @@ import { pageRequestSchema } from "@/model/page";
 import { outOfRangePageRedirect } from "@/utils/pagination";
 import { redirect } from "next/navigation";
 import { AttendeeList } from "@/app/(site)/guests/attendee-list";
-import { searchAttendees } from "@/utils/attendee-search";
+import {
+  ATTENDEE_SORTS,
+  DEFAULT_ATTENDEE_SORT,
+  searchAttendees,
+} from "@/utils/attendee-search";
+import { formatRelativeTime } from "@/utils/relative-time";
+import { serverNow } from "@/utils/dev-clock-server";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { z } from "zod";
 
@@ -18,44 +24,74 @@ export function getFilters() {
 export default async function GuestsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; page?: string; filter?: string }>;
+  searchParams: Promise<{
+    q?: string;
+    page?: string;
+    filter?: string;
+    sort?: string;
+  }>;
 }) {
   const params = await searchParams;
 
   const paramSchema = pageRequestSchema.extend({
     filter: z.enum(getFilters().map((filter) => filter.value)).optional(),
+    sort: z
+      .enum(ATTENDEE_SORTS.map((s) => s.value))
+      .catch(DEFAULT_ATTENDEE_SORT),
   });
 
-  const { page, query, filter } = paramSchema.parse({
+  const { page, query, filter, sort } = paramSchema.parse({
     page: params.page,
     query: params.q,
     filter: params.filter,
+    sort: params.sort,
   });
 
   const attendees = await getRepositories().guests.listAttendees({
     host: filter === "isHost",
   });
-  const matches = searchAttendees(attendees, query);
+  const matches = searchAttendees(attendees, query, sort);
   const total = matches.length;
+  const now = await serverNow();
   const rows = matches
     .slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
     // Strip fields the list doesn't show; TypeScript's structural typing
-    // wouldn't stop a full Attendee from reaching the client payload.
-    .map(({ id, name, avatarUrl, pronouns, basedIn, isHost }) => ({
-      id,
-      name,
-      avatarUrl,
-      pronouns,
-      basedIn,
-      isHost,
-    }));
+    // wouldn't stop a full Attendee from reaching the client payload. The
+    // update time is formatted here rather than shipped as a date: the list is
+    // a client component, and a "now" from the browser would disagree with the
+    // server-rendered markup.
+    .map(
+      ({
+        id,
+        name,
+        avatarUrl,
+        pronouns,
+        basedIn,
+        isHost,
+        profileUpdatedAt,
+      }) => ({
+        id,
+        name,
+        avatarUrl,
+        pronouns,
+        basedIn,
+        isHost,
+        profileUpdated: profileUpdatedAt
+          ? formatRelativeTime(profileUpdatedAt, now)
+          : null,
+      })
+    );
 
   const redirectTarget = outOfRangePageRedirect({
     basePath: "/guests",
     page,
     total,
     pageSize: PAGE_SIZE,
-    params: { q: query, filter: filter ?? "" },
+    params: {
+      q: query,
+      filter: filter ?? "",
+      sort: sort === DEFAULT_ATTENDEE_SORT ? "" : sort,
+    },
   });
 
   if (redirectTarget) redirect(redirectTarget);
@@ -63,8 +99,11 @@ export default async function GuestsPage({
   const cookieStore = await cookies();
   const currentUser = await verifiedCurrentUser(cookieStore);
 
+  // Wider than the max-w-2xl pages around it: the rows carry a name, a badge
+  // and an update time. That width can reach the viewport edge between sm and
+  // lg, so the horizontal padding stays on at every size.
   return (
-    <div className="max-w-2xl mx-auto flex flex-col gap-6 px-4 sm:px-0">
+    <div className="max-w-4xl mx-auto flex flex-col gap-6 px-4">
       <div className="flex items-center justify-between gap-4">
         <h1 className="text-3xl font-bold">Attendees</h1>
         {currentUser && (
@@ -80,6 +119,7 @@ export default async function GuestsPage({
       <AttendeeList
         filter={filter}
         filters={getFilters()}
+        sort={sort}
         rows={rows}
         pageSize={PAGE_SIZE}
         total={total}

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
 import { getImageRepositories } from "@/utils/images";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
+import { serverNow } from "@/utils/dev-clock-server";
 import { profileSchema } from "@/model/guest";
 import { z } from "zod";
 
@@ -72,7 +73,11 @@ export async function updateProfileAction(
     );
   }
 
-  await guests.updateProfile(currentUser, { ...profile, avatarUrl });
+  await guests.updateProfile(
+    currentUser,
+    { ...profile, avatarUrl },
+    await serverNow()
+  );
 
   revalidatePath(`/guests/${currentUser}`);
   revalidatePath("/guests");

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -167,6 +167,9 @@ export type Guest<PI extends GuestPrivateInfo | void = void> = {
   prompts?: ProfilePrompt[] | null;
   languages?: string[] | null;
   contacts?: ProfileContact[] | null;
+  // When a public field above was last changed; null for a profile that was
+  // never edited (see the schema comment). Drives the "recently updated" sort.
+  profileUpdatedAt?: Date | null;
   // Public (the name switcher must know to ask for credentials); the
   // password hash itself is server-only, see GuestAuthCredentials.
   authProtected?: boolean;
@@ -284,7 +287,7 @@ export interface GuestsRepository {
   /**
    * All guests as attendees (public profile fields plus whether they host any
    * session), ordered by name with id tiebreaker. `host: true` narrows to
-   * session hosts. Search and pagination happen in memory on top of this
+   * session hosts. Search, sorting and pagination happen in memory on top of this
    * (see utils/attendee-search.ts): attendee counts don't warrant a SQL or
    * persisted search index.
    */
@@ -336,6 +339,9 @@ export interface GuestsRepository {
     data: { name: string; info: { email: string } }
   ): Promise<CompleteGuest | undefined>;
   // Usage: a user updates their own public profile (name and profile fields).
+  // `profileUpdatedAt` is set to `now` only if a public profile field actually
+  // changed — saving the form unchanged must not push you to the top of the
+  // "recently updated" list.
   updateProfile(
     id: string,
     data: {
@@ -347,7 +353,8 @@ export interface GuestsRepository {
       prompts: ProfilePrompt[] | null;
       languages: string[] | null;
       contacts: ProfileContact[] | null;
-    }
+    },
+    now: Date
   ): Promise<CompleteGuest | undefined>;
   // Usage: a user updates their own email notification settings. Kept apart
   // from updateProfile: settings are private and independent of the public

--- a/db/repositories/sqlite/guests.ts
+++ b/db/repositories/sqlite/guests.ts
@@ -35,6 +35,38 @@ function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
 }
 
+// The fields whose change makes a profile "recently updated" — everything the
+// guest edits about themselves in public. Email settings and credentials are
+// updated elsewhere and never count.
+const PUBLIC_PROFILE_FIELDS = [
+  "name",
+  "aboutMe",
+  "avatarUrl",
+  "pronouns",
+  "basedIn",
+  "prompts",
+  "languages",
+  "contacts",
+] as const;
+
+type PublicProfile = Pick<
+  typeof schema.guests.$inferSelect,
+  (typeof PUBLIC_PROFILE_FIELDS)[number]
+>;
+
+function publicProfileChanged(
+  before: PublicProfile,
+  after: PublicProfile
+): boolean {
+  // JSON comparison covers prompts/languages/contacts, where reordering is a
+  // change the guest made on purpose.
+  return PUBLIC_PROFILE_FIELDS.some(
+    (field) =>
+      JSON.stringify(before[field] ?? null) !==
+      JSON.stringify(after[field] ?? null)
+  );
+}
+
 function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
   return {
     id: row.id,
@@ -46,6 +78,9 @@ function rowToGuest(row: typeof schema.guests.$inferSelect): CompleteGuest {
     prompts: row.prompts,
     languages: row.languages,
     contacts: row.contacts,
+    profileUpdatedAt: row.profileUpdatedAt
+      ? new Date(row.profileUpdatedAt)
+      : null,
     authProtected: row.authProtected,
     info: {
       email: row.email,
@@ -162,6 +197,7 @@ export class SqliteGuestsRepository implements GuestsRepository {
           prompts: schema.guests.prompts,
           languages: schema.guests.languages,
           contacts: schema.guests.contacts,
+          profileUpdatedAt: schema.guests.profileUpdatedAt,
           // SQLite has no boolean type; this yields 0/1 at runtime despite the
           // sql<boolean> annotation, so coerce explicitly below.
           isHost: opts.host ? sql<boolean>`true` : isHostExpr,
@@ -171,7 +207,16 @@ export class SqliteGuestsRepository implements GuestsRepository {
         // id as tiebreaker so equal names keep a deterministic order.
         .orderBy(sql`${schema.guests.name} collate nocase`, schema.guests.id)
         .all()
-        .map((row) => ({ ...row, isHost: Boolean(row.isHost) }) as Attendee)
+        .map(
+          (row) =>
+            ({
+              ...row,
+              isHost: Boolean(row.isHost),
+              profileUpdatedAt: row.profileUpdatedAt
+                ? new Date(row.profileUpdatedAt)
+                : null,
+            }) as Attendee
+        )
     );
   }
 
@@ -396,23 +441,38 @@ export class SqliteGuestsRepository implements GuestsRepository {
       prompts: ProfilePrompt[] | null;
       languages: string[] | null;
       contacts: ProfileContact[] | null;
-    }
+    },
+    now: Date
   ): Promise<CompleteGuest | undefined> {
-    const result = this.db
-      .update(schema.guests)
-      .set({
-        name: data.name,
-        aboutMe: data.aboutMe,
-        avatarUrl: data.avatarUrl,
-        pronouns: data.pronouns,
-        basedIn: data.basedIn,
-        prompts: data.prompts,
-        languages: data.languages,
-        contacts: data.contacts,
-      })
-      .where(eq(schema.guests.id, id))
-      .run();
-    if (result.changes === 0) return undefined;
+    // Read and write in one transaction: profileUpdatedAt is derived from the
+    // row being overwritten, so a concurrent save must not slip in between.
+    const found = this.db.transaction((tx) => {
+      const before = tx
+        .select()
+        .from(schema.guests)
+        .where(eq(schema.guests.id, id))
+        .get();
+      if (!before) return false;
+
+      tx.update(schema.guests)
+        .set({
+          name: data.name,
+          aboutMe: data.aboutMe,
+          avatarUrl: data.avatarUrl,
+          pronouns: data.pronouns,
+          basedIn: data.basedIn,
+          prompts: data.prompts,
+          languages: data.languages,
+          contacts: data.contacts,
+          profileUpdatedAt: publicProfileChanged(before, data)
+            ? now.toISOString()
+            : before.profileUpdatedAt,
+        })
+        .where(eq(schema.guests.id, id))
+        .run();
+      return true;
+    });
+    if (!found) return undefined;
     return this.findById(id);
   }
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -55,6 +55,12 @@ export const guests = sqliteTable(
       .notNull()
       .default(false),
     avatarUrl: text("avatar_url"),
+    // When the guest last changed a public profile field — their name counts,
+    // email settings and credentials don't. NULL for profiles nobody ever
+    // filled in, which sort last under "recently updated"; profiles that
+    // already had content when the column was added all share the migration's
+    // instant, there being no history to date them from.
+    profileUpdatedAt: text("profile_updated_at"),
     // Account security (issue #370): when set, acting as this guest requires
     // a verified session (password or emailed code) instead of the open
     // name-switcher.

--- a/docs/dev/design/attendee-profiles.md
+++ b/docs/dev/design/attendee-profiles.md
@@ -7,7 +7,12 @@ Requirements for reworking the attendee list and profile view, covering
 non-empty profiles),
 [#712](https://github.com/LWCW-Europe/schellingboard/issues/712) (sort order)
 and [#764](https://github.com/LWCW-Europe/schellingboard/issues/764) (read
-profiles without clicking through each one). Nothing here is implemented yet.
+profiles without clicking through each one).
+
+Only [§ Sorting (#712)](#sorting-712) is implemented, on today's list rather
+than the reworked one: the `profileUpdatedAt` column exists, the toolbar has
+the "Sort by" dropdown, and each row carries its relative update time. The
+rest is still a plan.
 
 Assumed scale: 150–400 attendees per event, 30–60% with a filled-in profile,
 `aboutMe` typically one to three paragraphs.
@@ -127,14 +132,17 @@ Two options: **Name (A–Z)** (default) and **Recently updated**.
 
 This needs a new nullable `profileUpdatedAt` column; `guests` currently has no
 timestamps at all, and the only `created_at` in the schema is on `auth_codes`,
-so there is nothing to backfill from. Existing rows stay NULL and sort last.
-The sort therefore honestly means "recently updated since we started tracking",
-and self-heals within an event cycle. Backfilling everyone to the migration
-date would manufacture a fake ordering.
+so there is no history to date existing rows from. The migration backfills
+every profile that has any self-entered field to its own instant, so they all
+tie and rank ahead of the untouched ones, which stay NULL and sort last. That
+is the one distinction the data supports; dating them apart would be fiction.
+The sort therefore means "recently updated since we started tracking", and
+self-heals within an event cycle.
 
-The column is touched only when a **public profile field** changes (`aboutMe`,
-`pronouns`, `basedIn`, `prompts`, `languages`, `contacts`, `avatarUrl`) — not
-email preferences, not password changes.
+The column is touched only when a **public profile field** changes (`name`,
+`aboutMe`, `pronouns`, `basedIn`, `prompts`, `languages`, `contacts`,
+`avatarUrl`) — not email preferences, not password changes. `name` counts:
+people do rename themselves, and that is a profile edit like any other.
 
 ### Back links
 

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -182,6 +182,13 @@ published — so a remembered handle, a service name like "Signal", or a shared
 interest is enough to find someone. Your private email address is never part
 of a profile and is never searched.
 
+The list is alphabetical by default; **Sort by → Recently updated** puts the
+profiles that changed most recently first, which is the quick way to see who
+has filled theirs in since you last looked. Each row shows when that profile
+was last edited; profiles that are still empty show no date and come last.
+While you are searching, results stay ordered by how well they match, so the
+sort choice is unavailable.
+
 ![Searchable attendee directory with avatars, bios, and Session host badges](../screenshots/attendees.webp)
 
 ## Your profile

--- a/drizzle/0025_guest_profile_updated_at.sql
+++ b/drizzle/0025_guest_profile_updated_at.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `guests` ADD `profile_updated_at` text;--> statement-breakpoint
+-- Backfill: nothing records when these profiles were written, so everyone who
+-- has filled anything in shares this migration's instant. That buys the one
+-- distinction worth having — profiles with content ahead of untouched ones —
+-- without inventing an order among them. Only self-entered fields count: the
+-- CSV importer writes name and email, so those say nothing.
+UPDATE `guests` SET `profile_updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE coalesce(`about_me`, '') <> ''
+   OR coalesce(`pronouns`, '') <> ''
+   OR coalesce(`based_in`, '') <> ''
+   OR coalesce(`avatar_url`, '') <> ''
+   OR coalesce(`prompts`, '[]') NOT IN ('[]', 'null', '')
+   OR coalesce(`languages`, '[]') NOT IN ('[]', 'null', '')
+   OR coalesce(`contacts`, '[]') NOT IN ('[]', 'null', '');

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1319 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0a3e659f-e07a-43e9-a904-053b706f9548",
+  "prevId": "6fcccc6b-72f0-4076-b5e6-e4dfd2b4d3da",
+  "tables": {
+    "auth_codes": {
+      "name": "auth_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'login'"
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_codes_guest_id_guests_id_fk": {
+          "name": "auth_codes_guest_id_guests_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_likes": {
+      "name": "comment_likes",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comment_likes_guest_idx": {
+          "name": "comment_likes_guest_idx",
+          "columns": ["guest_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_likes_comment_id_comments_id_fk": {
+          "name": "comment_likes_comment_id_comments_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_likes_guest_id_guests_id_fk": {
+          "name": "comment_likes_guest_id_guests_id_fk",
+          "tableFrom": "comment_likes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "comment_likes_comment_id_guest_id_pk": {
+          "columns": ["comment_id", "guest_id"],
+          "name": "comment_likes_comment_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_time": {
+          "name": "edited_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_guests_id_fk": {
+          "name": "comments_author_id_guests_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "guests",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "days": {
+      "name": "days",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_bookings": {
+          "name": "start_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_bookings": {
+          "name": "end_bookings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "days_event_id_events_id_fk": {
+          "name": "days_event_id_events_id_fk",
+          "tableFrom": "days",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_guests": {
+      "name": "event_guests",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_guests_event_id_events_id_fk": {
+          "name": "event_guests_event_id_events_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_guests_guest_id_guests_id_fk": {
+          "name": "event_guests_guest_id_guests_id_fk",
+          "tableFrom": "event_guests",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_guests_event_id_guest_id_pk": {
+          "columns": ["event_id", "guest_id"],
+          "name": "event_guests_event_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_locations": {
+      "name": "event_locations",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_locations_event_id_events_id_fk": {
+          "name": "event_locations_event_id_events_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_locations_location_id_locations_id_fk": {
+          "name": "event_locations_location_id_locations_id_fk",
+          "tableFrom": "event_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_locations_event_id_location_id_pk": {
+          "columns": ["event_id", "location_id"],
+          "name": "event_locations_event_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_phase_start": {
+          "name": "proposal_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_phase_end": {
+          "name": "proposal_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_start": {
+          "name": "voting_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voting_phase_end": {
+          "name": "voting_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_start": {
+          "name": "scheduling_phase_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_phase_end": {
+          "name": "scheduling_phase_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_session_duration": {
+          "name": "max_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 120
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "slot_increment_minutes": {
+          "name": "slot_increment_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "rsvp_capacity_hard_limit": {
+          "name": "rsvp_capacity_hard_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guests": {
+      "name": "guests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "about_me": {
+          "name": "about_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "based_in": {
+          "name": "based_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_on_rsvp_change": {
+          "name": "email_on_rsvp_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_host_change": {
+          "name": "email_on_host_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_cohost_add": {
+          "name": "email_on_cohost_add",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_proposal_comment": {
+          "name": "email_on_proposal_comment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "email_on_comment_thread": {
+          "name": "email_on_comment_thread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_updated_at": {
+          "name": "profile_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_protected": {
+          "name": "auth_protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guests_email_unique": {
+          "name": "guests_email_unique",
+          "columns": ["lower(\"email\")"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bookable": {
+          "name": "bookable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_index": {
+          "name": "sort_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "area_description": {
+          "name": "area_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_comments": {
+      "name": "proposal_comments",
+      "columns": {
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proposal_comments_proposal_idx": {
+          "name": "proposal_comments_proposal_idx",
+          "columns": ["proposal_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_comments_comment_id_comments_id_fk": {
+          "name": "proposal_comments_comment_id_comments_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_comments_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_comments_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_comments",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proposal_hosts": {
+      "name": "proposal_hosts",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_hosts_proposal_id_session_proposals_id_fk": {
+          "name": "proposal_hosts_proposal_id_session_proposals_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_hosts_guest_id_guests_id_fk": {
+          "name": "proposal_hosts_guest_id_guests_id_fk",
+          "tableFrom": "proposal_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_hosts_proposal_id_guest_id_pk": {
+          "columns": ["proposal_id", "guest_id"],
+          "name": "proposal_hosts_proposal_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rsvps": {
+      "name": "rsvps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rsvps_session_guest_unique": {
+          "name": "rsvps_session_guest_unique",
+          "columns": ["session_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rsvps_session_id_sessions_id_fk": {
+          "name": "rsvps_session_id_sessions_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rsvps_guest_id_guests_id_fk": {
+          "name": "rsvps_guest_id_guests_id_fk",
+          "tableFrom": "rsvps",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_hosts": {
+      "name": "session_hosts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_hosts_session_id_sessions_id_fk": {
+          "name": "session_hosts_session_id_sessions_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_hosts_guest_id_guests_id_fk": {
+          "name": "session_hosts_guest_id_guests_id_fk",
+          "tableFrom": "session_hosts",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_hosts_session_id_guest_id_pk": {
+          "columns": ["session_id", "guest_id"],
+          "name": "session_hosts_session_id_guest_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_locations": {
+      "name": "session_locations",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_locations_session_id_sessions_id_fk": {
+          "name": "session_locations_session_id_sessions_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_locations_location_id_locations_id_fk": {
+          "name": "session_locations_location_id_locations_id_fk",
+          "tableFrom": "session_locations",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_locations_session_id_location_id_pk": {
+          "columns": ["session_id", "location_id"],
+          "name": "session_locations_session_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_proposals": {
+      "name": "session_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_time": {
+          "name": "created_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_proposals_event_id_events_id_fk": {
+          "name": "session_proposals_event_id_events_id_fk",
+          "tableFrom": "session_proposals",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "admin_managed": {
+          "name": "admin_managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "blocker": {
+          "name": "blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_proposal_id_session_proposals_id_fk": {
+          "name": "sessions_proposal_id_session_proposals_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_event_id_events_id_fk": {
+          "name": "sessions_event_id_events_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_settings": {
+      "name": "site_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Conference Weekend'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Welcome! Browse the schedules for each event below.'"
+        },
+        "map_image_url": {
+          "name": "map_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "votes": {
+      "name": "votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "choice": {
+          "name": "choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "votes_proposal_guest_unique": {
+          "name": "votes_proposal_guest_unique",
+          "columns": ["proposal_id", "guest_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "votes_proposal_id_session_proposals_id_fk": {
+          "name": "votes_proposal_id_session_proposals_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "session_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_guest_id_guests_id_fk": {
+          "name": "votes_guest_id_guests_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "guests",
+          "columnsFrom": ["guest_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "guests_email_unique": {
+        "columns": {
+          "lower(\"email\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785596621720,
       "tag": "0024_comment_email_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1786525223340,
+      "tag": "0025_guest_profile_updated_at",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -1157,7 +1157,7 @@ async function seedTestData() {
   console.log("  📝 Creating test guests...");
   fs.mkdirSync(uploadedAvatarsDir(), { recursive: true });
   const guestRows = await Promise.all(
-    guestConfigs.map(async (config) => {
+    guestConfigs.map(async (config, index) => {
       const id = nanoid();
       let avatarUrl: string | null = null;
       if (config.avatar !== undefined) {
@@ -1174,6 +1174,20 @@ async function seedTestData() {
       const passwordHash = config.password
         ? await hashUserPassword(config.password)
         : null;
+      // The app stamps this when a guest saves their profile; the seed writes
+      // rows directly, so it has to stamp them itself or "Recently updated"
+      // has nothing to sort. Spread over the past month, oldest last, so the
+      // list shows a range of ages. Guests with nothing filled in keep a null
+      // stamp — they have never edited a profile.
+      const hasProfile = [
+        config.aboutMe,
+        config.pronouns,
+        config.avatar,
+        config.basedIn,
+        config.languages,
+        config.prompts,
+        config.contacts,
+      ].some((field) => field !== undefined);
       return {
         id,
         name: config.name,
@@ -1185,6 +1199,11 @@ async function seedTestData() {
         languages: config.languages ?? null,
         prompts: config.prompts ?? null,
         contacts: config.contacts ?? null,
+        profileUpdatedAt: hasProfile
+          ? new Date(
+              Date.now() - (index * 19 + 3) * 60 * 60 * 1000
+            ).toISOString()
+          : null,
         authProtected: passwordHash !== null,
         passwordHash,
       };

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -479,3 +479,41 @@ test("Back to attendees preserves the search query", async ({ page }) => {
   await expect(page.getByRole("link", { name: "Bob Test" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Charlie Test" })).toBeVisible();
 });
+
+test("sorts the attendee directory by recently updated", async ({ page }) => {
+  await login(page);
+  await page.goto("/Conference-Alpha/proposals");
+
+  await selectCurrentUser(page);
+  await page.getByRole("link", { name: "Attendees", exact: true }).click();
+  await page.getByRole("link", { name: /Edit profile/i }).click();
+  await page.getByLabel("About me").fill(`Freshly edited ${Date.now()}`);
+  await page.getByRole("button", { name: /^Save$/ }).click();
+  await expect(page).toHaveURL(/\/guests\/[^/]+$/);
+  // The save redirects here itself; a click that lands while that navigation
+  // is still in flight is dropped, so retry until it takes.
+  await expect(async () => {
+    await page.getByRole("link", { name: "Back to attendees" }).click();
+    await expect(page).toHaveURL(/\/guests$/, { timeout: 2000 });
+  }).toPass();
+
+  const attendees = page
+    .getByRole("list")
+    .filter({ has: page.getByRole("link", { name: "Alice Test" }) })
+    .getByRole("listitem");
+
+  // The seeded update times are all hours or days old, so the edit above makes
+  // Alice the most recent — and alphabetically she is not first.
+  await expect(attendees.first()).toContainText("Ahmad Karimi");
+
+  await page.getByLabel("Sort by").selectOption("Recently updated");
+  await expect(attendees.first()).toContainText("Alice Test");
+  await expect(attendees.first()).toContainText("updated just now");
+
+  // A search is ranked by relevance, so sorting is off the table while one is
+  // active.
+  await page.getByLabel("Search").fill("Alice");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(page).toHaveURL(/[?&]q=Alice/);
+  await expect(page.getByLabel("Sort by")).toBeDisabled();
+});

--- a/tests/integration/comment-likes.test.ts
+++ b/tests/integration/comment-likes.test.ts
@@ -83,16 +83,20 @@ describe("comment likes", () => {
 
   it("carries each liker's avatar, so it can be shown next to their name", async () => {
     const { event, guest, proposal, comment } = await setup();
-    await getRepositories().guests.updateProfile(guest.id, {
-      name: guest.name,
-      aboutMe: null,
-      avatarUrl: "/uploads/avatar.webp",
-      pronouns: null,
-      basedIn: null,
-      prompts: null,
-      languages: null,
-      contacts: null,
-    });
+    await getRepositories().guests.updateProfile(
+      guest.id,
+      {
+        name: guest.name,
+        aboutMe: null,
+        avatarUrl: "/uploads/avatar.webp",
+        pronouns: null,
+        basedIn: null,
+        prompts: null,
+        languages: null,
+        contacts: null,
+      },
+      new Date()
+    );
 
     await toggleCommentLike({ commentId: comment.id, eventSlug: event.slug });
 

--- a/tests/integration/guest-profile-repos.test.ts
+++ b/tests/integration/guest-profile-repos.test.ts
@@ -66,16 +66,20 @@ describe("guest profile repositories", () => {
       const { guests } = getRepositories();
       const guest = await createGuest({ name: "Old", email: "g@test.example" });
 
-      const updated = await guests.updateProfile(guest.id, {
-        name: "New Name",
-        aboutMe: "I love unconferences.",
-        avatarUrl: "/media/uploads/avatar.png",
-        pronouns: "they/them",
-        basedIn: null,
-        prompts: null,
-        languages: null,
-        contacts: null,
-      });
+      const updated = await guests.updateProfile(
+        guest.id,
+        {
+          name: "New Name",
+          aboutMe: "I love unconferences.",
+          avatarUrl: "/media/uploads/avatar.png",
+          pronouns: "they/them",
+          basedIn: null,
+          prompts: null,
+          languages: null,
+          contacts: null,
+        },
+        new Date()
+      );
 
       expect(updated).toMatchObject({
         id: guest.id,
@@ -93,24 +97,108 @@ describe("guest profile repositories", () => {
     });
   });
 
+  describe("guests.updateProfile profileUpdatedAt", () => {
+    const profile = {
+      name: "Someone",
+      aboutMe: null,
+      avatarUrl: null,
+      pronouns: null,
+      basedIn: null,
+      prompts: null,
+      languages: null,
+      contacts: null,
+    };
+    const FIRST = new Date("2026-05-01T10:00:00Z");
+    const LATER = new Date("2026-06-02T09:30:00Z");
+
+    it("is null until the guest fills something in", async () => {
+      const { guests } = getRepositories();
+      const guest = await createGuest({ name: "Someone" });
+
+      expect((await guests.findById(guest.id))?.profileUpdatedAt).toBeNull();
+
+      await guests.updateProfile(
+        guest.id,
+        { ...profile, basedIn: "Vienna" },
+        FIRST
+      );
+
+      expect((await guests.findById(guest.id))?.profileUpdatedAt).toEqual(
+        FIRST
+      );
+    });
+
+    it("is not touched when the profile is saved unchanged", async () => {
+      const { guests } = getRepositories();
+      const guest = await createGuest({ name: "Someone" });
+      const filled = { ...profile, languages: ["Dutch"] };
+      await guests.updateProfile(guest.id, filled, FIRST);
+
+      await guests.updateProfile(guest.id, filled, LATER);
+
+      expect((await guests.findById(guest.id))?.profileUpdatedAt).toEqual(
+        FIRST
+      );
+    });
+
+    it("is bumped when the guest renames themselves", async () => {
+      const { guests } = getRepositories();
+      const guest = await createGuest({ name: "Someone" });
+
+      await guests.updateProfile(
+        guest.id,
+        { ...profile, name: "Someone Else" },
+        LATER
+      );
+
+      expect((await guests.findById(guest.id))?.profileUpdatedAt).toEqual(
+        LATER
+      );
+    });
+
+    it("is bumped when a public profile field changes", async () => {
+      const { guests } = getRepositories();
+      const guest = await createGuest({ name: "Someone" });
+      await guests.updateProfile(
+        guest.id,
+        { ...profile, aboutMe: "First draft" },
+        FIRST
+      );
+
+      await guests.updateProfile(
+        guest.id,
+        { ...profile, aboutMe: "Second draft" },
+        LATER
+      );
+
+      expect((await guests.findById(guest.id))?.profileUpdatedAt).toEqual(
+        LATER
+      );
+    });
+  });
+
   describe("guests.updateProfile extended fields", () => {
     it("stores and returns basedIn, prompts, languages, and contacts", async () => {
       const { guests } = getRepositories();
       const guest = await createGuest();
 
-      const updated = await guests.updateProfile(guest.id, {
-        name: guest.name,
-        aboutMe: null,
-        avatarUrl: null,
-        pronouns: null,
-        basedIn: "Berlin",
-        prompts: [{ prompt: "Ask me about", answer: "Urban beekeeping" }],
-        languages: ["German", "Swiss German"],
-        contacts: [
-          { type: "signal", value: "@someone.01" },
-          { type: "other", label: "Matrix", value: "@someone:matrix.org" },
-        ],
-      });
+      const updated = await guests.updateProfile(
+        guest.id,
+        {
+          name: guest.name,
+          aboutMe: null,
+          avatarUrl: null,
+          pronouns: null,
+          basedIn: "Berlin",
+          prompts: [{ prompt: "Ask me about", answer: "Urban beekeeping" }],
+          languages: ["German", "Swiss German"],
+          contacts: [
+            { type: "signal", value: "@someone.01" },
+            { type: "other", label: "Matrix", value: "@someone:matrix.org" },
+          ],
+        },
+        new Date()
+      );
 
       expect(updated).toMatchObject({ id: guest.id, basedIn: "Berlin" });
       const fetched = await guests.findById(guest.id);

--- a/tests/integration/guest-search-attendees.test.ts
+++ b/tests/integration/guest-search-attendees.test.ts
@@ -53,16 +53,20 @@ describe("guests.listAttendees", () => {
   it("includes the public profile fields used by search", async () => {
     const guest = await createGuest({ name: "Polyglot" });
     const repos = getRepositories();
-    await repos.guests.updateProfile(guest.id, {
-      name: guest.name,
-      aboutMe: "Hello",
-      avatarUrl: null,
-      pronouns: "they/them",
-      basedIn: "Lisbon",
-      prompts: [{ prompt: "Offering", answer: "Sourdough starters" }],
-      languages: ["Portuguese"],
-      contacts: null,
-    });
+    await repos.guests.updateProfile(
+      guest.id,
+      {
+        name: guest.name,
+        aboutMe: "Hello",
+        avatarUrl: null,
+        pronouns: "they/them",
+        basedIn: "Lisbon",
+        prompts: [{ prompt: "Offering", answer: "Sourdough starters" }],
+        languages: ["Portuguese"],
+        contacts: null,
+      },
+      new Date()
+    );
 
     const rows = await repos.guests.listAttendees({});
 
@@ -73,5 +77,34 @@ describe("guests.listAttendees", () => {
       languages: ["Portuguese"],
       prompts: [{ prompt: "Offering", answer: "Sourdough starters" }],
     });
+  });
+
+  it("exposes when each profile was last updated, so the list can sort by it", async () => {
+    const updatedAt = new Date("2026-04-10T08:00:00Z");
+    const active = await createGuest({ name: "Active" });
+    await createGuest({ name: "Never Edited" });
+    const repos = getRepositories();
+    await repos.guests.updateProfile(
+      active.id,
+      {
+        name: active.name,
+        aboutMe: "Hello",
+        avatarUrl: null,
+        pronouns: null,
+        basedIn: null,
+        prompts: null,
+        languages: null,
+        contacts: null,
+      },
+      updatedAt
+    );
+
+    const rows = await repos.guests.listAttendees({});
+
+    const byName = Object.fromEntries(
+      rows.map((r) => [r.name, r.profileUpdatedAt])
+    );
+    expect(byName["Active"]).toEqual(updatedAt);
+    expect(byName["Never Edited"]).toBeNull();
   });
 });

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -233,6 +233,74 @@ describe("runMigrations", () => {
     ]);
   });
 
+  // The profile columns of `guests` as they stand just before the
+  // profile_updated_at migration.
+  const preProfileUpdatedGuestsTable = `CREATE TABLE \`guests\` (
+      \`id\` text PRIMARY KEY NOT NULL,
+      \`name\` text NOT NULL,
+      \`email\` text NOT NULL,
+      \`about_me\` text,
+      \`pronouns\` text,
+      \`based_in\` text,
+      \`prompts\` text,
+      \`languages\` text,
+      \`contacts\` text,
+      \`avatar_url\` text
+    );`;
+
+  function readProfileUpdatedMigration(): string[] {
+    const drizzleDir = path.join(process.cwd(), "drizzle");
+    const file = fs
+      .readdirSync(drizzleDir)
+      .filter((f) => /^\d+_.*\.sql$/.test(f))
+      .find((f) =>
+        fs
+          .readFileSync(path.join(drizzleDir, f), "utf8")
+          .includes("`profile_updated_at`")
+      );
+    expect(file, "profile_updated_at migration not found").toBeDefined();
+    return fs
+      .readFileSync(path.join(drizzleDir, file!), "utf8")
+      .split("--> statement-breakpoint\n");
+  }
+
+  it("the profile_updated_at migration dates the profiles that have content", () => {
+    writeMigrations(tmpDir, [
+      [
+        preProfileUpdatedGuestsTable,
+        `INSERT INTO guests (id, name, email, about_me, pronouns, based_in, prompts, languages, contacts, avatar_url) VALUES
+           ('g1', 'Imported only', 'i@test.example', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+           ('g2', 'Wrote a bio', 'b@test.example', 'Hello', NULL, NULL, NULL, NULL, NULL, NULL),
+           ('g3', 'Listed a language', 'l@test.example', NULL, NULL, NULL, NULL, '["Dutch"]', NULL, NULL),
+           ('g4', 'Uploaded a photo', 'p@test.example', NULL, NULL, NULL, NULL, NULL, NULL, '/media/a.webp'),
+           ('g5', 'Saved an empty form', 'e@test.example', '', '', '', '[]', '[]', '[]', NULL);`,
+      ],
+      readProfileUpdatedMigration(),
+    ]);
+
+    runMigrations(sqlite, tmpDir);
+
+    const rows = sqlite
+      .prepare("SELECT id, profile_updated_at FROM guests ORDER BY id")
+      .all() as { id: string; profile_updated_at: string | null }[];
+    const dated = Object.fromEntries(
+      rows.map((r) => [r.id, r.profile_updated_at])
+    );
+
+    // Nothing self-entered: no date, so they sort last under "recently
+    // updated" instead of claiming an edit that never happened.
+    expect(dated.g1).toBeNull();
+    expect(dated.g5).toBeNull();
+    // There is no history to date these from, so they share the migration's
+    // own instant: enough to rank filled-in profiles ahead of empty ones.
+    expect(dated.g2).toEqual(expect.any(String));
+    expect(dated.g3).toEqual(dated.g2);
+    expect(dated.g4).toEqual(dated.g2);
+    // Stored the way the app writes the column, or reading it back breaks.
+    expect(dated.g2).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+    expect(Number.isNaN(new Date(dated.g2!).getTime())).toBe(false);
+  });
+
   it("leaves foreign key enforcement enabled afterwards", () => {
     writeMigration(tmpDir, ["CREATE TABLE t (id text PRIMARY KEY);"]);
 

--- a/tests/integration/profile-action.test.ts
+++ b/tests/integration/profile-action.test.ts
@@ -90,6 +90,21 @@ describe("updateProfileAction", () => {
     });
   });
 
+  it("records when the profile was updated", async () => {
+    const guest = await createGuest({ name: "Guest" });
+    cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));
+    const before = new Date();
+
+    expect(await updateProfileAction({ name: "Guest", aboutMe: "Hi" })).toEqual(
+      { ok: true }
+    );
+
+    const updated = await getRepositories().guests.findById(guest.id);
+    expect(updated?.profileUpdatedAt?.getTime()).toBeGreaterThanOrEqual(
+      before.getTime()
+    );
+  });
+
   it("updates name, aboutMe, pronouns and avatar for the current user", async () => {
     const guest = await createGuest({ name: "Old" });
     cookieJar.set(GUEST_COOKIE_NAME, openGuestValue(guest.id));

--- a/tests/unit/attendee-search.test.ts
+++ b/tests/unit/attendee-search.test.ts
@@ -165,3 +165,51 @@ describe("searchAttendees", () => {
     expect(result.map((r) => r.name)).toEqual(["Anna", "Zoe"]);
   });
 });
+
+describe("searchAttendees sorted by recently updated", () => {
+  const updated = (name: string, iso: string | null) =>
+    attendee({
+      name,
+      profileUpdatedAt: iso === null ? null : new Date(iso),
+    });
+
+  it("puts the most recently updated profile first", () => {
+    const rows = [
+      updated("Older", "2026-01-01T00:00:00Z"),
+      updated("Newest", "2026-03-01T00:00:00Z"),
+      updated("Middle", "2026-02-01T00:00:00Z"),
+    ];
+
+    const result = searchAttendees(rows, "", "updated");
+    expect(result.map((r) => r.name)).toEqual(["Newest", "Middle", "Older"]);
+  });
+
+  it("sorts profiles never updated last, among themselves by name", () => {
+    const rows = [
+      updated("Zoe", null),
+      updated("Anna", null),
+      updated("Updated", "2026-01-01T00:00:00Z"),
+    ];
+
+    const result = searchAttendees(rows, "", "updated");
+    expect(result.map((r) => r.name)).toEqual(["Updated", "Anna", "Zoe"]);
+  });
+
+  it("keeps relevance ranking while a query is active", () => {
+    const rows = [
+      attendee({
+        name: "Foodie",
+        aboutMe: "I adore Italian food",
+        profileUpdatedAt: new Date("2026-03-01T00:00:00Z"),
+      }),
+      attendee({
+        name: "Speaker",
+        languages: ["Italian"],
+        profileUpdatedAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+    ];
+
+    const result = searchAttendees(rows, "Italian", "updated");
+    expect(result.map((r) => r.name)).toEqual(["Speaker", "Foodie"]);
+  });
+});

--- a/tests/unit/relative-time.test.ts
+++ b/tests/unit/relative-time.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { formatRelativeTime } from "@/utils/relative-time";
+
+const NOW = new Date("2026-03-15T12:00:00Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("formatRelativeTime", () => {
+  it("collapses anything under a minute to 'just now'", () => {
+    expect(formatRelativeTime(ago(20 * SECOND), NOW)).toBe("just now");
+  });
+
+  it("counts minutes, hours and days", () => {
+    expect(formatRelativeTime(ago(5 * MINUTE), NOW)).toBe("5 minutes ago");
+    expect(formatRelativeTime(ago(3 * HOUR), NOW)).toBe("3 hours ago");
+    expect(formatRelativeTime(ago(3 * DAY), NOW)).toBe("3 days ago");
+  });
+
+  it("names yesterday, last month and last year", () => {
+    expect(formatRelativeTime(ago(DAY), NOW)).toBe("yesterday");
+    expect(formatRelativeTime(ago(45 * DAY), NOW)).toBe("last month");
+    expect(formatRelativeTime(ago(400 * DAY), NOW)).toBe("last year");
+  });
+
+  it("treats a timestamp in the future as just now", () => {
+    // The two clocks involved (the server that wrote it, the server that
+    // renders) can disagree; "in 2 minutes" would be nonsense to the reader.
+    expect(formatRelativeTime(ago(-2 * MINUTE), NOW)).toBe("just now");
+  });
+});

--- a/utils/attendee-search.ts
+++ b/utils/attendee-search.ts
@@ -37,21 +37,45 @@ function rank(attendee: Attendee, query: string): number {
   return 0;
 }
 
+export const ATTENDEE_SORTS = [
+  { value: "name", label: "Name (A–Z)" },
+  { value: "updated", label: "Recently updated" },
+] as const;
+
+export type AttendeeSort = (typeof ATTENDEE_SORTS)[number]["value"];
+
+export const DEFAULT_ATTENDEE_SORT: AttendeeSort = "name";
+
 /**
  * In-memory search over the full attendee list. Case-insensitive substring
  * matching, ranked by tier (name > declared language > free text), ties by
- * name. An empty query returns everyone in name order. Pagination is the
+ * name. An empty query returns everyone in `sort` order. Pagination is the
  * caller's job (slice the result).
+ *
+ * A query overrides `sort`: relevance ranking is the more useful answer to a
+ * search, and an explicit sort would discard it.
  */
 export function searchAttendees<A extends Attendee>(
   attendees: A[],
-  query: string
+  query: string,
+  sort: AttendeeSort = DEFAULT_ATTENDEE_SORT
 ): A[] {
   const byName = (a: A, b: A) =>
     a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
 
+  // Profiles never updated have no place on a recency axis, so they keep the
+  // default ordering at the end of the list rather than at an arbitrary date.
+  const byRecency = (a: A, b: A) => {
+    const at = a.profileUpdatedAt?.getTime() ?? null;
+    const bt = b.profileUpdatedAt?.getTime() ?? null;
+    if (at === bt) return byName(a, b);
+    if (at === null) return 1;
+    if (bt === null) return -1;
+    return bt - at;
+  };
+
   const q = query.trim();
-  if (!q) return [...attendees].sort(byName);
+  if (!q) return [...attendees].sort(sort === "updated" ? byRecency : byName);
 
   return attendees
     .map((attendee) => ({ attendee, rank: rank(attendee, q) }))

--- a/utils/relative-time.ts
+++ b/utils/relative-time.ts
@@ -1,0 +1,31 @@
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+// Calendar-free approximations: the label is a rough hint ("last month"), and
+// rounding a 31st onto a 30th would not change what the reader takes from it.
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+const UNITS: [ms: number, unit: Intl.RelativeTimeFormatUnit][] = [
+  [YEAR, "year"],
+  [MONTH, "month"],
+  [DAY, "day"],
+  [HOUR, "hour"],
+  [MINUTE, "minute"],
+];
+
+const format = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+/**
+ * A coarse "3 days ago" / "yesterday" label for `date` seen from `now`. Both
+ * are explicit so the caller decides which clock applies (server render, dev
+ * fake clock). Sub-minute and future timestamps — the two servers involved
+ * need not agree to the second — collapse to "just now".
+ */
+export function formatRelativeTime(date: Date, now: Date): string {
+  const elapsed = now.getTime() - date.getTime();
+  for (const [ms, unit] of UNITS) {
+    if (elapsed >= ms) return format.format(-Math.floor(elapsed / ms), unit);
+  }
+  return "just now";
+}


### PR DESCRIPTION
Alphabetical order only serves lookup. Before an event people also want to
see who has filled in or changed their profile, which nothing in the list
made visible.

Recency needs a timestamp the schema didn't have, so guests gains a nullable
profileUpdatedAt, stamped only when a public profile field actually changes.
There is no history to date existing rows from, so the migration backfills
every profile with any self-entered field to its own instant: they tie, but
rank ahead of the profiles nobody ever filled in, which stay NULL and sort
last. Real edit times accumulate from here on.

Sorting by "based in" (the issue's secondary suggestion) is deliberately left
out: free text sorts Berlin, berlin, germany and DE into unrelated places.

Closes #712

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- jip:pushed-commit=825e0394ae33d5473eb0e0f8125de33c5e82ea1a -->