### PR TITLE
ci: let dependabot update the mailpit image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,30 @@ updates:
         patterns:
           - "*"
 
+  # Enable version updates for the mailpit image in docker-compose.dev.yml.
+  # Workflow `services:` images are out of Dependabot's reach
+  # (dependabot-core#5819), which is why CI starts mailpit from the compose file.
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    assignees:
+      - "omarkohl"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    ignore:
+      # Our own image in docker-compose.yml. Self-hosters choose the tag via
+      # SCHELLINGBOARD_VERSION; it is not a dependency to bump here.
+      - dependency-name: "schellingboard/schellingboard"
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -55,23 +55,15 @@ jobs:
       SMTP_URL: smtp://localhost:1025
       SMTP_FROM: Test <mailer-test@test.example>
 
-    services:
-      # e2e tests send real email to mailpit (see docs/dev/testing.md
-      # § Running tests). Same pinned image as docker-compose.dev.yml.
-      mailpit:
-        image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
-        ports:
-          - 1025:1025
-          - 8025:8025
-        options: >-
-          --health-cmd "/mailpit readyz"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 15
-
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7.0.1
+
+      # e2e tests send real email to mailpit (see docs/dev/testing.md
+      # § Running tests). Started from the compose file rather than as a service
+      # container so the image pin has one home that Dependabot can update.
+      - name: Start mailpit
+        run: docker compose -f docker-compose.dev.yml up -d --wait mailpit
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,24 +88,16 @@ jobs:
       SMTP_URL: smtp://localhost:1025
       SMTP_FROM: Test <mailer-test@test.example>
 
-    services:
-      # The mailer integration test sends real email to mailpit (see
-      # docs/dev/testing.md § Running tests). Same pinned image as
-      # docker-compose.dev.yml.
-      mailpit:
-        image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
-        ports:
-          - 1025:1025
-          - 8025:8025
-        options: >-
-          --health-cmd "/mailpit readyz"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 15
-
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7.0.1
+
+      # The mailer integration test sends real email to mailpit (see
+      # docs/dev/testing.md § Running tests). Started from the compose file
+      # rather than as a service container so the image pin has one home that
+      # Dependabot can update.
+      - name: Start mailpit
+        run: docker compose -f docker-compose.dev.yml up -d --wait mailpit
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Dependabot now keeps the mailpit image up to date. Its pin was repeated in `docker-compose.dev.yml` and in both CI workflows, and Dependabot cannot see a workflow's `services:` image ([dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819)), so CI now starts mailpit from the compose file and the pin has a single home. The image carries a tag as well as a digest, since a digest alone gives Dependabot no version to compare
 - The seed data gives Conference Gamma four more proposals: two hosted by Hana Kobayashi, whose profile is the most complete of the seeded guests, and two with no host yet. Both cases were previously only reachable through the random host assignment, which made them awkward to point a screenshot at
 
 ## [3.3.1] - 2026-08-08

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,10 +14,19 @@ services:
   #
   # [1]: https://mailpit.axllent.org/
   mailpit:
-    # If you update this pin, update it in the CI service containers too:
-    # the `test` job in .github/workflows/ci.yml and the `test-e2e` job in
-    # .github/workflows/ci-e2e.yml.
-    image: axllent/mailpit@sha256:956d688cbd13dca36c72d8e94c34d6d1cdf4a005aa6aa4ff6edaaac56c34d8df
+    # The only place the mailpit pin lives — CI starts mailpit from this file
+    # rather than declaring a service container, because Dependabot can update a
+    # compose file but not a workflow's `services:` image (dependabot-core#5819).
+    # Tag *and* digest: the digest is the actual pin, the tag is what Dependabot
+    # compares versions against (a digest on its own tells it nothing).
+    image: axllent/mailpit:v1.30.7@sha256:d5ecbb067db3705fa953d79e1b7f81ef84038df67aba6c52825d8c02a1ea748a
+    # CI sets neither variable and hardcodes these defaults in the MAILPIT_API_URL
+    # and SMTP_URL of both workflows — change a default here and change them too.
     ports:
       - "${MAILPIT_SMTP_PORT:-1025}:1025" # SMTP
       - "${MAILPIT_UI_PORT:-8025}:8025" # web UI
+    healthcheck:
+      test: ["CMD", "/mailpit", "readyz"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -58,9 +58,9 @@ SMTP_FROM='Test <mailer-test@test.example>'
 When these are unset (the default on a fresh checkout), the email tests are
 reported as skipped; when they are set but mailpit is unreachable, the tests
 fail. CI always sets them (in `.github/workflows/ci.yml` and
-`.github/workflows/ci-e2e.yml`, alongside a mailpit service container) and the
-tests fail there if the variables go missing, so they can never be silently
-skipped in CI.
+`.github/workflows/ci-e2e.yml`, where mailpit is started from
+`docker-compose.dev.yml` so its image pin lives in one place) and the tests fail
+there if the variables go missing, so they can never be silently skipped in CI.
 
 E2E tests run in their own workflow so that they can be skipped for changes
 that cannot affect the app — documentation, the landing page, repository


### PR DESCRIPTION
The pin was repeated in docker-compose.dev.yml and both CI workflows, and
Dependabot cannot see a workflow's `services:` image (dependabot-core#5819).
CI now starts mailpit from the compose file, so the pin has one home
Dependabot can reach. It needs a tag as well as a digest to have anything
to compare versions against, which moves the pin from v1.30.3 to v1.30.7.

<!-- jip:pushed-commit=98cc3564515dbc8c2011f4cd2d8b051b6e696866 -->