### PR TITLE
fix: mark the chosen vote with more than a colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **The vote you picked is now unmistakable**: a chosen vote button was marked only by a pale blue tint, which was nearly invisible to attendees using a dark-mode browser extension and to anyone who has trouble telling colours apart — so it was impossible to see whether you had voted at all, let alone which of the three you had chosen. The chosen button is now filled in dark with a check mark on it, and screen readers announce it as selected
+
 ### Added
 
 - **Sort the attendee directory by who edited their profile last**: a "Sort by" choice next to the filters switches the list between "Name (A–Z)" and "Recently updated", so it's easy to catch up on profiles that are new or have changed since you last looked. Each row shows when that profile was last edited ("updated 3 days ago"). Nothing recorded edit times before this version, so every profile that already has something in it is dated from the upgrade and they all rank together, ahead of the ones nobody has filled in — those show no date and come last. Real edit times build up from the upgrade onwards. While a search is active the list stays ordered by how well each profile matches, and the choice is unavailable

--- a/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
+++ b/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import clsx from "clsx";
 import { VoteChoice, type Vote } from "@/app/(site)/votes";
 import HoverTooltip from "@/app/(site)/hover-tooltip";
 import { UserContext, VotesContext } from "@/app/(site)/context";
@@ -122,61 +123,94 @@ export function VotingButtons({
     e.stopPropagation();
   };
 
+  const chosen = votes.find(
+    (vote) => vote.proposalId === proposalId && vote.guestId === currentUserId
+  )?.choice;
+
   return (
     <div
-      className={`flex gap-1 ${large ? "gap-2 sm:gap-3 justify-center" : "flex-row"}`}
+      className={clsx(
+        "flex",
+        large ? "gap-2 sm:gap-3 justify-center" : "gap-1.5 flex-row"
+      )}
     >
-      <HoverTooltip
-        text={votingEnabled ? "Interested" : votingDisabledText}
-        visible={true}
-        unavailable={!votingEnabled}
-      >
-        <button
-          type="button"
-          className={`rounded-md border border-black shadow-sm font-medium focus:ring-2 focus:ring-offset-2 text-black focus:outline-none
-            ${large ? "w-16 h-16 sm:w-20 sm:h-20 flex flex-col items-center justify-center" : "px-1 py-1"}
-            ${votingEnabled ? "" : "opacity-50 cursor-not-allowed grayscale"}
-            ${votes.some((vote) => vote.proposalId === proposalId && vote.choice === VoteChoice.interested && vote.guestId === currentUserId) ? "bg-blue-200" : "bg-white"}`}
-          onClick={(e) => handleVote(VoteChoice.interested, e)}
+      {VOTE_OPTIONS.map(({ choice, emoji, label }) => (
+        <HoverTooltip
+          key={label}
+          text={votingEnabled ? label : votingDisabledText}
+          visible={true}
+          unavailable={!votingEnabled}
         >
-          <div className={large ? "text-sm sm:text-lg mb-1" : ""}>❤️</div>
-          {large && <div className="text-[10px] sm:text-xs">Interested</div>}
-        </button>
-      </HoverTooltip>
-      <HoverTooltip
-        text={votingEnabled ? "Maybe" : votingDisabledText}
-        visible={true}
-        unavailable={!votingEnabled}
-      >
-        <button
-          type="button"
-          className={`rounded-md border border-black shadow-sm font-medium focus:ring-2 focus:ring-offset-2 text-black focus:outline-none
-            ${large ? "w-16 h-16 sm:w-20 sm:h-20 flex flex-col items-center justify-center" : "px-1 py-1"}
-            ${votingEnabled ? "" : "opacity-50 cursor-not-allowed grayscale"}
-            ${votes.some((vote) => vote.proposalId === proposalId && vote.choice === VoteChoice.maybe && vote.guestId === currentUserId) ? "bg-blue-200" : "bg-white"}`}
-          onClick={(e) => handleVote(VoteChoice.maybe, e)}
-        >
-          <div className={large ? "text-sm sm:text-lg mb-1" : ""}>⭐</div>
-          {large && <div className="text-[10px] sm:text-xs">Maybe</div>}
-        </button>
-      </HoverTooltip>
-      <HoverTooltip
-        text={votingEnabled ? "Skip" : votingDisabledText}
-        visible={true}
-        unavailable={!votingEnabled}
-      >
-        <button
-          type="button"
-          className={`rounded-md border border-black shadow-sm font-medium focus:ring-2 focus:ring-offset-2 text-black focus:outline-none
-            ${large ? "w-16 h-16 sm:w-20 sm:h-20 flex flex-col items-center justify-center" : "px-1 py-1"}
-            ${votingEnabled ? "" : "opacity-50 cursor-not-allowed grayscale"}
-            ${votes.some((vote) => vote.proposalId === proposalId && vote.choice === VoteChoice.skip && vote.guestId === currentUserId) ? "bg-blue-200" : "bg-white"}`}
-          onClick={(e) => handleVote(VoteChoice.skip, e)}
-        >
-          <div className={large ? "text-sm sm:text-lg mb-1" : ""}>👋🏽</div>
-          {large && <div className="text-[10px] sm:text-xs">Skip</div>}
-        </button>
-      </HoverTooltip>
+          <VoteButton
+            emoji={emoji}
+            label={label}
+            large={large}
+            selected={chosen === choice}
+            votingEnabled={votingEnabled}
+            onClick={(e) => handleVote(choice, e)}
+          />
+        </HoverTooltip>
+      ))}
     </div>
+  );
+}
+
+const VOTE_OPTIONS = [
+  { choice: VoteChoice.interested, emoji: "❤️", label: "Interested" },
+  { choice: VoteChoice.maybe, emoji: "⭐", label: "Maybe" },
+  { choice: VoteChoice.skip, emoji: "👋🏽", label: "Skip" },
+] as const;
+
+// The chosen vote must stay recognisable without perceiving hue: a light tint
+// against white collapsed into "no visible difference" under the Dark Reader
+// extension and for colourblind attendees (issue #802). Hence three redundant
+// cues — aria-pressed, a dark fill that keeps its luminance gap under any
+// recolouring, and a check mark — rather than a background colour alone.
+function VoteButton({
+  emoji,
+  label,
+  large,
+  selected,
+  votingEnabled,
+  // HoverTooltip clones this element to attach its aria wiring, so anything it
+  // passes has to reach the underlying <button>.
+  ...rest
+}: {
+  emoji: string;
+  label: string;
+  large: boolean;
+  selected: boolean;
+  votingEnabled: boolean;
+} & React.ComponentPropsWithoutRef<"button">) {
+  return (
+    <button
+      {...rest}
+      type="button"
+      aria-pressed={selected}
+      className={clsx(
+        "relative rounded-md border shadow-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400",
+        large
+          ? "w-16 h-16 sm:w-20 sm:h-20 flex flex-col items-center justify-center"
+          : "px-1 py-1",
+        !votingEnabled && "opacity-50 cursor-not-allowed grayscale",
+        selected
+          ? "bg-gray-800 border-gray-900 text-white ring-2 ring-gray-900"
+          : // gray-500 is the lightest border that still clears the 3:1 contrast
+            // the button's outline needs against white, being its only edge.
+            "bg-white border-gray-500 text-gray-700",
+        !selected && votingEnabled && "hover:bg-gray-100"
+      )}
+    >
+      <div className={large ? "text-sm sm:text-lg mb-1" : ""}>{emoji}</div>
+      {large && <div className="text-[10px] sm:text-xs">{label}</div>}
+      {selected && (
+        <span
+          aria-hidden="true"
+          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-white bg-gray-900 text-[9px] leading-none text-white"
+        >
+          ✓
+        </span>
+      )}
+    </button>
   );
 }

--- a/tests/e2e/voting.spec.ts
+++ b/tests/e2e/voting.spec.ts
@@ -25,25 +25,29 @@ test("should allow voting on proposals with different choices", async ({
   const interestedButton = proposalRow.getByRole("button", { name: "❤️" });
   await interestedButton.click();
 
-  // Verify the button shows active state (should have blue background)
-  await expect(interestedButton).toHaveClass(/bg-blue-200/);
+  // The chosen vote is exposed as a pressed toggle and marked with a check,
+  // not by background colour alone (see issue #802).
+  await expect(interestedButton).toHaveAttribute("aria-pressed", "true");
+  await expect(interestedButton).toContainText("✓");
 
   // Change vote to "Maybe" (⭐ emoji button)
   const maybeButton = proposalRow.getByRole("button", { name: "⭐" });
   await maybeButton.click();
 
   // Verify the maybe button is now active and interested is not
-  await expect(maybeButton).toHaveClass(/bg-blue-200/);
-  await expect(interestedButton).not.toHaveClass(/bg-blue-200/);
+  await expect(maybeButton).toHaveAttribute("aria-pressed", "true");
+  await expect(maybeButton).toContainText("✓");
+  await expect(interestedButton).toHaveAttribute("aria-pressed", "false");
+  await expect(interestedButton).not.toContainText("✓");
 
   // Change vote to "Skip" (👋🏽 emoji button)
   const skipButton = proposalRow.getByRole("button", { name: "👋🏽" });
   await skipButton.click();
 
   // Verify the skip button is now active and others are not
-  await expect(skipButton).toHaveClass(/bg-blue-200/);
-  await expect(maybeButton).not.toHaveClass(/bg-blue-200/);
-  await expect(interestedButton).not.toHaveClass(/bg-blue-200/);
+  await expect(skipButton).toHaveAttribute("aria-pressed", "true");
+  await expect(maybeButton).toHaveAttribute("aria-pressed", "false");
+  await expect(interestedButton).toHaveAttribute("aria-pressed", "false");
 });
 
 test("should navigate to quick voting and allow voting on proposals", async ({
@@ -139,8 +143,9 @@ test("votes from two users persist independently across reloads", async ({
   // The vote persists across a reload
   await page.reload();
   await expect(row).toBeVisible();
-  await expect(row.getByRole("button", { name: "❤️" })).toHaveClass(
-    /bg-blue-200/
+  await expect(row.getByRole("button", { name: "❤️" })).toHaveAttribute(
+    "aria-pressed",
+    "true"
   );
 
   // A second user votes on the same proposal with a different choice.
@@ -148,8 +153,9 @@ test("votes from two users persist independently across reloads", async ({
   // combined count is asserted per-user here; tally aggregation is covered
   // by tests/integration/voting.test.ts.)
   await selectUser(page, /Charlie Test/i);
-  await expect(row.getByRole("button", { name: "❤️" })).not.toHaveClass(
-    /bg-blue-200/
+  await expect(row.getByRole("button", { name: "❤️" })).toHaveAttribute(
+    "aria-pressed",
+    "false"
   );
   await Promise.all([
     page.waitForResponse(
@@ -161,15 +167,18 @@ test("votes from two users persist independently across reloads", async ({
   // Each user still sees their own vote after a reload
   await page.reload();
   await expect(row).toBeVisible();
-  await expect(row.getByRole("button", { name: "⭐" })).toHaveClass(
-    /bg-blue-200/
+  await expect(row.getByRole("button", { name: "⭐" })).toHaveAttribute(
+    "aria-pressed",
+    "true"
   );
   await selectUser(page, /Alice Test/i);
-  await expect(row.getByRole("button", { name: "❤️" })).toHaveClass(
-    /bg-blue-200/
+  await expect(row.getByRole("button", { name: "❤️" })).toHaveAttribute(
+    "aria-pressed",
+    "true"
   );
-  await expect(row.getByRole("button", { name: "⭐" })).not.toHaveClass(
-    /bg-blue-200/
+  await expect(row.getByRole("button", { name: "⭐" })).toHaveAttribute(
+    "aria-pressed",
+    "false"
   );
 });
 


### PR DESCRIPTION
A pale blue fill against white was the only cue for which of the three
vote buttons was selected. Under the Dark Reader extension both fills
collapse to near-identical darks, leaving voted and unvoted proposals
indistinguishable (#802), and the cue was invisible to colourblind
attendees and absent for screen readers either way. Encode the state
three ways instead: aria-pressed, a dark fill whose luminance gap
survives recolouring, and a check mark.

fixes #802

<!-- jip:pushed-commit=9bf970738b1d118738c362df675cad450b57be61 -->