### PR TITLE
fix: order comments and likes by insertion, not by random id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Internal
 
+- Comments and the likers of a comment are now ordered by when they were written, falling back to insertion order rather than their random id when two land in the same millisecond. `tests/integration/comment-likes.test.ts` failed intermittently in `make precommit` because of it, and the same coin flip could reorder a comment thread or a like avatar stack in production
 - Dependabot now keeps the mailpit image up to date. Its pin was repeated in `docker-compose.dev.yml` and in both CI workflows, and Dependabot cannot see a workflow's `services:` image ([dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819)), so CI now starts mailpit from the compose file and the pin has a single home. The image carries a tag as well as a digest, since a digest alone gives Dependabot no version to compare
 - Seeded guests with a profile now carry a last-edited date, spread over the past month, instead of all being undated — the seed writes guest rows directly, so nothing stamped them. "Recently updated" had nothing to sort in dev and demos
 - The seed data gives Conference Gamma four more proposals: two hosted by Hana Kobayashi, whose profile is the most complete of the seeded guests, and two with no host yet. Both cases were previously only reachable through the random host assignment, which made them awkward to point a screenshot at

--- a/db/repositories/sqlite/comments.ts
+++ b/db/repositories/sqlite/comments.ts
@@ -1,5 +1,6 @@
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, sql, type SQL } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import { nanoid } from "nanoid";
 import * as schema from "../../schema";
 import type { Comment, CommentLiker, CommentsRepository } from "../interfaces";
@@ -39,7 +40,10 @@ export class SqliteCommentsRepository implements CommentsRepository {
       )
       .leftJoin(schema.guests, eq(schema.comments.authorId, schema.guests.id))
       .where(eq(schema.proposalComments.proposalId, proposalId))
-      .orderBy(asc(schema.comments.createdTime), asc(schema.comments.id))
+      .orderBy(
+        asc(schema.comments.createdTime),
+        asc(insertionOrder(schema.comments))
+      )
       .all();
   }
 
@@ -63,7 +67,7 @@ export class SqliteCommentsRepository implements CommentsRepository {
       .where(inArray(schema.commentLikes.commentId, commentIds))
       .orderBy(
         asc(schema.commentLikes.createdTime),
-        asc(schema.commentLikes.guestId)
+        asc(insertionOrder(schema.commentLikes))
       )
       .all();
     for (const { commentId, id, name, avatarUrl } of rows) {
@@ -244,6 +248,12 @@ export class SqliteCommentsRepository implements CommentsRepository {
       }
     });
   }
+}
+
+// Ids are random nanoids, so they can't break a tie between two rows written in
+// the same millisecond; the implicit rowid is insertion order.
+function insertionOrder(table: SQLiteTable): SQL {
+  return sql`${table}.rowid`;
 }
 
 function toComment(row: CommentRow, likes: CommentLiker[] = []): Comment {

--- a/tests/integration/comment-likes.test.ts
+++ b/tests/integration/comment-likes.test.ts
@@ -132,6 +132,34 @@ describe("comment likes", () => {
     ]);
   });
 
+  it("keeps the pressing order for likes that land in the same millisecond", async () => {
+    const { event, proposal, comment } = await setup();
+    const guests = [
+      await createGuest({ eventId: event.id }),
+      await createGuest({ eventId: event.id }),
+    ];
+    // Press in descending id order, so a tiebreak on the (random) guest id
+    // would hand back the reverse of the order they were pressed in.
+    const likers = guests.sort((a, b) => (a.id < b.id ? 1 : -1));
+    const sameMillisecond = new Date();
+
+    for (const liker of likers) {
+      await getRepositories().comments.toggleLike({
+        commentId: comment.id,
+        guestId: liker.id,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    expect(await likesOn(proposal.id, comment.id)).toEqual(
+      likers.map((liker) => ({
+        id: liker.id,
+        name: liker.name,
+        avatarUrl: null,
+      }))
+    );
+  });
+
   it("refuses to like without a selected name", async () => {
     const { event, proposal, comment } = await setup();
     cookieJar.clear();

--- a/tests/integration/comments.test.ts
+++ b/tests/integration/comments.test.ts
@@ -139,6 +139,27 @@ describe("comments", () => {
     expect(comments.map((c) => c.body)).toEqual(["first", "second"]);
   });
 
+  it("lists comments posted in the same millisecond in the order they were posted", async () => {
+    const { guest, proposal } = await setup();
+    const { comments } = getRepositories();
+    const sameMillisecond = new Date();
+    const bodies = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th"];
+
+    for (const body of bodies) {
+      await comments.createForProposal({
+        proposalId: proposal.id,
+        authorId: guest.id,
+        body,
+        createdTime: sameMillisecond,
+      });
+    }
+
+    // Comment ids are random, so a tiebreak on the id would shuffle these.
+    expect(
+      (await comments.listByProposal(proposal.id)).map((c) => c.body)
+    ).toEqual(bodies);
+  });
+
   it("keeps each proposal's comments separate", async () => {
     const { event, guest, proposal } = await setup();
     const other = await createProposal(event.id, []);


### PR DESCRIPTION
createdTime only has millisecond resolution, so two comments (or two
likes) written in the same millisecond fell back to their nanoid — a coin
flip. That made comment-likes' "oldest first" test fail intermittently
in precommit, and could just as well reorder a thread or a like avatar
stack in production. Tiebreak on the implicit rowid instead, which is
actual insertion order.

<!-- jip:pushed-commit=1ad0c081904ab38928e549e7df59eba17d604c70 -->