### PR TITLE
feat: render markdown in prompt answers and contact details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- **Formatting and clickable links in the rest of your profile**: the answers to the conversation starters and your contact details now accept Markdown, like "About me" already did — so a link can be given a name (`[my blog](https://example.com)`), and a web address or email address pasted in plainly becomes clickable on its own
+
 ### Changed
 
 - **Attendee search now looks at the whole profile**: searching the attendee directory also matches the contact details attendees chose to publish (handles, usernames, websites, and the service they belong to) and the prompt questions themselves, not only their answers — so knowing someone's handle is enough to find them. Private email addresses are never searched; they are not part of a profile

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -1,11 +1,7 @@
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { getRepositories } from "@/db/container";
-import type {
-  ContactType,
-  ProfileContact,
-  ProfilePrompt,
-} from "@/db/repositories/interfaces";
+import type { ContactType, ProfilePrompt } from "@/db/repositories/interfaces";
 import { CONTACT_TYPE_LABELS } from "@/model/guest";
 import {
   EnvelopeIcon,
@@ -24,7 +20,7 @@ import { eventNameToSlug } from "@/utils/utils";
 import { sanitizeGuest } from "@/utils/guests";
 import { verifiedCurrentUser } from "@/utils/acting-guest";
 import { ZoomableAvatar } from "../zoomable-avatar";
-import { Markdown } from "@/app/(site)/markdown";
+import { InlineMarkdown, Markdown } from "@/app/(site)/markdown";
 import { ComponentType, JSX, PropsWithChildren, SVGProps } from "react";
 import {
   ProfileItem,
@@ -120,7 +116,9 @@ export default async function GuestProfilePage(props: {
       {orderPrompts(guest.prompts ?? []).map(({ prompt, answer }) => (
         <section key={prompt}>
           <h2 className="text-lg font-semibold mb-2">{prompt}</h2>
-          <p className="text-gray-800">{answer}</p>
+          <p className="text-gray-800">
+            <InlineMarkdown>{answer}</InlineMarkdown>
+          </p>
         </section>
       ))}
 
@@ -155,7 +153,7 @@ export default async function GuestProfilePage(props: {
                         CONTACT_TYPE_LABELS[contact.type]}
                       :
                     </span>{" "}
-                    <ContactValue contact={contact} />
+                    <InlineMarkdown>{contact.value}</InlineMarkdown>
                   </span>
                 </li>
               );
@@ -207,37 +205,6 @@ function orderPrompts(prompts: ProfilePrompt[]): ProfilePrompt[] {
     ...CORE_PROMPTS.flatMap((core) => prompts.filter((p) => p.prompt === core)),
     ...prompts.filter((p) => !CORE_PROMPTS.includes(p.prompt)),
   ];
-}
-
-/**
- * Values are attendee-supplied: only turn them into links when they are
- * unambiguously safe (mailto for email, http(s) URLs for websites).
- */
-function ContactValue({ contact }: { contact: ProfileContact }) {
-  const linkClass = "text-rose-500 hover:text-rose-600 underline";
-  if (contact.type === "email") {
-    return (
-      <a className={linkClass} href={`mailto:${contact.value}`}>
-        {contact.value}
-      </a>
-    );
-  }
-  if (
-    contact.type === "website" &&
-    /^https?:\/\//i.test(contact.value.trim())
-  ) {
-    return (
-      <a
-        className={linkClass}
-        href={contact.value.trim()}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {contact.value}
-      </a>
-    );
-  }
-  return <>{contact.value}</>;
 }
 
 function ProfileList({

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -427,6 +427,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           >
             Suggest a prompt
           </button>
+          <MarkdownHint />
         </DisclosureSection>
 
         <DisclosureSection
@@ -553,6 +554,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           >
             Add contact
           </button>
+          <MarkdownHint />
           <span className="text-rose-400 text-sm">
             {form.formState.errors.contacts?.root?.message ??
               form.formState.errors.contacts?.message}

--- a/app/(site)/markdown.tsx
+++ b/app/(site)/markdown.tsx
@@ -17,7 +17,7 @@ const heading = (weight: string, size: string) =>
     );
   };
 
-const components: Components = {
+const blockComponents: Components = {
   h1: heading("font-bold", "text-[1.1em]"),
   h2: heading("font-bold", "text-[1.05em]"),
   h3: heading("font-semibold", "text-[1em]"),
@@ -28,7 +28,9 @@ const components: Components = {
   a: ({ href, children }) => (
     <a
       href={href}
-      target="_blank"
+      // mailto:/tel: hand off to another app; a new tab would just be left
+      // behind blank.
+      target={/^https?:/i.test(href ?? "") ? "_blank" : undefined}
       rel="noopener noreferrer nofollow"
       className="text-rose-500 underline hover:text-rose-600"
     >
@@ -62,8 +64,56 @@ const components: Components = {
   hr: () => <hr className="my-3 border-gray-200" />,
 };
 
+// Fields written in a single-line input and shown inside a line of text (a
+// contact row, a prompt answer): nothing block-level may come out of them, so
+// every block element is unwrapped to its text and paragraphs disappear.
+const INLINE_DISALLOWED_ELEMENTS = [
+  ...MARKDOWN_DISALLOWED_ELEMENTS,
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "pre",
+  "hr",
+];
+
+// Spread rather than picking the inline overrides by hand, so a styling change
+// to a link or to inline code can't reach one renderer and not the other. The
+// block entries are dead weight: their elements never survive.
+const inlineComponents: Components = {
+  ...blockComponents,
+  p: ({ children }) => <>{children}</>,
+};
+
 export function MarkdownHint() {
   return <p className="text-xs text-gray-500">Markdown supported</p>;
+}
+
+function MarkdownRoot({
+  children,
+  components,
+  disallowedElements,
+}: {
+  children: string | null | undefined;
+  components: Components;
+  disallowedElements: string[];
+}) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      disallowedElements={disallowedElements}
+      unwrapDisallowed
+      components={components}
+    >
+      {children ?? ""}
+    </ReactMarkdown>
+  );
 }
 
 export function Markdown({
@@ -72,13 +122,26 @@ export function Markdown({
   children: string | null | undefined;
 }) {
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkBreaks]}
+    <MarkdownRoot
+      components={blockComponents}
       disallowedElements={MARKDOWN_DISALLOWED_ELEMENTS}
-      unwrapDisallowed
-      components={components}
     >
-      {children ?? ""}
-    </ReactMarkdown>
+      {children}
+    </MarkdownRoot>
+  );
+}
+
+export function InlineMarkdown({
+  children,
+}: {
+  children: string | null | undefined;
+}) {
+  return (
+    <MarkdownRoot
+      components={inlineComponents}
+      disallowedElements={INLINE_DISALLOWED_ELEMENTS}
+    >
+      {children}
+    </MarkdownRoot>
   );
 }

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -190,6 +190,10 @@ After picking your name, open "Edit profile" to set your About me,
 pronouns, and avatar. These are visible to other attendees wherever your
 name appears (proposals, hosting, RSVPs).
 
+About me, the answers to the conversation starters, and your contact details
+all accept Markdown, so you can add bold text or a named link — and a web
+address or email address you paste in becomes clickable on its own.
+
 ![Edit profile form with name, pronouns, avatar, and a Markdown-supported about-me field](../screenshots/edit-profile.webp)
 
 ## Protect your name

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -219,7 +219,9 @@ test.describe("Edit profile", () => {
       await leftoverRows.first().click();
     }
 
-    await page.getByLabel("Ask me about").fill("Urban beekeeping");
+    await page
+      .getByLabel("Ask me about")
+      .fill("Urban beekeeping, see https://bees.example.com");
 
     // Suggested prompts can be swapped in place for a different one. The
     // suggestion is random, so find which pool prompt is on screen. One
@@ -252,6 +254,13 @@ test.describe("Edit profile", () => {
     await page.getByLabel("Contact type").selectOption("Signal");
     await page.getByLabel("Contact value").fill("@alice.01");
 
+    await page.getByRole("button", { name: "Add contact" }).click();
+    await page.getByLabel("Contact type").nth(1).selectOption("Website");
+    await page
+      .getByLabel("Contact value")
+      .nth(1)
+      .fill("[my homepage](https://alice.example.com)");
+
     await page.getByRole("button", { name: /^Save$/ }).click();
 
     // Profile page shows every filled-in section.
@@ -267,6 +276,14 @@ test.describe("Edit profile", () => {
     await expect(page.getByText("Italian")).toBeVisible();
     await expect(page.getByText("Signal:")).toBeVisible();
     await expect(page.getByText("@alice.01")).toBeVisible();
+
+    // Markdown in prompt answers and contacts: pasted links are clickable.
+    await expect(
+      page.getByRole("link", { name: "https://bees.example.com" })
+    ).toHaveAttribute("href", "https://bees.example.com");
+    await expect(
+      page.getByRole("link", { name: "my homepage" })
+    ).toHaveAttribute("href", "https://alice.example.com");
 
     // The directory row shows Based in, and search finds the language.
     await page.getByRole("link", { name: "Back to attendees" }).click();

--- a/tests/unit/markdown.test.tsx
+++ b/tests/unit/markdown.test.tsx
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Markdown } from "@/app/(site)/markdown";
+import { InlineMarkdown, Markdown } from "@/app/(site)/markdown";
 import { stripMarkdown } from "@/utils/markdown";
 
 function render(markdown: string): string {
   return renderToStaticMarkup(<Markdown>{markdown}</Markdown>);
+}
+
+function renderInline(markdown: string): string {
+  return renderToStaticMarkup(<InlineMarkdown>{markdown}</InlineMarkdown>);
 }
 
 describe("Markdown component", () => {
@@ -56,6 +60,15 @@ describe("Markdown component", () => {
     expect(html).toContain('href="https://example.com/page"');
   });
 
+  // A new tab is right for a web page, but a mail or phone link hands off to
+  // another app and would leave a blank tab behind.
+  it("does not open mail and phone links in a new tab", () => {
+    expect(render("alice@example.com")).not.toContain('target="_blank"');
+    expect(render("[call](tel:+491701234567)")).not.toContain(
+      'target="_blank"'
+    );
+  });
+
   it("does not render markdown images", () => {
     const html = render("![tracking pixel](https://evil.example/p.gif)");
     expect(html).not.toContain("<img");
@@ -71,6 +84,57 @@ describe("Markdown component", () => {
   it("does not render tables but keeps their text", () => {
     const html = render("| a | b |\n| - | - |\n| c | d |");
     expect(html).not.toContain("<table");
+  });
+});
+
+describe("InlineMarkdown component", () => {
+  it("renders emphasis and links without wrapping them in a paragraph", () => {
+    const html = renderInline("**bold** and [my site](https://example.com)");
+    expect(html).not.toContain("<p");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it("autolinks bare URLs", () => {
+    const html = renderInline("https://example.com/page");
+    expect(html).toContain('href="https://example.com/page"');
+  });
+
+  it("autolinks bare email addresses", () => {
+    const html = renderInline("alice@example.com");
+    expect(html).toContain('href="mailto:alice@example.com"');
+  });
+
+  it("keeps block markdown as plain inline text", () => {
+    const html = renderInline("# Title");
+    expect(html).not.toMatch(/<h[1-6]/);
+    expect(html).not.toContain("<p");
+    expect(html).toContain("Title");
+  });
+
+  it("does not render lists", () => {
+    const html = renderInline("- one\n- two");
+    expect(html).not.toContain("<ul");
+    expect(html).not.toContain("<li");
+    expect(html).toContain("one");
+    expect(html).toContain("two");
+  });
+
+  it("escapes raw HTML instead of rendering it", () => {
+    const html = renderInline('<img src="x" onerror="alert(1)">');
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("drops javascript: URLs", () => {
+    const html = renderInline("[click](javascript:alert(1))");
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("leaves handles with underscores untouched", () => {
+    const html = renderInline("@alice_the_bee");
+    expect(html).not.toContain("<em>");
+    expect(html).toContain("@alice_the_bee");
   });
 });
 


### PR DESCRIPTION
Both are single-line fields shown inside a line of text, so they get an
inline renderer with every block element unwrapped. GFM autolinking also
replaces the profile page's hand-rolled mailto/website linking.

<!-- jip:pushed-commit=8effef071ed87f22f167a276744c7c68d23a4dd5 -->