### PR TITLE
test: give the added session a unique title so retries can pass

### DIFF
--- a/tests/e2e/add-session.spec.ts
+++ b/tests/e2e/add-session.spec.ts
@@ -17,7 +17,9 @@ test("a newly added session appears on the overview and can be opened", async ({
     page.getByRole("heading", { name: /Add a session/i })
   ).toBeVisible();
 
-  const sessionTitle = "Yak shaving";
+  // Unique per attempt: the DB is seeded once for the whole run, so a retry
+  // would otherwise find the session its failed predecessor already created.
+  const sessionTitle = `Yak shaving ${Date.now()}`;
   await page.getByRole("textbox").first().fill(sessionTitle);
 
   // Add a host via the combobox (a host is required to enable Submit).


### PR DESCRIPTION
The E2E database is seeded once per run, so a failed attempt left its
session behind and every retry found one more link with the same name.

<!-- jip:pushed-commit=a0b621d48d4cdaa59873f2d6b050ce19415e0ac6 -->