### PR TITLE
refactor: name colour roles instead of palette shades

### DIFF
--- a/app/(site)/[eventSlug]/comment-likes.tsx
+++ b/app/(site)/[eventSlug]/comment-likes.tsx
@@ -70,8 +70,8 @@ export function CommentLikes({
           aria-pressed={liked}
           className={`cursor-pointer disabled:opacity-50 ${
             liked
-              ? "font-semibold text-rose-500 hover:text-rose-600"
-              : "hover:text-gray-800 hover:underline"
+              ? "font-semibold text-brand-fg hover:text-brand-fg-hover"
+              : "hover:text-fg hover:underline"
           }`}
         >
           {liked ? "Liked" : "Like"}
@@ -91,12 +91,12 @@ export function CommentLikes({
               setPreviewing(false);
               setShowingLikers(true);
             }}
-            className="cursor-pointer hover:text-gray-800 hover:underline"
+            className="cursor-pointer hover:text-fg hover:underline"
           >
             {countLabel}
           </button>
           <span
-            className={`pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 rounded bg-gray-800 px-2 py-1 text-sm whitespace-nowrap text-white transition-opacity duration-200 [@media(hover:hover)]:block ${
+            className={`pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 rounded bg-surface-inverse px-2 py-1 text-sm whitespace-nowrap text-fg-inverse transition-opacity duration-200 [@media(hover:hover)]:block ${
               previewing && !showingLikers ? "opacity-100" : "opacity-0"
             }`}
             role="tooltip"
@@ -107,7 +107,7 @@ export function CommentLikes({
               </span>
             ))}
             {beyondPreview > 0 && (
-              <span className="block text-gray-300">
+              <span className="block text-fg-inverse-muted">
                 and {beyondPreview} more
               </span>
             )}
@@ -115,11 +115,11 @@ export function CommentLikes({
         </span>
       )}
 
-      {error && <span className="text-red-500">{error}</span>}
+      {error && <span className="text-danger-fg">{error}</span>}
 
       {showingLikers && (
         <Modal open setOpen={setShowingLikers} zIndex="z-[60]" portal>
-          <Dialog.Title className="text-base font-semibold text-gray-900">
+          <Dialog.Title className="text-base font-semibold text-fg">
             Liked by
           </Dialog.Title>
           <ul className="mt-3 max-h-72 overflow-y-auto text-sm">
@@ -127,7 +127,7 @@ export function CommentLikes({
               <li key={liker.id}>
                 <Link
                   href={`/guests/${liker.id}`}
-                  className="flex items-center gap-3 rounded-md px-2 py-1.5 font-medium text-gray-900 hover:bg-gray-50"
+                  className="flex items-center gap-3 rounded-md px-2 py-1.5 font-medium text-fg hover:bg-surface-sunken"
                 >
                   <Avatar
                     name={liker.name}

--- a/app/(site)/[eventSlug]/proposal.tsx
+++ b/app/(site)/[eventSlug]/proposal.tsx
@@ -13,17 +13,17 @@ export function Proposal(props: { proposal: SessionProposal }) {
     <>
       <h1 className="text-xl font-semibold mb-2 mt-5">{proposal.title}</h1>
       {proposal.hosts.length === 0 ? (
-        <p className="text-lg font-medium italic text-gray-500 mb-4">
+        <p className="text-lg font-medium italic text-fg-subtle mb-4">
           No host yet — someone would like this session to be offered
         </p>
       ) : (
-        <p className="text-lg font-medium text-gray-700 mb-4">
+        <p className="text-lg font-medium text-fg-muted mb-4">
           {proposal.hosts.map((h, i) => (
             <span key={h.id}>
               {i > 0 && ", "}
               <Link
                 href={`/guests/${h.id}`}
-                className="text-rose-500 hover:text-rose-600 hover:underline"
+                className="text-brand-fg hover:text-brand-fg-hover hover:underline"
               >
                 {h.name}
               </Link>
@@ -35,7 +35,7 @@ export function Proposal(props: { proposal: SessionProposal }) {
         <Markdown>{proposal.description}</Markdown>
       </div>
       {proposal.durationMinutes && (
-        <p className="text-sm text-gray-600 mb-4">
+        <p className="text-sm text-fg-muted mb-4">
           Duration:{" "}
           {formatDuration(
             durationMinusBreak(proposal.durationMinutes, breakMinutes),

--- a/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/[proposalId]/edit/page.tsx
@@ -11,10 +11,10 @@ import { notFound } from "next/navigation";
 function CantEdit(props: { eventSlug: string; children: React.ReactNode }) {
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-      <p className="text-gray-700">{props.children}</p>
+      <p className="text-fg-muted">{props.children}</p>
       <Link
         href={`/${props.eventSlug}/proposals`}
-        className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+        className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
       >
         Back to proposals
       </Link>

--- a/app/(site)/[eventSlug]/proposals/page.tsx
+++ b/app/(site)/[eventSlug]/proposals/page.tsx
@@ -43,7 +43,7 @@ export default async function ProposalsPage({
             <h1 className="text-3xl font-bold">
               {event.name}: Session Proposals
             </h1>
-            <p className="text-gray-600 mt-2">
+            <p className="text-fg-muted mt-2">
               Browse session ideas or add your own proposal
             </p>
           </div>
@@ -52,16 +52,16 @@ export default async function ProposalsPage({
       </div>
 
       {proposals.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg">
-          <h2 className="text-xl font-medium text-gray-600">
+        <div className="text-center py-12 bg-surface-sunken rounded-lg">
+          <h2 className="text-xl font-medium text-fg-muted">
             No proposals yet
           </h2>
-          <p className="text-gray-500 mt-2">
+          <p className="text-fg-subtle mt-2">
             Be the first to suggest a session!
           </p>
           <Link
             href={`/${eventSlug}/proposals/new`}
-            className="mt-4 inline-block bg-rose-400 text-white px-4 py-2 rounded-md hover:bg-rose-500"
+            className="mt-4 inline-block bg-brand text-on-brand px-4 py-2 rounded-md hover:bg-brand-hover"
           >
             Add Proposal
           </Link>

--- a/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-action-bar.tsx
@@ -52,7 +52,7 @@ export function ProposalActionBar({
       >
         <Link
           href={`/${eventSlug}/proposals/new`}
-          className={`bg-rose-400 hover:bg-rose-500 transition-colors text-white px-4 py-2 rounded-md flex items-center gap-2 ${
+          className={`bg-brand hover:bg-brand-hover transition-colors text-on-brand px-4 py-2 rounded-md flex items-center gap-2 ${
             inSchedPhase(event, now) ? "opacity-50 cursor-not-allowed" : ""
           }`}
         >
@@ -67,7 +67,7 @@ export function ProposalActionBar({
       >
         <Link
           href={votingEnabled ? `/${eventSlug}/proposals/quick-voting` : "#"}
-          className={`bg-rose-400 hover:bg-rose-500 transition-colors text-white px-4 py-2 rounded-md flex items-center gap-2 ${
+          className={`bg-brand hover:bg-brand-hover transition-colors text-on-brand px-4 py-2 rounded-md flex items-center gap-2 ${
             votingEnabled ? "" : "opacity-50 cursor-not-allowed"
           }`}
         >
@@ -82,7 +82,7 @@ export function ProposalActionBar({
       >
         <Link
           href={schedEnabled ? `/${eventSlug}` : "#"}
-          className={`bg-rose-400 hover:bg-rose-500 transition-colors text-white px-4 py-2 rounded-md flex items-center gap-2 ${
+          className={`bg-brand hover:bg-brand-hover transition-colors text-on-brand px-4 py-2 rounded-md flex items-center gap-2 ${
             schedEnabled ? "" : "opacity-50 cursor-not-allowed"
           }`}
         >

--- a/app/(site)/[eventSlug]/proposals/proposal-comments.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-comments.tsx
@@ -81,7 +81,7 @@ export function ProposalComments({
   }, [highlightedId, comments]);
 
   return (
-    <section className="mt-8 border-t border-gray-200 pt-6">
+    <section className="mt-8 border-t border-line-subtle pt-6">
       <h2 className="text-lg font-semibold mb-4">
         {total === 1 ? "1 comment" : `${total} comments`}
       </h2>
@@ -112,7 +112,7 @@ export function ProposalComments({
           submitLabel="Comment"
         />
       ) : (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-fg-subtle">
           Select your name to leave a comment.
         </p>
       )}
@@ -149,7 +149,7 @@ function CommentThread({
 
   const permalink = `/${eventSlug}/proposals?viewProposal=${proposalId}#comment-${node.id}`;
   const isAuthor = !!currentUserId && node.author?.id === currentUserId;
-  const background = depth % 2 === 1 ? "bg-[#f2f2f2]" : "bg-white";
+  const background = depth % 2 === 1 ? "bg-surface-muted" : "bg-surface-raised";
 
   const onDelete = async () => {
     setError(null);
@@ -169,14 +169,16 @@ function CommentThread({
     <div
       className={`relative rounded ${background} ${
         depth === 0
-          ? "mb-[17px] border border-gray-200"
-          : "border-l-2 border-gray-300"
+          ? "mb-[17px] border border-line-subtle"
+          : "border-l-2 border-line"
       }`}
     >
       <div
         id={`comment-${node.id}`}
         className={`rounded ${depth > 0 ? "pl-3 pr-2 py-2" : "px-3 py-2"} ${
-          node.id === highlightedId ? "relative z-10 ring-2 ring-rose-400" : ""
+          node.id === highlightedId
+            ? "relative z-10 ring-2 ring-brand-accent"
+            : ""
         }`}
       >
         <div className="flex flex-wrap items-baseline gap-x-2 text-sm">
@@ -185,12 +187,12 @@ function CommentThread({
             onClick={() => setCollapsed(!collapsed)}
             aria-expanded={!collapsed}
             aria-label={collapsed ? "Expand comment" : "Collapse comment"}
-            className="cursor-pointer font-mono text-xs text-gray-500 hover:text-gray-800"
+            className="cursor-pointer font-mono text-xs text-fg-muted hover:text-fg"
           >
             [{collapsed ? "+" : "-"}]
           </button>
           {node.deleted ? (
-            <span className="text-sm italic text-gray-500">
+            <span className="text-sm italic text-fg-muted">
               Comment deleted
             </span>
           ) : (
@@ -198,13 +200,13 @@ function CommentThread({
               {node.author ? (
                 <Link
                   href={`/guests/${node.author.id}`}
-                  className="font-medium text-rose-500 hover:text-rose-600 hover:underline"
+                  className="font-medium text-brand-fg hover:text-brand-fg-hover hover:underline"
                 >
                   {node.author.name}
                 </Link>
               ) : (
                 // The author's guest was removed; there is no profile to link.
-                <span className="font-medium text-gray-500">Unknown</span>
+                <span className="font-medium text-fg-muted">Unknown</span>
               )}
               <Link
                 href={permalink}
@@ -214,7 +216,7 @@ function CommentThread({
                 replace
                 scroll={false}
                 onClick={() => highlight(node.id)}
-                className="text-xs text-gray-500 hover:text-gray-800 hover:underline"
+                className="text-xs text-fg-muted hover:text-fg hover:underline"
               >
                 <time dateTime={node.createdTime.toISOString()}>
                   {formatInLocalZone(node.createdTime, timezone, localZone)}
@@ -222,7 +224,7 @@ function CommentThread({
               </Link>
               {node.editedTime && (
                 <span
-                  className="text-xs text-gray-400"
+                  className="text-xs text-fg-muted"
                   title={`Edited ${formatInLocalZone(node.editedTime, timezone, localZone)}`}
                 >
                   (edited)
@@ -246,19 +248,19 @@ function CommentThread({
                 onDone={() => setEditing(false)}
               />
             ) : (
-              <div className="mt-1 text-sm text-gray-800 break-words">
+              <div className="mt-1 text-sm text-fg break-words">
                 <Markdown>{node.body}</Markdown>
               </div>
             )}
 
             {!editing && (
-              <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+              <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-fg-muted">
                 <CommentLikes comment={node} eventSlug={eventSlug} />
                 {currentUserId && (
                   <button
                     type="button"
                     onClick={() => setReplying(!replying)}
-                    className="cursor-pointer hover:text-gray-800 hover:underline"
+                    className="cursor-pointer hover:text-fg hover:underline"
                   >
                     Reply
                   </button>
@@ -268,14 +270,14 @@ function CommentThread({
                     <button
                       type="button"
                       onClick={() => setEditing(true)}
-                      className="cursor-pointer hover:text-gray-800 hover:underline"
+                      className="cursor-pointer hover:text-fg hover:underline"
                     >
                       Edit
                     </button>
                     <button
                       type="button"
                       onClick={() => setConfirmingDelete(true)}
-                      className="cursor-pointer hover:text-red-600 hover:underline"
+                      className="cursor-pointer hover:text-danger-fg hover:underline"
                     >
                       Delete
                     </button>
@@ -284,7 +286,7 @@ function CommentThread({
               </div>
             )}
 
-            {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+            {error && <p className="mt-1 text-sm text-danger-fg">{error}</p>}
 
             {replying && (
               <CommentForm
@@ -303,7 +305,7 @@ function CommentThread({
 
       {!collapsed && node.replies.length > 0 && (
         <div className="flex">
-          <span className="w-3 shrink-0 hover:bg-black/10" />
+          <span className="w-3 shrink-0 hover:bg-surface-hover" />
           <div className="min-w-0 flex-1">
             {node.replies.map((reply) => (
               <CommentThread
@@ -411,7 +413,7 @@ function CommentForm({
         maxLength={COMMENT_MAX_LENGTH}
         onChange={(e) => setBody(e.target.value)}
         placeholder={placeholder}
-        className="w-full rounded-md border border-gray-300 p-2 text-sm focus:border-rose-400 focus:ring-rose-400"
+        className="w-full rounded-md border border-line p-2 text-sm focus:border-brand-accent focus:ring-brand-accent"
       />
       <div className="mt-1 flex items-center justify-between gap-2">
         <MarkdownHint />
@@ -420,7 +422,7 @@ function CommentForm({
             <button
               type="button"
               onClick={onCancel}
-              className="rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-100"
+              className="rounded-md border border-line px-3 py-1 text-sm font-medium text-fg-muted hover:bg-surface-muted"
             >
               Cancel
             </button>
@@ -428,13 +430,13 @@ function CommentForm({
           <button
             type="submit"
             disabled={submitting || body.trim().length === 0}
-            className="rounded-md bg-rose-400 px-3 py-1 text-sm font-medium text-white hover:bg-rose-500 disabled:opacity-50"
+            className="rounded-md bg-brand px-3 py-1 text-sm font-medium text-on-brand hover:bg-brand-hover disabled:opacity-50"
           >
             {submitting ? "Saving..." : submitLabel}
           </button>
         </div>
       </div>
-      {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      {error && <p className="mt-1 text-sm text-danger-fg">{error}</p>}
     </form>
   );
 }

--- a/app/(site)/[eventSlug]/proposals/proposal-modal.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-modal.tsx
@@ -51,11 +51,11 @@ export function ProposalModal({
       aria-modal="true"
       aria-label="Proposal details"
     >
-      <div className="fixed inset-0 bg-black/50" onClick={onDismiss} />
-      <div className="relative bg-white rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <div className="fixed inset-0 bg-overlay" onClick={onDismiss} />
+      <div className="relative bg-surface-raised rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-y-auto">
         <button
           onClick={onDismiss}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+          className="absolute top-4 right-4 text-fg-subtle hover:text-fg-muted"
           aria-label="Close"
         >
           <svg

--- a/app/(site)/[eventSlug]/proposals/proposal-table.tsx
+++ b/app/(site)/[eventSlug]/proposals/proposal-table.tsx
@@ -200,10 +200,10 @@ export function ProposalTable({
 
   const getPageNumbers = () => {
     const arrowCss =
-      "px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed";
-    const currentPageNumCss = "bg-blue-600 text-white";
+      "px-3 py-2 text-sm font-medium text-fg-muted bg-surface-raised border border-line rounded-md hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed";
+    const currentPageNumCss = "bg-info text-on-info";
     const otherPageNumCss =
-      "text-gray-700 bg-white border border-gray-300 hover:bg-gray-200";
+      "text-fg-muted bg-surface-raised border border-line hover:bg-surface-hover";
     const pages = [
       { display: "<<", toPage: 1, css: arrowCss },
       { display: "<", toPage: Math.max(page - 1, 1), css: arrowCss },
@@ -259,10 +259,10 @@ export function ProposalTable({
         <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
           <div className="lg:flex-1">
             <div className="flex items-center gap-3 mb-3">
-              <span className="text-sm font-medium text-gray-700">
+              <span className="text-sm font-medium text-fg-muted">
                 Filters:
               </span>
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-fg-subtle">
                 ({searchResults.length} result
                 {searchResults.length !== 1 ? "s" : ""})
               </span>
@@ -274,12 +274,12 @@ export function ProposalTable({
                 unavailable
               >
                 <button
-                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm text-white px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
+                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
                     effectiveFilter === "mine"
-                      ? "bg-blue-600 hover:bg-blue-700"
+                      ? "bg-info text-on-info hover:bg-info-hover"
                       : currentUserId
-                        ? "bg-gray-400 hover:bg-gray-500"
-                        : "bg-gray-400"
+                        ? "bg-surface-muted text-fg-muted hover:bg-surface-hover"
+                        : "bg-surface-muted text-fg-muted"
                   }`}
                   onClick={() => updateResultFilter("mine")}
                   aria-pressed={effectiveFilter === "mine"}
@@ -288,7 +288,7 @@ export function ProposalTable({
                   <UserIcon className="h-4 w-4" />
                   My proposals
                   {effectiveFilter === "mine" && (
-                    <span className="bg-blue-800 text-white text-xs px-1.5 py-0.5 rounded-full">
+                    <span className="bg-info-hover text-on-info text-xs px-1.5 py-0.5 rounded-full">
                       {filteredProposals.length}
                     </span>
                   )}
@@ -300,12 +300,12 @@ export function ProposalTable({
                 unavailable
               >
                 <button
-                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm text-white px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
+                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
                     effectiveFilter === "unvoted"
-                      ? "bg-blue-600 hover:bg-blue-700"
+                      ? "bg-info text-on-info hover:bg-info-hover"
                       : currentUserId
-                        ? "bg-gray-400 hover:bg-gray-500"
-                        : "bg-gray-400"
+                        ? "bg-surface-muted text-fg-muted hover:bg-surface-hover"
+                        : "bg-surface-muted text-fg-muted"
                   }`}
                   aria-label="Filter to show only unvoted proposals"
                   onClick={() => updateResultFilter("unvoted")}
@@ -313,7 +313,7 @@ export function ProposalTable({
                   <EyeSlashIcon className="h-4 w-4" />
                   Only unvoted
                   {effectiveFilter === "unvoted" && (
-                    <span className="bg-blue-800 text-white text-xs px-1.5 py-0.5 rounded-full">
+                    <span className="bg-info-hover text-on-info text-xs px-1.5 py-0.5 rounded-full">
                       {filteredProposals.length}
                     </span>
                   )}
@@ -325,12 +325,12 @@ export function ProposalTable({
                 unavailable
               >
                 <button
-                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm text-white px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
+                  className={`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed text-sm px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
                     effectiveFilter === "voted"
-                      ? "bg-blue-600 hover:bg-blue-700"
+                      ? "bg-info text-on-info hover:bg-info-hover"
                       : currentUserId
-                        ? "bg-gray-400 hover:bg-gray-500"
-                        : "bg-gray-400"
+                        ? "bg-surface-muted text-fg-muted hover:bg-surface-hover"
+                        : "bg-surface-muted text-fg-muted"
                   }`}
                   aria-label="Filter to show only voted proposals"
                   onClick={() => updateResultFilter("voted")}
@@ -338,7 +338,7 @@ export function ProposalTable({
                   <CheckCircleIcon className="h-4 w-4" />
                   Only voted
                   {effectiveFilter === "voted" && (
-                    <span className="bg-blue-800 text-white text-xs px-1.5 py-0.5 rounded-full">
+                    <span className="bg-info-hover text-on-info text-xs px-1.5 py-0.5 rounded-full">
                       {filteredProposals.length}
                     </span>
                   )}
@@ -347,7 +347,7 @@ export function ProposalTable({
               {effectiveFilter && (
                 <button
                   onClick={() => updateResultFilter(undefined)}
-                  className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded border border-gray-300 bg-white hover:bg-gray-50 transition-colors inline-flex items-center gap-1"
+                  className="text-xs text-fg-subtle hover:text-fg-muted px-2 py-1 rounded border border-line bg-surface-raised hover:bg-surface-sunken transition-colors inline-flex items-center gap-1"
                   aria-label="Clear all active filters"
                 >
                   Clear filters
@@ -360,7 +360,7 @@ export function ProposalTable({
             <input
               type="text"
               placeholder="Search proposals..."
-              className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-rose-400 focus:border-transparent"
+              className="w-full p-3 border border-line rounded-md focus:ring-2 focus:ring-brand-accent focus:border-transparent"
               value={searchQuery}
               onChange={(e) => handleSearch(e.target.value)}
             />
@@ -371,7 +371,7 @@ export function ProposalTable({
       {/* Mobile Sort Dropdown */}
       <div className="block md:hidden">
         <div className="flex items-center justify-between">
-          <label className="text-sm font-medium text-gray-700">Sort by:</label>
+          <label className="text-sm font-medium text-fg-muted">Sort by:</label>
           <select
             value={`${sortConfig.key}-${sortConfig.direction}`}
             onChange={(e) => {
@@ -381,7 +381,7 @@ export function ProposalTable({
               ];
               setSortConfig({ key, direction });
             }}
-            className="block w-48 px-3 py-2 text-sm border border-gray-300 rounded-md bg-white focus:ring-2 focus:ring-rose-400 focus:border-transparent"
+            className="block w-48 px-3 py-2 text-sm border border-line rounded-md bg-surface-raised focus:ring-2 focus:ring-brand-accent focus:border-transparent"
           >
             <option value="title-asc">Title ↓</option>
             <option value="title-desc">Title ↑</option>
@@ -403,14 +403,14 @@ export function ProposalTable({
 
       {/* Desktop Table View */}
       <div className="hidden md:block overflow-x-auto">
-        <table className="table-fixed w-full divide-y divide-gray-200 min-w-0">
-          <thead className="bg-gray-50">
+        <table className="table-fixed w-full divide-y divide-line-subtle min-w-0">
+          <thead className="bg-surface-sunken">
             <tr>
               <th
                 onClick={() => handleSort("title")}
                 scope="col"
-                className={`${schedEnabled ? "w-[18%]" : "w-[20%]"} text-left px-4 lg:px-6 py-3 text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
-                  ${sortConfig.key === "title" && !searchQuery.trim() ? "text-gray-900 font-semibold" : "text-gray-500"}`}
+                className={`${schedEnabled ? "w-[18%]" : "w-[20%]"} text-left px-4 lg:px-6 py-3 text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-surface-hover
+                  ${sortConfig.key === "title" && !searchQuery.trim() ? "text-fg font-semibold" : "text-fg-subtle"}`}
               >
                 Title
                 {!searchQuery.trim() &&
@@ -423,8 +423,8 @@ export function ProposalTable({
               <th
                 onClick={() => handleSort("hosts")}
                 scope="col"
-                className={`w-[15%] px-4 lg:px-6 py-3 text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
-                  ${sortConfig.key === "hosts" && !searchQuery.trim() ? "text-gray-900 font-semibold" : "text-gray-500"}`}
+                className={`w-[15%] px-4 lg:px-6 py-3 text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-surface-hover
+                  ${sortConfig.key === "hosts" && !searchQuery.trim() ? "text-fg font-semibold" : "text-fg-subtle"}`}
               >
                 Host(s)
                 {!searchQuery.trim() &&
@@ -436,15 +436,15 @@ export function ProposalTable({
               </th>
               <th
                 scope="col"
-                className={`${schedEnabled ? "w-[20%]" : "w-[25%]"} px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider`}
+                className={`${schedEnabled ? "w-[20%]" : "w-[25%]"} px-4 lg:px-6 py-3 text-left text-xs font-medium text-fg-subtle uppercase tracking-wider`}
               >
                 Description
               </th>
               <th
                 onClick={() => handleSort("durationMinutes")}
                 scope="col"
-                className={`w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
-                  ${sortConfig.key === "durationMinutes" && !searchQuery.trim() ? "text-gray-900 font-semibold" : "text-gray-500"}`}
+                className={`w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-surface-hover
+                  ${sortConfig.key === "durationMinutes" && !searchQuery.trim() ? "text-fg font-semibold" : "text-fg-subtle"}`}
               >
                 Duration
                 {!searchQuery.trim() &&
@@ -457,8 +457,8 @@ export function ProposalTable({
               <th
                 onClick={() => handleSort("userVote")}
                 scope="col"
-                className={`${schedEnabled ? "w-[7%]" : "w-[10%]"} px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
-                  ${sortConfig.key === "userVote" && !searchQuery.trim() ? "text-gray-900 font-semibold" : "text-gray-500"}`}
+                className={`${schedEnabled ? "w-[7%]" : "w-[10%]"} px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-surface-hover
+                  ${sortConfig.key === "userVote" && !searchQuery.trim() ? "text-fg font-semibold" : "text-fg-subtle"}`}
               >
                 Your vote
                 {!searchQuery.trim() &&
@@ -472,8 +472,8 @@ export function ProposalTable({
                 <th
                   onClick={() => handleSort("votes")}
                   scope="col"
-                  className={`w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-gray-200
-                    ${sortConfig.key === "votes" && !searchQuery.trim() ? "text-gray-900 font-semibold" : "text-gray-500"}`}
+                  className={`w-[10%] px-4 lg:px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer hover:bg-surface-hover
+                    ${sortConfig.key === "votes" && !searchQuery.trim() ? "text-fg font-semibold" : "text-fg-subtle"}`}
                 >
                   Votes
                   {!searchQuery.trim() &&
@@ -486,28 +486,28 @@ export function ProposalTable({
               )}
               <th
                 scope="col"
-                className={`w-[20%] px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider`}
+                className={`w-[20%] px-4 lg:px-6 py-3 text-left text-xs font-medium text-fg-subtle uppercase tracking-wider`}
               >
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-surface-raised divide-y divide-line-subtle">
             {currentPageProposals.map((proposal) => {
               const plainDescription = stripMarkdown(proposal.description);
               return (
-                <tr key={proposal.id} className="hover:bg-gray-200">
+                <tr key={proposal.id} className="hover:bg-surface-hover">
                   <td className="px-4 lg:px-6 py-4" title={proposal.title}>
                     <Link
                       {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
                       className="block w-full"
                     >
-                      <div className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors line-clamp-2 leading-tight">
+                      <div className="text-sm font-medium text-fg hover:text-link transition-colors line-clamp-2 leading-tight">
                         {proposal.title}
                       </div>
                     </Link>
                   </td>
-                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-fg-subtle">
                     <div className="truncate">
                       {proposal.hosts.length === 0 ? (
                         <span className="italic">No host yet</span>
@@ -517,7 +517,7 @@ export function ProposalTable({
                             {i > 0 && ", "}
                             <Link
                               href={`/guests/${h.id}`}
-                              className="hover:text-blue-600 transition-colors"
+                              className="hover:text-link transition-colors"
                             >
                               {h.name}
                             </Link>
@@ -527,7 +527,7 @@ export function ProposalTable({
                     </div>
                   </td>
                   <td className="px-4 lg:px-6 py-4" title={plainDescription}>
-                    <div className="text-sm text-gray-500 line-clamp-2 leading-tight">
+                    <div className="text-sm text-fg-subtle line-clamp-2 leading-tight">
                       {plainDescription || "-"}
                     </div>
                   </td>
@@ -535,8 +535,8 @@ export function ProposalTable({
                     <div className="flex items-center">
                       {proposal.durationMinutes ? (
                         <>
-                          <ClockIcon className="h-4 w-4 mr-1 text-gray-400 flex-shrink-0" />
-                          <span className="text-sm text-gray-500 truncate">
+                          <ClockIcon className="h-4 w-4 mr-1 text-fg-subtle flex-shrink-0" />
+                          <span className="text-sm text-fg-subtle truncate">
                             {formatDuration(
                               durationMinusBreak(
                                 proposal.durationMinutes,
@@ -546,7 +546,7 @@ export function ProposalTable({
                           </span>
                         </>
                       ) : (
-                        <span className="text-sm text-gray-500">-</span>
+                        <span className="text-sm text-fg-subtle">-</span>
                       )}
                     </div>
                   </td>
@@ -592,13 +592,13 @@ export function ProposalTable({
                         <div className="flex items-center gap-2">
                           <span
                             title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                            className="flex items-center gap-1 text-sm text-gray-500"
+                            className="flex items-center gap-1 text-sm text-fg-subtle"
                           >
                             ❤️&nbsp;{proposal.interestedVotesCount}
                           </span>
                           <span
                             title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                            className="flex items-center gap-1 text-sm text-gray-500"
+                            className="flex items-center gap-1 text-sm text-fg-subtle"
                           >
                             ⭐&nbsp;{proposal.maybeVotesCount}
                           </span>
@@ -617,7 +617,7 @@ export function ProposalTable({
                                 `/${eventSlug}/proposals/${proposal.id}/edit`
                               );
                             }}
-                            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+                            className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-brand-accent text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors"
                           >
                             <PencilIcon className="h-3 w-3 mr-1" />
                             Edit
@@ -636,7 +636,7 @@ export function ProposalTable({
                                 `/${eventSlug}/add-session?proposalID=${proposal.id}`
                               )
                             }
-                            className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
+                            className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-brand-accent text-brand-fg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent hover:bg-brand-tint transition-colors ${
                               schedEnabled
                                 ? ""
                                 : "opacity-50 cursor-not-allowed"
@@ -656,7 +656,7 @@ export function ProposalTable({
               <tr>
                 <td
                   colSpan={6}
-                  className="px-4 lg:px-6 py-4 text-center text-sm text-gray-500"
+                  className="px-4 lg:px-6 py-4 text-center text-sm text-fg-subtle"
                 >
                   No proposals found
                 </td>
@@ -673,19 +673,19 @@ export function ProposalTable({
           return (
             <div
               key={proposal.id}
-              className="bg-white border border-gray-200 rounded-lg p-4 hover:bg-gray-50 relative"
+              className="bg-surface-raised border border-line-subtle rounded-lg p-4 hover:bg-surface-sunken relative"
             >
               <div className="space-y-3">
                 <div>
-                  <h3 className="text-base font-medium text-gray-900">
+                  <h3 className="text-base font-medium text-fg">
                     <Link
                       {...viewProposalLinkFromOwner(eventSlug, proposal.id)}
-                      className="hover:text-blue-600 transition-colors after:absolute after:inset-0"
+                      className="hover:text-link transition-colors after:absolute after:inset-0"
                     >
                       {proposal.title}
                     </Link>
                   </h3>
-                  <p className="text-sm text-gray-500 mt-1">
+                  <p className="text-sm text-fg-subtle mt-1">
                     {proposal.hosts.length === 0 ? (
                       <span className="italic">No host yet</span>
                     ) : (
@@ -695,17 +695,17 @@ export function ProposalTable({
                 </div>
 
                 {plainDescription ? (
-                  <p className="text-sm text-gray-600 line-clamp-3">
+                  <p className="text-sm text-fg-muted line-clamp-3">
                     {plainDescription}
                   </p>
                 ) : (
-                  <p className="text-sm text-gray-500">-</p>
+                  <p className="text-sm text-fg-subtle">-</p>
                 )}
 
                 {proposal.durationMinutes ? (
                   <div className="flex items-center">
-                    <ClockIcon className="h-4 w-4 mr-1 text-gray-400" />
-                    <span className="text-sm text-gray-500">
+                    <ClockIcon className="h-4 w-4 mr-1 text-fg-subtle" />
+                    <span className="text-sm text-fg-subtle">
                       {formatDuration(
                         durationMinusBreak(
                           proposal.durationMinutes,
@@ -715,10 +715,10 @@ export function ProposalTable({
                     </span>
                   </div>
                 ) : (
-                  <div className="text-sm text-gray-500">-</div>
+                  <div className="text-sm text-fg-subtle">-</div>
                 )}
 
-                <div className="pt-2 border-t border-gray-100 space-y-3">
+                <div className="pt-2 border-t border-line-subtle space-y-3">
                   {currentUserId &&
                     !proposal.hosts.some((h) => h.id === currentUserId) &&
                     !schedEnabled && (
@@ -764,13 +764,13 @@ export function ProposalTable({
                         Total votes:
                         <span
                           title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-gray-500"
+                          className="flex items-center gap-1 text-sm text-fg-subtle"
                         >
                           ❤️&nbsp;{proposal.interestedVotesCount}
                         </span>
                         <span
                           title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                          className="flex items-center gap-1 text-sm text-gray-500"
+                          className="flex items-center gap-1 text-sm text-fg-subtle"
                         >
                           ⭐&nbsp;{proposal.maybeVotesCount}
                         </span>
@@ -788,7 +788,7 @@ export function ProposalTable({
                               `/${eventSlug}/proposals/${proposal.id}/edit`
                             );
                           }}
-                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-brand-accent text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors"
                         >
                           <PencilIcon className="h-4 w-4 mr-1" />
                           Edit
@@ -808,7 +808,7 @@ export function ProposalTable({
                               `/${eventSlug}/add-session?proposalID=${proposal.id}`
                             );
                           }}
-                          className={`inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-rose-400 text-rose-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 hover:bg-rose-50 transition-colors ${
+                          className={`inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-brand-accent text-brand-fg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent hover:bg-brand-tint transition-colors ${
                             schedEnabled ? "" : "opacity-50 cursor-not-allowed"
                           }`}
                         >
@@ -824,7 +824,7 @@ export function ProposalTable({
           );
         })}
         {searchResults.length === 0 && (
-          <div className="text-center py-8 text-sm text-gray-500">
+          <div className="text-center py-8 text-sm text-fg-subtle">
             No proposals found
           </div>
         )}

--- a/app/(site)/[eventSlug]/proposals/quick-voting/quick-voting.tsx
+++ b/app/(site)/[eventSlug]/proposals/quick-voting/quick-voting.tsx
@@ -129,7 +129,7 @@ export function QuickVoting(props: {
     <div className="max-w-2xl mx-auto px-4 pb-32 relative">
       <BackLink href={`/${eventSlug}/proposals`}>Proposals</BackLink>
       <p className="text-lg mt-4 mb-4">{eventName} Quick Voting</p>
-      <div className="text-gray-600 mb-6">
+      <div className="text-fg-muted mb-6">
         You have voted on {votes.length} / {totalProposals} proposals
       </div>
 
@@ -137,7 +137,7 @@ export function QuickVoting(props: {
 
       {/* Fixed voting buttons - only show when there's a proposal to vote on */}
       {proposal && (
-        <div className="fixed bottom-4 sm:bottom-16 left-1/2 transform -translate-x-1/2 z-30 bg-white/95 backdrop-blur-sm border border-gray-200 rounded-lg shadow-lg p-3 sm:p-4">
+        <div className="fixed bottom-4 sm:bottom-16 left-1/2 transform -translate-x-1/2 z-30 bg-surface-raised/95 backdrop-blur-sm border border-line-subtle rounded-lg shadow-lg p-3 sm:p-4">
           <VotingButtons
             proposalId={proposal.id}
             votingEnabled={true}

--- a/app/(site)/[eventSlug]/proposals/view-proposal.tsx
+++ b/app/(site)/[eventSlug]/proposals/view-proposal.tsx
@@ -88,7 +88,7 @@ export function ViewProposal(props: {
       <Proposal proposal={proposal} />
 
       {proposal.hosts.length === 0 && (
-        <p className="mt-4 rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-gray-700">
+        <p className="mt-4 rounded-md border border-brand-tint-hover bg-brand-tint px-3 py-2 text-sm text-fg-muted">
           Nobody is offering this session yet. If you could give it, take it on:
           click Edit and add yourself as a host.
         </p>
@@ -99,7 +99,7 @@ export function ViewProposal(props: {
           <div className="relative inline-block group">
             <Link
               href={`/${eventSlug}/proposals/${proposal.id}/edit`}
-              className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors"
+              className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-brand-accent text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors"
             >
               <PencilIcon className="h-3 w-3 mr-1" />
               Edit
@@ -112,7 +112,7 @@ export function ViewProposal(props: {
           >
             <button
               onClick={handleScheduleClick}
-              className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-rose-400 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 transition-colors ${
+              className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-md border border-brand-accent text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent transition-colors ${
                 schedEnabled ? "" : "opacity-50 cursor-not-allowed"
               }`}
             >
@@ -137,7 +137,7 @@ export function ViewProposal(props: {
       {schedEnabled && (
         <div className="mt-6 space-y-3">
           {!isHost() && (
-            <div className="text-sm text-gray-700">
+            <div className="text-sm text-fg-muted">
               Your vote:
               <span
                 title={(() => {
@@ -164,18 +164,18 @@ export function ViewProposal(props: {
               </span>
             </div>
           )}
-          <div className="text-sm text-gray-700">
+          <div className="text-sm text-fg-muted">
             Total votes:
             <span className="ml-2 inline-flex items-center gap-3">
               <span
                 title={`${proposal.interestedVotesCount} interested vote${proposal.interestedVotesCount !== 1 ? "s" : ""}`}
-                className="inline-flex items-center gap-1 text-sm text-gray-500"
+                className="inline-flex items-center gap-1 text-sm text-fg-subtle"
               >
                 ❤️&nbsp;{proposal.interestedVotesCount}
               </span>
               <span
                 title={`${proposal.maybeVotesCount} maybe vote${proposal.maybeVotesCount !== 1 ? "s" : ""}`}
-                className="inline-flex items-center gap-1 text-sm text-gray-500"
+                className="inline-flex items-center gap-1 text-sm text-fg-subtle"
               >
                 ⭐&nbsp;{proposal.maybeVotesCount}
               </span>
@@ -184,7 +184,7 @@ export function ViewProposal(props: {
         </div>
       )}
       {schedEnabled && (
-        <div className="mt-6 text-sm text-gray-600">
+        <div className="mt-6 text-sm text-fg-muted">
           {sessions.length === 0 ? (
             <p>This proposal has not been scheduled yet.</p>
           ) : sessions.length === 1 ? (
@@ -192,7 +192,7 @@ export function ViewProposal(props: {
               This proposal was scheduled on{" "}
               <Link
                 {...viewSessionLinkFromElsewhere(eventSlug, sessions[0].id)}
-                className="text-rose-500 underline hover:text-rose-600 transition-colors"
+                className="text-brand-fg underline hover:text-brand-fg-hover transition-colors"
               >
                 {DateTime.fromJSDate(sessions[0].startTime ?? new Date())
                   .setZone(event.timezone)
@@ -213,7 +213,7 @@ export function ViewProposal(props: {
                   <li key={session.id}>
                     <Link
                       {...viewSessionLinkFromElsewhere(eventSlug, session.id)}
-                      className="text-rose-500 underline hover:text-rose-600 transition-colors"
+                      className="text-brand-fg underline hover:text-brand-fg-hover transition-colors"
                     >
                       {DateTime.fromJSDate(session.startTime ?? new Date())
                         .setZone(event.timezone)

--- a/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
+++ b/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
@@ -188,17 +188,15 @@ function VoteButton({
       type="button"
       aria-pressed={selected}
       className={clsx(
-        "relative rounded-md border shadow-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400",
+        "relative rounded-md border shadow-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent",
         large
           ? "w-16 h-16 sm:w-20 sm:h-20 flex flex-col items-center justify-center"
           : "px-1 py-1",
         !votingEnabled && "opacity-50 cursor-not-allowed grayscale",
         selected
-          ? "bg-gray-800 border-gray-900 text-white ring-2 ring-gray-900"
-          : // gray-500 is the lightest border that still clears the 3:1 contrast
-            // the button's outline needs against white, being its only edge.
-            "bg-white border-gray-500 text-gray-700",
-        !selected && votingEnabled && "hover:bg-gray-100"
+          ? "bg-surface-inverse border-line-strong text-fg-inverse ring-2 ring-line-strong"
+          : "bg-surface-raised border-line-strong text-fg-muted",
+        !selected && votingEnabled && "hover:bg-surface-muted"
       )}
     >
       <div className={large ? "text-sm sm:text-lg mb-1" : ""}>{emoji}</div>
@@ -206,7 +204,7 @@ function VoteButton({
       {selected && (
         <span
           aria-hidden="true"
-          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-white bg-gray-900 text-[9px] leading-none text-white"
+          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-surface-raised bg-surface-inverse text-[9px] leading-none text-fg-inverse"
         >
           ✓
         </span>

--- a/app/(site)/auth/login/page.tsx
+++ b/app/(site)/auth/login/page.tsx
@@ -16,7 +16,7 @@ export default async function AuthLoginPage({
   if (!guest) {
     return (
       <div className="max-w-2xl mx-auto px-4 sm:px-0">
-        <p className="text-gray-700">
+        <p className="text-fg-muted">
           This login link is invalid. Request a new code from the name selector
           or your settings page.
         </p>

--- a/app/(site)/auth/reset/page.tsx
+++ b/app/(site)/auth/reset/page.tsx
@@ -18,7 +18,7 @@ export default async function AuthResetPage({
   if (!guest || !token) {
     return (
       <div className="max-w-2xl mx-auto px-4 sm:px-0">
-        <p className="text-gray-700">
+        <p className="text-fg-muted">
           This password link is invalid. Request a new one from the name
           selector or your settings page.
         </p>

--- a/app/(site)/auth/reset/reset-password-form.tsx
+++ b/app/(site)/auth/reset/reset-password-form.tsx
@@ -45,13 +45,13 @@ export function ResetPasswordForm({
   if (done) {
     return (
       <div className="flex flex-col gap-3">
-        <p role="status" className="text-sm text-green-700">
+        <p role="status" className="text-sm text-success-fg">
           Password set. Your name is now protected — log in with your new
           password.
         </p>
         <Link
           href="/"
-          className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm hover:bg-rose-500 self-start"
+          className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm hover:bg-brand-hover self-start"
         >
           Go to sign in
         </Link>
@@ -67,14 +67,14 @@ export function ResetPasswordForm({
         void submit();
       }}
     >
-      <p className="text-sm text-gray-600">
+      <p className="text-sm text-fg-muted">
         Choose a new password. You&apos;ll use it to switch to your name from
         now on.
       </p>
       <PasswordManagerHint username={guestName} />
       <label
         htmlFor="reset-new-password"
-        className="text-sm font-medium text-gray-700"
+        className="text-sm font-medium text-fg-muted"
       >
         New password (at least 8 characters)
       </label>
@@ -84,10 +84,10 @@ export function ResetPasswordForm({
         autoComplete="new-password"
         value={newPassword}
         onChange={(e) => setNewPassword(e.target.value)}
-        className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-rose-400 focus:border-transparent outline-none"
+        className="rounded-md border border-line px-3 py-2 text-sm focus:ring-2 focus:ring-brand-accent focus:border-transparent outline-none"
       />
       {error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger-fg">
           {error}
         </p>
       )}
@@ -95,7 +95,7 @@ export function ResetPasswordForm({
         <button
           type="submit"
           disabled={busy || newPassword.length === 0}
-          className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500"
+          className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none hover:bg-brand-hover active:bg-brand-hover"
         >
           Set password
         </button>

--- a/app/(site)/dev-toolbar.tsx
+++ b/app/(site)/dev-toolbar.tsx
@@ -85,37 +85,37 @@ export function DevToolbar() {
   const simulated = new Date(nowMs + offset);
 
   return (
-    <div className="fixed bottom-0 inset-x-0 z-50 bg-amber-100 border-t border-amber-400 text-amber-900 text-sm px-3 py-2 flex flex-wrap items-center gap-2 shadow">
+    <div className="fixed bottom-0 inset-x-0 z-50 bg-warning-tint border-t border-warning text-warning-fg text-sm px-3 py-2 flex flex-wrap items-center gap-2 shadow">
       <span className="font-semibold">🕒 Dev clock</span>
       <span className="tabular-nums">
         {simulated.toISOString().replace("T", " ").slice(0, 16)} UTC
         {offset !== 0 && (
-          <span className="ml-1 text-amber-700">
+          <span className="ml-1 text-warning-fg">
             ({offset > 0 ? "+" : ""}
             {Math.round(offset / HOUR_MS)}h)
           </span>
         )}
       </span>
       <button
-        className="px-2 py-0.5 rounded border border-amber-500 hover:bg-amber-200"
+        className="px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => apply(0)}
       >
         Real time
       </button>
       <button
-        className="px-2 py-0.5 rounded border border-amber-500 hover:bg-amber-200"
+        className="px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => apply(offset + HOUR_MS)}
       >
         +1h
       </button>
       <button
-        className="px-2 py-0.5 rounded border border-amber-500 hover:bg-amber-200"
+        className="px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => apply(offset + DAY_MS)}
       >
         +1d
       </button>
       <button
-        className="px-2 py-0.5 rounded border border-amber-500 hover:bg-amber-200"
+        className="px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => apply(offset + 7 * DAY_MS)}
       >
         +7d
@@ -124,7 +124,7 @@ export function DevToolbar() {
         <span className="sr-only">Pick date and time</span>
         <input
           type="datetime-local"
-          className="rounded border border-amber-500 bg-white px-1 py-0.5"
+          className="rounded border border-warning bg-surface-raised px-1 py-0.5"
           value={toLocalInputValue(simulated)}
           onChange={(e) => {
             const target = new Date(e.target.value);
@@ -135,7 +135,7 @@ export function DevToolbar() {
         />
       </label>
       <button
-        className="ml-auto px-2 py-0.5 rounded border border-amber-500 hover:bg-amber-200"
+        className="ml-auto px-2 py-0.5 rounded border border-warning hover:bg-warning/20"
         onClick={() => setDismissed(true)}
         aria-label="Dismiss dev clock toolbar"
       >

--- a/app/(site)/event-select.tsx
+++ b/app/(site)/event-select.tsx
@@ -19,8 +19,8 @@ export function EventSelect(props: { eventNames: string[] }) {
           }}
           className={clsx(
             urlSearchParams.get("event") === name
-              ? "bg-rose-100 text-rose-700"
-              : "text-gray-500 hover:text-gray-700",
+              ? "bg-brand-tint-hover text-brand-fg"
+              : "text-fg-subtle hover:text-fg-muted",
             "rounded-md px-3 py-2 text-sm font-medium"
           )}
         >

--- a/app/(site)/guest-login-form.tsx
+++ b/app/(site)/guest-login-form.tsx
@@ -96,14 +96,14 @@ export function GuestLoginForm({
         void submit();
       }}
     >
-      <p className="text-sm text-gray-600">
+      <p className="text-sm text-fg-muted">
         {guestName} has protected their account. Enter their password, or use a
         single-use code emailed to them. Forgot the password? Reset it instead.
       </p>
       <PasswordManagerHint username={guestName} />
       <label
         htmlFor="guest-credential"
-        className="text-sm font-medium text-gray-700"
+        className="text-sm font-medium text-fg-muted"
       >
         Password or emailed code
       </label>
@@ -113,15 +113,15 @@ export function GuestLoginForm({
         autoComplete="current-password"
         value={credential}
         onChange={(e) => setCredential(e.target.value)}
-        className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-rose-400 focus:border-transparent outline-none"
+        className="rounded-md border border-line px-3 py-2 text-sm focus:ring-2 focus:ring-brand-accent focus:border-transparent outline-none"
       />
-      {error && <p className="text-sm text-red-600">{error}</p>}
-      {info && <p className="text-sm text-green-700">{info}</p>}
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
+      {info && <p className="text-sm text-success-fg">{info}</p>}
       <div className="flex flex-wrap items-center gap-2">
         <button
           type="submit"
           disabled={busy || credential.length === 0}
-          className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500"
+          className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none hover:bg-brand-hover active:bg-brand-hover"
         >
           Log in
         </button>
@@ -129,7 +129,7 @@ export function GuestLoginForm({
           type="button"
           onClick={() => void requestCode()}
           disabled={busy}
-          className="text-sm text-rose-500 hover:text-rose-600 underline disabled:text-gray-400"
+          className="text-sm text-brand-fg hover:text-brand-fg-hover underline disabled:text-fg-subtle"
         >
           Email me a code
         </button>
@@ -137,7 +137,7 @@ export function GuestLoginForm({
           type="button"
           onClick={() => void forgotPassword()}
           disabled={busy}
-          className="text-sm text-gray-500 hover:text-gray-700 underline disabled:text-gray-400"
+          className="text-sm text-fg-subtle hover:text-fg-muted underline disabled:text-fg-subtle"
         >
           Forgot your password?
         </button>

--- a/app/(site)/guests/[guestId]/page.tsx
+++ b/app/(site)/guests/[guestId]/page.tsx
@@ -47,7 +47,7 @@ export default async function GuestProfilePage(props: {
   ]);
 
   if (!completeGuest) {
-    return <p className="text-gray-600">Profile not found.</p>;
+    return <p className="text-fg-muted">Profile not found.</p>;
   }
 
   // This is a public profile; never expose private info (email) here.
@@ -65,14 +65,14 @@ export default async function GuestProfilePage(props: {
       <div className="flex items-center justify-between gap-4">
         <Link
           href={backHref}
-          className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+          className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
         >
           Back to attendees
         </Link>
         {isOwnProfile && (
           <Link
             href="/guests/edit"
-            className="text-sm font-semibold text-rose-500 hover:text-rose-600"
+            className="text-sm font-semibold text-brand-fg hover:text-brand-fg-hover"
           >
             Edit profile
           </Link>
@@ -89,17 +89,17 @@ export default async function GuestProfilePage(props: {
           {(guest.pronouns || isSessionHost) && (
             <div className="flex flex-row gap-2">
               {guest.pronouns && (
-                <p className="text-gray-700">{guest.pronouns}</p>
+                <p className="text-fg-muted">{guest.pronouns}</p>
               )}
               {isSessionHost && (
-                <span className="w-fit rounded-full bg-rose-100 text-rose-700 text-xs font-semibold px-3 py-1">
+                <span className="w-fit rounded-full bg-brand-tint-hover text-brand-fg text-xs font-semibold px-3 py-1">
                   Session host
                 </span>
               )}
             </div>
           )}
           {guest.basedIn && (
-            <p className="text-gray-700">Based in {guest.basedIn}</p>
+            <p className="text-fg-muted">Based in {guest.basedIn}</p>
           )}
         </div>
       </header>
@@ -107,7 +107,7 @@ export default async function GuestProfilePage(props: {
       {guest.aboutMe && (
         <section>
           <h2 className="text-lg font-semibold mb-2">About me</h2>
-          <div className="text-gray-800">
+          <div className="text-fg">
             <Markdown>{guest.aboutMe}</Markdown>
           </div>
         </section>
@@ -116,7 +116,7 @@ export default async function GuestProfilePage(props: {
       {orderPrompts(guest.prompts ?? []).map(({ prompt, answer }) => (
         <section key={prompt}>
           <h2 className="text-lg font-semibold mb-2">{prompt}</h2>
-          <p className="text-gray-800">
+          <p className="text-fg">
             <InlineMarkdown>{answer}</InlineMarkdown>
           </p>
         </section>
@@ -129,7 +129,7 @@ export default async function GuestProfilePage(props: {
             {guest.languages!.map((language, i) => (
               <li
                 key={i}
-                className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800"
+                className="rounded-full bg-surface-muted px-3 py-1 text-sm text-fg"
               >
                 {language}
               </li>
@@ -145,8 +145,8 @@ export default async function GuestProfilePage(props: {
             {guest.contacts!.map((contact, i) => {
               const Icon = CONTACT_ICONS[contact.type];
               return (
-                <li key={i} className="flex items-start gap-2 text-gray-800">
-                  <Icon className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+                <li key={i} className="flex items-start gap-2 text-fg">
+                  <Icon className="mt-0.5 h-5 w-5 shrink-0 text-fg-subtle" />
                   <span className="min-w-0 break-words">
                     <span className="font-medium">
                       {(contact.type === "other" && contact.label) ||
@@ -227,7 +227,7 @@ function ProfileList({
               {item.item ? (
                 <LinkType {...item.item}>{item.label}</LinkType>
               ) : (
-                <span className="text-gray-800">{item.label}</span>
+                <span className="text-fg">{item.label}</span>
               )}
             </li>
           ))}

--- a/app/(site)/guests/[guestId]/profile-link.tsx
+++ b/app/(site)/guests/[guestId]/profile-link.tsx
@@ -19,7 +19,7 @@ function ProfileItemLink({
   return (
     <Link
       {...props}
-      className="text-rose-500 hover:text-rose-600 hover:underline"
+      className="text-brand-fg hover:text-brand-fg-hover hover:underline"
     >
       {children}
     </Link>

--- a/app/(site)/guests/attendee-list.tsx
+++ b/app/(site)/guests/attendee-list.tsx
@@ -40,20 +40,20 @@ function AttendeeRow({
   // have no room for it beside the name, so it rides along under the name
   // there and only moves out to the right edge from sm up.
   const updated = profileUpdated && (
-    <span className="text-xs text-gray-400">updated {profileUpdated}</span>
+    <span className="text-xs text-fg-subtle">updated {profileUpdated}</span>
   );
   return (
     <Link
       href={href}
-      className="flex items-center gap-4 hover:bg-gray-50 rounded-md px-2"
+      className="flex items-center gap-4 hover:bg-surface-sunken rounded-md px-2"
     >
       <Avatar name={name} size="sm" image={avatarUrl ?? undefined} />
       <div className="flex flex-col gap-1 min-w-0 flex-1">
         {/* Wraps rather than squeezing the name to fit the badge beside it. */}
-        <span className="font-medium text-gray-900 flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="font-medium text-fg flex flex-wrap items-center gap-x-2 gap-y-1">
           {name}
           {isHost && (
-            <span className="w-fit rounded-full bg-rose-100 text-rose-700 text-xs font-semibold px-3 py-1">
+            <span className="w-fit rounded-full bg-brand-tint-hover text-brand-fg text-xs font-semibold px-3 py-1">
               Session host
             </span>
           )}
@@ -61,7 +61,7 @@ function AttendeeRow({
         {(pronouns || basedIn || updated) && (
           <span className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             {(pronouns || basedIn) && (
-              <span className="text-sm text-gray-500 line-clamp-1">
+              <span className="text-sm text-fg-subtle line-clamp-1">
                 {[pronouns, basedIn].filter(Boolean).join(" · ")}
               </span>
             )}
@@ -104,24 +104,24 @@ export function AttendeeList(props: {
               page: null,
             });
           }}
-          className={`text-sm text-white px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
+          className={`text-sm px-3 py-2 rounded-md transition-colors inline-flex items-center gap-2 ${
             props.filter === f.value
-              ? "bg-blue-600 hover:bg-blue-700"
-              : "bg-gray-400 hover:bg-gray-500"
+              ? "bg-info text-on-info hover:bg-info-hover"
+              : "bg-surface-muted text-fg-muted hover:bg-surface-hover"
           }`}
           aria-pressed={props.filter === f.value}
           aria-label={`Filter by ${f.label}${props.filter === f.value ? " (active)" : ""}`}
         >
           {f.label}
           {props.filter === f.value && (
-            <span className="bg-blue-800 text-white text-xs px-1.5 py-0.5 rounded-full">
+            <span className="bg-info-hover text-on-info text-xs px-1.5 py-0.5 rounded-full">
               {props.total}
             </span>
           )}
         </button>
       ))}
       <label
-        className="flex items-center gap-2 text-sm text-gray-600"
+        className="flex items-center gap-2 text-sm text-fg-muted"
         // On the label, not the select: browsers suppress pointer events on a
         // disabled control, so a title there would never show a tooltip.
         title={
@@ -143,7 +143,7 @@ export function AttendeeList(props: {
           }}
           // pr-9 clears the chevron the forms plugin paints in the right
           // padding; a plain px-2 would let the longest option run under it.
-          className="pl-2 pr-9 py-1.5 text-sm rounded-md border border-gray-300 bg-white disabled:bg-gray-100 disabled:text-gray-400"
+          className="pl-2 pr-9 py-1.5 text-sm rounded-md border border-line bg-surface-raised disabled:bg-surface-muted disabled:text-fg-subtle"
         >
           {ATTENDEE_SORTS.map((s) => (
             <option key={s.value} value={s.value}>

--- a/app/(site)/guests/avatar.tsx
+++ b/app/(site)/guests/avatar.tsx
@@ -42,7 +42,7 @@ export function Avatar({
       className={clsx(
         className,
         dimensions,
-        "shrink-0 rounded-full bg-rose-100 text-rose-600 font-semibold flex items-center justify-center overflow-hidden"
+        "shrink-0 rounded-full bg-brand-tint-hover text-brand-fg font-semibold flex items-center justify-center overflow-hidden"
       )}
       onClick={onClick}
       onDrop={onDrop}

--- a/app/(site)/guests/edit/page.tsx
+++ b/app/(site)/guests/edit/page.tsx
@@ -12,14 +12,14 @@ export default async function EditProfilePage() {
   if (!currentUser) {
     return (
       <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-        <p className="text-gray-700">
+        <p className="text-fg-muted">
           You need to select who you are before editing your profile. Pick your
           name via the &ldquo;Select your name&rdquo; chip in the header at the
           top of the page.
         </p>
         <Link
           href="/guests"
-          className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+          className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
         >
           Back to attendees
         </Link>
@@ -31,7 +31,7 @@ export default async function EditProfilePage() {
 
   if (!guest) {
     return (
-      <p className="text-gray-600">Profile not found, please log in again.</p>
+      <p className="text-fg-muted">Profile not found, please log in again.</p>
     );
   }
 

--- a/app/(site)/guests/edit/profile-form.tsx
+++ b/app/(site)/guests/edit/profile-form.tsx
@@ -225,17 +225,17 @@ export function ProfileForm({ guest }: { guest: Guest }) {
     <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
       <Link
         href="/guests"
-        className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+        className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
       >
         Back to attendees
       </Link>
       <h1 className="text-2xl font-bold">Edit profile</h1>
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-fg-subtle">
         Everything here is shown on your public profile. Email notifications and
         other private preferences live in{" "}
         <Link
           href="/settings"
-          className="text-rose-500 hover:text-rose-600 underline"
+          className="text-brand-fg hover:text-brand-fg-hover underline"
         >
           Settings
         </Link>
@@ -252,11 +252,11 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           <button
             className={clsx(
               "flex items-center gap-4 cursor-pointer pe-4 border-solid border-e",
-              "hover:text-rose-500 active:text-rose-600 drop:boder-rose-400",
-              "transition-outline duration-200 ease-in-out outline-gray-500 outline-dashed outline-0",
+              "hover:text-brand-fg active:text-brand-fg-hover",
+              "transition-outline duration-200 ease-in-out outline-line outline-dashed outline-0",
               isDragging
                 ? "cursor-grabbing outline-4 rounded-full border-transparent"
-                : "border-gray-500"
+                : "border-line-strong"
             )}
             type="button"
             ref={avatarPicker}
@@ -279,7 +279,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           </button>
           <button
             type="button"
-            className="text-rose-400 hover:text-rose-500 active:text-rose-600 cursor-pointer"
+            className="text-brand-fg hover:text-brand-fg-hover active:text-brand-fg-hover cursor-pointer"
             onClick={() => form.setValue("avatar", null)}
           >
             Reset
@@ -296,7 +296,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
             hidden
           />
         </div>
-        <span className="text-rose-400 text-sm">
+        <span className="text-brand-fg text-sm">
           {form.formState.errors.avatar?.message}
         </span>
 
@@ -304,7 +304,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           <div className="flex flex-1 flex-col gap-1">
             <label className="font-medium" htmlFor="profile-name">
               Name
-              <span className="text-rose-500 mx-1">*</span>
+              <span className="text-brand-fg mx-1">*</span>
             </label>
             <Input
               id="profile-name"
@@ -312,7 +312,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
               {...form.register("name")}
               placeholder="Your name"
             />
-            <span className="text-rose-400 text-sm">
+            <span className="text-brand-fg text-sm">
               {form.formState.errors.name?.message}
             </span>
           </div>
@@ -330,7 +330,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
               invalid={pronounController.fieldState.invalid}
               fieldRef={pronounController.field.ref}
             />
-            <span className="text-rose-400 text-sm">
+            <span className="text-brand-fg text-sm">
               {form.formState.errors.pronouns?.message}
             </span>
           </div>
@@ -346,7 +346,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
             {...form.register("basedIn")}
             placeholder="City, region, or country"
           />
-          <span className="text-rose-400 text-sm">
+          <span className="text-brand-fg text-sm">
             {form.formState.errors.basedIn?.message}
           </span>
         </div>
@@ -362,7 +362,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
             className={form.formState.errors.aboutMe ? "invalid" : ""}
           />
           <MarkdownHint />
-          <span className="text-rose-400 text-sm">
+          <span className="text-brand-fg text-sm">
             {form.formState.errors.aboutMe?.message}
           </span>
         </div>
@@ -391,14 +391,14 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                         type="button"
                         aria-label="Suggest a different prompt"
                         title="Suggest a different prompt"
-                        className="text-rose-400 hover:text-rose-500"
+                        className="text-brand-fg hover:text-brand-fg-hover"
                         onClick={() => swapPrompt(i)}
                       >
                         <ArrowPathIcon className="h-4 w-4" />
                       </button>
                       <button
                         type="button"
-                        className="text-sm text-rose-400 hover:text-rose-500"
+                        className="text-sm text-brand-fg hover:text-brand-fg-hover"
                         onClick={() => prompts.remove(i)}
                       >
                         Remove
@@ -414,7 +414,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                   {...form.register(`prompts.${i}.answer`)}
                   placeholder="A sentence or two"
                 />
-                <span className="text-rose-400 text-sm">
+                <span className="text-brand-fg text-sm">
                   {form.formState.errors.prompts?.[i]?.answer?.message}
                 </span>
               </div>
@@ -422,7 +422,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           })}
           <button
             type="button"
-            className="text-sm font-semibold text-rose-500 hover:text-rose-600 w-fit"
+            className="text-sm font-semibold text-brand-fg hover:text-brand-fg-hover w-fit"
             onClick={suggestPrompt}
           >
             Suggest a prompt
@@ -456,7 +456,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                         fieldRef={f.ref}
                       />
                       {fieldState.error && (
-                        <span className="text-rose-400 text-sm">
+                        <span className="text-brand-fg text-sm">
                           {fieldState.error.message}
                         </span>
                       )}
@@ -466,7 +466,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
               </div>
               <button
                 type="button"
-                className="text-sm text-rose-400 hover:text-rose-500"
+                className="text-sm text-brand-fg hover:text-brand-fg-hover"
                 onClick={() => languages.remove(i)}
               >
                 Remove
@@ -475,13 +475,13 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           ))}
           <button
             type="button"
-            className="text-sm font-semibold text-rose-500 hover:text-rose-600 w-fit disabled:text-gray-400"
+            className="text-sm font-semibold text-brand-fg hover:text-brand-fg-hover w-fit disabled:text-fg-subtle"
             disabled={languages.fields.length >= MAX_LANGUAGES}
             onClick={() => languages.append({ value: "" })}
           >
             Add language
           </button>
-          <span className="text-rose-400 text-sm">
+          <span className="text-brand-fg text-sm">
             {form.formState.errors.languages?.root?.message ??
               form.formState.errors.languages?.message}
           </span>
@@ -500,7 +500,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                 <select
                   aria-label="Contact type"
                   {...form.register(`contacts.${i}.type`)}
-                  className="h-12 sm:w-40 rounded-md border border-gray-300 bg-white px-3 shadow-sm focus:ring-2 focus:ring-rose-400 focus:outline-0"
+                  className="h-12 sm:w-40 rounded-md border border-line bg-surface-raised px-3 shadow-sm focus:ring-2 focus:ring-brand-accent focus:outline-0"
                 >
                   {CONTACT_TYPES.map((type) => (
                     <option key={type} value={type}>
@@ -532,13 +532,13 @@ export function ProfileForm({ guest }: { guest: Guest }) {
                 />
                 <button
                   type="button"
-                  className="text-sm text-rose-400 hover:text-rose-500"
+                  className="text-sm text-brand-fg hover:text-brand-fg-hover"
                   onClick={() => contacts.remove(i)}
                 >
                   Remove
                 </button>
               </div>
-              <span className="text-rose-400 text-sm">
+              <span className="text-brand-fg text-sm">
                 {form.formState.errors.contacts?.[i]?.label?.message ??
                   form.formState.errors.contacts?.[i]?.value?.message}
               </span>
@@ -546,7 +546,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
           ))}
           <button
             type="button"
-            className="text-sm font-semibold text-rose-500 hover:text-rose-600 w-fit disabled:text-gray-400"
+            className="text-sm font-semibold text-brand-fg hover:text-brand-fg-hover w-fit disabled:text-fg-subtle"
             disabled={contacts.fields.length >= MAX_CONTACTS}
             onClick={() =>
               contacts.append({ type: "email", label: "", value: "" })
@@ -555,7 +555,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
             Add contact
           </button>
           <MarkdownHint />
-          <span className="text-rose-400 text-sm">
+          <span className="text-brand-fg text-sm">
             {form.formState.errors.contacts?.root?.message ??
               form.formState.errors.contacts?.message}
           </span>
@@ -573,7 +573,7 @@ export function ProfileForm({ guest }: { guest: Guest }) {
 
         <button
           type="submit"
-          className="bg-rose-400 text-white font-semibold py-2 rounded shadow disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500 mx-auto px-12"
+          className="bg-brand text-on-brand font-semibold py-2 rounded shadow disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none hover:bg-brand-hover active:bg-brand-hover mx-auto px-12"
           disabled={form.formState.isSubmitting}
         >
           {form.formState.isSubmitting ? "Saving..." : "Save"}
@@ -610,11 +610,11 @@ function DisclosureSection({
         // this section's own jump: another section's is none of its business.
         if (!e.currentTarget.open && forceOpen) onCollapse?.();
       }}
-      className="rounded-md border border-gray-200 bg-white shadow-sm"
+      className="rounded-md border border-line-subtle bg-surface-raised shadow-sm"
     >
       <summary className="cursor-pointer select-none px-4 py-3">
         <span className="font-medium">{title}</span>
-        <span className="block text-sm text-gray-500">{hint}</span>
+        <span className="block text-sm text-fg-subtle">{hint}</span>
       </summary>
       <div className="flex flex-col gap-4 px-4 pb-4">{children}</div>
     </details>
@@ -688,10 +688,10 @@ function FreeformCombobox({
       <Combobox value={value ?? null} onChange={onChange} immediate>
         <ComboboxInput
           className={clsx(
-            "h-12 w-full rounded-md border bg-white px-4 shadow-sm transition-colors invalid:border-red-500 invalid:text-red-900 invalid:placeholder-red-300 focus:outline-none disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500",
+            "h-12 w-full rounded-md border bg-surface-raised px-4 shadow-sm transition-colors invalid:border-danger invalid:text-danger-fg invalid:placeholder-danger-border focus:outline-none disabled:cursor-not-allowed disabled:border-line-subtle disabled:bg-surface-sunken disabled:text-fg-subtle",
             invalid
-              ? "border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500" // matches invalid: styles
-              : "border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none"
+              ? "border-danger-border text-danger-fg placeholder-danger-border focus:border-danger focus:ring-danger" // matches invalid: styles
+              : "border-line placeholder-fg-subtle focus:ring-2 focus:ring-brand-accent focus:outline-0 focus:border-none"
           )}
           id={id}
           aria-label={ariaLabel}
@@ -712,12 +712,12 @@ function FreeformCombobox({
           }}
         />
         <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-2">
-          <ChevronUpDownIcon className="h-5 w-5 text-gray-400" />
+          <ChevronUpDownIcon className="h-5 w-5 text-fg-subtle" />
         </ComboboxButton>
         {/* modal={false} keeps the page scrollable while the list is open */}
         <ComboboxOptions
           modal={false}
-          className="absolute mt-1 z-10 w-full rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm"
+          className="absolute mt-1 z-10 w-full rounded-md bg-surface-raised py-1 text-base shadow-lg ring-1 ring-line-subtle focus:outline-none sm:text-sm"
         >
           <div className="max-h-60 overflow-auto">
             {shownOptions.map((option) => (
@@ -726,14 +726,14 @@ function FreeformCombobox({
                 value={option}
                 className={({ focus }) =>
                   clsx`relative cursor-pointer select-none py-2 pl-10 pr-4 z-10
-                    ${focus ? "bg-rose-100 text-rose-900" : "text-gray-900 bg-white"}`
+                    ${focus ? "bg-brand-tint-hover text-brand-fg" : "text-fg bg-surface-raised"}`
                 }
               >
                 {option}
               </ComboboxOption>
             ))}
           </div>
-          <div className="border-t border-gray-100 px-4 py-2 text-xs text-gray-500">
+          <div className="border-t border-line-subtle px-4 py-2 text-xs text-fg-subtle">
             Pick one or type any text
           </div>
         </ComboboxOptions>

--- a/app/(site)/guests/page.tsx
+++ b/app/(site)/guests/page.tsx
@@ -109,7 +109,7 @@ export default async function GuestsPage({
         {currentUser && (
           <Link
             href="/guests/edit"
-            className="text-sm font-semibold text-rose-500 hover:text-rose-600"
+            className="text-sm font-semibold text-brand-fg hover:text-brand-fg-hover"
           >
             Edit profile
           </Link>

--- a/app/(site)/guests/zoomable-avatar.tsx
+++ b/app/(site)/guests/zoomable-avatar.tsx
@@ -37,7 +37,7 @@ export function ZoomableAvatar({
       <button
         type="button"
         aria-label={`Enlarge photo of ${name}`}
-        className="w-fit rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400"
+        className="w-fit rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent"
         onClick={() => setOpen(true)}
       >
         <Avatar name={name} image={image} />

--- a/app/(site)/header-user-select.tsx
+++ b/app/(site)/header-user-select.tsx
@@ -48,11 +48,11 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
   };
 
   const chipClasses =
-    "flex min-w-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-400";
+    "flex min-w-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-accent";
 
   const selectModal = (
     <Modal open={open} setOpen={setOpen}>
-      <label htmlFor="user-selection" className="text-gray-500">
+      <label htmlFor="user-selection" className="text-fg-subtle">
         My name is:
       </label>
       <UserSelect guests={guests} onSelect={() => setOpen(false)} />
@@ -71,7 +71,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
           className={clsx(
             chipClasses,
             // No name set: gently draw attention to prompt a selection.
-            "bg-rose-50 text-rose-500 hover:bg-rose-100"
+            "bg-brand-tint text-brand-fg hover:bg-brand-tint-hover"
           )}
         >
           <UserCircleIcon className="h-5 w-5 shrink-0 stroke-2" />
@@ -87,7 +87,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
   const itemClasses = (focus: boolean) =>
     clsx(
       "block w-full text-left px-4 py-2 text-sm",
-      focus ? "bg-gray-100 text-gray-900" : "text-gray-700"
+      focus ? "bg-surface-muted text-fg" : "text-fg-muted"
     );
 
   return (
@@ -95,7 +95,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
       <Menu>
         <MenuButton
           aria-label={`Your name: ${currentGuest.name}`}
-          className={clsx(chipClasses, "text-gray-600 hover:bg-gray-100")}
+          className={clsx(chipClasses, "text-fg-muted hover:bg-surface-muted")}
         >
           <UserCircleIcon className="h-5 w-5 shrink-0 stroke-2" />
           <span className="max-w-[40vw] truncate sm:max-w-[12rem]">
@@ -105,7 +105,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
         </MenuButton>
         <MenuItems
           anchor="bottom end"
-          className="z-40 mt-1 w-48 rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none"
+          className="z-40 mt-1 w-48 rounded-md bg-surface-raised py-1 shadow-lg ring-1 ring-line-subtle focus:outline-none"
         >
           <MenuItem>
             {({ focus }) => (
@@ -131,7 +131,7 @@ export function HeaderUserSelect({ guests }: { guests: Guest[] }) {
               </Link>
             )}
           </MenuItem>
-          <MenuSeparator className="my-1 h-px bg-gray-100" />
+          <MenuSeparator className="my-1 h-px bg-surface-muted" />
           <MenuItem>
             {({ focus }) => (
               <button

--- a/app/(site)/hover-tooltip.tsx
+++ b/app/(site)/hover-tooltip.tsx
@@ -102,7 +102,7 @@ export default function HoverTooltip(props: {
           ref={tooltipRef}
           id={hintId}
           style={{ left: pos?.left ?? 0, top: pos?.top ?? 0 }}
-          className={`fixed px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50 ${
+          className={`fixed px-2 py-1 text-sm text-fg-inverse bg-surface-inverse rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50 ${
             pos ? "" : "invisible"
           }`}
         >

--- a/app/(site)/login/page.tsx
+++ b/app/(site)/login/page.tsx
@@ -26,10 +26,8 @@ function LoginForm() {
   return (
     <div className="max-w-md w-full space-y-8">
       <div className="text-center">
-        <h2 className="mt-6 text-3xl font-bold text-gray-900">
-          Access Required
-        </h2>
-        <p className="mt-2 text-sm text-gray-600">
+        <h2 className="mt-6 text-3xl font-bold text-fg">Access Required</h2>
+        <p className="mt-2 text-sm text-fg-muted">
           Please enter the password to access this site
         </p>
       </div>
@@ -60,8 +58,8 @@ function LoginForm() {
           <button
             type="submit"
             className={clsx(
-              "group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-500",
-              "bg-rose-600 hover:bg-rose-700"
+              "group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-on-brand transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent",
+              "bg-brand hover:bg-brand-hover"
             )}
           >
             Access Site
@@ -74,7 +72,7 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-surface-sunken py-12 px-4 sm:px-6 lg:px-8">
       <Suspense fallback={<div>Loading...</div>}>
         <LoginForm />
       </Suspense>

--- a/app/(site)/markdown.tsx
+++ b/app/(site)/markdown.tsx
@@ -32,7 +32,7 @@ const blockComponents: Components = {
       // behind blank.
       target={/^https?:/i.test(href ?? "") ? "_blank" : undefined}
       rel="noopener noreferrer nofollow"
-      className="text-rose-500 underline hover:text-rose-600"
+      className="text-brand-fg underline hover:text-brand-fg-hover"
     >
       {
         children ||
@@ -47,21 +47,21 @@ const blockComponents: Components = {
     <ol className="list-decimal pl-5 my-2 first:mt-0 last:mb-0">{children}</ol>
   ),
   blockquote: ({ children }) => (
-    <blockquote className="border-l-4 border-gray-300 pl-3 text-gray-600 my-2">
+    <blockquote className="border-l-4 border-line pl-3 text-fg-muted my-2">
       {children}
     </blockquote>
   ),
   code: ({ children }) => (
-    <code className="bg-gray-100 rounded px-1 font-mono text-[0.9em]">
+    <code className="bg-surface-muted rounded px-1 font-mono text-[0.9em]">
       {children}
     </code>
   ),
   pre: ({ children }) => (
-    <pre className="bg-gray-100 rounded p-2 my-2 overflow-x-auto">
+    <pre className="bg-surface-muted rounded p-2 my-2 overflow-x-auto">
       {children}
     </pre>
   ),
-  hr: () => <hr className="my-3 border-gray-200" />,
+  hr: () => <hr className="my-3 border-line-subtle" />,
 };
 
 // Fields written in a single-line input and shown inside a line of text (a
@@ -92,7 +92,7 @@ const inlineComponents: Components = {
 };
 
 export function MarkdownHint() {
-  return <p className="text-xs text-gray-500">Markdown supported</p>;
+  return <p className="text-xs text-fg-subtle">Markdown supported</p>;
 }
 
 function MarkdownRoot({

--- a/app/(site)/modals.tsx
+++ b/app/(site)/modals.tsx
@@ -15,7 +15,7 @@ export function MapModal({ mapImageUrl }: { mapImageUrl: string }) {
       <button
         type="button"
         aria-label="Show map"
-        className="relative inline-flex items-center justify-center rounded-md p-1.5 bg-rose-400 text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-400"
+        className="relative inline-flex items-center justify-center rounded-md p-1.5 bg-brand text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-accent"
         onClick={() => setOpen(true)}
       >
         <MapIcon className="h-5 w-5 stroke-2" aria-hidden="true" />
@@ -78,7 +78,7 @@ export function CurrentUserModal(props: {
       {sessionInfoDisplay}
       {
         <div className="mt-2">
-          <span className="text-gray-500">RSVPing as...</span>
+          <span className="text-fg-subtle">RSVPing as...</span>
           <UserSelect guests={guests} />
         </div>
       }
@@ -86,14 +86,14 @@ export function CurrentUserModal(props: {
         <div className="relative inline-block group">
           <button
             type="button"
-            className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm disabled:bg-gray-400 px-4 py-2 bg-rose-400 text-base font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 sm:text-sm mt-4"
+            className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm disabled:bg-surface-hover disabled:text-fg-subtle px-4 py-2 bg-brand text-base font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent sm:text-sm mt-4"
             onClick={onClickHandler}
             disabled={isDisabled}
           >
             {rsvpd ? "Un-RSVP" : "RSVP"}
           </button>
           {isDisabled && (
-            <div className="absolute bottom-3/4 left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-sm text-white bg-gray-800 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap">
+            <div className="absolute bottom-3/4 left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-sm text-fg-inverse bg-surface-inverse rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap">
               Cannot RSVP to your own event
             </div>
           )}
@@ -119,7 +119,7 @@ export function ConfirmDeletionModal(props: {
     <>
       <button
         type="submit"
-        className="bg-white-400 text-red-900 font-semibold py-2 rounded shadow disabled:bg-gray-200 border-2 border-red-500 mx-auto px-12 hover:bg-rose-100 active:bg-rose-100"
+        className="bg-surface-raised text-danger-fg font-semibold py-2 rounded shadow disabled:bg-surface-hover border-2 border-danger mx-auto px-12 hover:bg-danger-tint active:bg-danger-tint"
         onClick={() => setOpen(true)}
         disabled={btnDisabled}
       >
@@ -130,14 +130,14 @@ export function ConfirmDeletionModal(props: {
         <div className="mt-4">
           <button
             type="button"
-            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-rose-400 font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400"
+            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
             onClick={() => void clickHandler()}
           >
             Yes
           </button>
           <button
             type="button"
-            className="ml-4 rounded-md border border-black shadow-sm px-6 py-2 bg-white font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-200"
+            className="ml-4 rounded-md border border-line-strong shadow-sm px-6 py-2 bg-surface-raised font-medium text-fg hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-line"
             onClick={() => setOpen(false)}
           >
             No
@@ -174,14 +174,14 @@ export function ConfirmationModal(props: {
         <div className="mt-4">
           <button
             type="button"
-            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-rose-400 font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400"
+            className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
             onClick={clickHandler}
           >
             Yes
           </button>
           <button
             type="button"
-            className="ml-4 rounded-md border border-black shadow-sm px-6 py-2 bg-white font-medium text-black hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-200"
+            className="ml-4 rounded-md border border-line-strong shadow-sm px-6 py-2 bg-surface-raised font-medium text-fg hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-line"
             onClick={close}
           >
             No
@@ -212,7 +212,7 @@ export function AlertModal(props: {
       <div className="mt-4">
         <button
           type="button"
-          className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-rose-400 font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400"
+          className="rounded-md border border-transparent shadow-sm px-6 py-2 bg-brand font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent"
           onClick={close}
         >
           OK
@@ -259,7 +259,7 @@ export function Modal(props: {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
+            <div className="fixed inset-0 bg-overlay transition-opacity" />
           </Transition.Child>
           <div className={`fixed inset-0 ${zIndex} w-full overflow-y-auto`}>
             <div className="flex min-h-full w-full items-center justify-center p-4 text-center sm:p-0">
@@ -272,13 +272,13 @@ export function Modal(props: {
                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
-                <Dialog.Panel className="relative mb-10 transform overflow-visible rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <Dialog.Panel className="relative mb-10 transform overflow-visible rounded-lg bg-surface-raised px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                   {children}
                   {!hideClose && (
                     <div className="mt-4">
                       <button
                         type="button"
-                        className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-rose-400 text-base font-medium text-white hover:bg-rose-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-400 sm:text-sm"
+                        className="inline-flex justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-brand text-base font-medium text-on-brand hover:bg-brand-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent sm:text-sm"
                         onClick={() => setOpen(false)}
                       >
                         Close

--- a/app/(site)/nav-bar.tsx
+++ b/app/(site)/nav-bar.tsx
@@ -33,7 +33,7 @@ export default function NavBar({
   return (
     <Disclosure
       as="nav"
-      className="bg-white border-b border-gray-300 fixed w-full z-30"
+      className="bg-surface-raised border-b border-line fixed w-full z-30"
     >
       {({ open }) => (
         <>
@@ -41,7 +41,7 @@ export default function NavBar({
             <div className="relative flex h-16 items-center justify-between">
               <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                 {/* Mobile menu button*/}
-                <Disclosure.Button className="relative inline-flex items-center justify-center rounded-md p-2 text-rose-400 hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-400">
+                <Disclosure.Button className="relative inline-flex items-center justify-center rounded-md p-2 text-brand-fg hover:bg-brand-tint focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-accent">
                   <span className="absolute -inset-0.5" />
                   {open ? (
                     <XMarkIcon className="block h-6 w-6 stroke-2" />
@@ -69,7 +69,7 @@ export default function NavBar({
                   {showGuestsLink && (
                     <Link
                       href="/guests"
-                      className="hidden sm:flex group gap-1 cursor-pointer items-center rounded-md px-3 py-2 text-sm font-medium text-gray-400 hover:bg-gray-100"
+                      className="hidden sm:flex group gap-1 cursor-pointer items-center rounded-md px-3 py-2 text-sm font-medium text-fg-subtle hover:bg-surface-muted"
                     >
                       <UserGroupIcon className="block h-5 w-auto" />
                       Attendees
@@ -94,7 +94,7 @@ export default function NavBar({
                 <Disclosure.Button
                   as="a"
                   href="/guests"
-                  className="flex gap-2 items-center rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-100"
+                  className="flex gap-2 items-center rounded-md px-3 py-2 text-base font-medium text-fg-subtle hover:bg-surface-muted"
                 >
                   <UserGroupIcon className="block h-5 w-auto" />
                   Attendees
@@ -120,8 +120,8 @@ function NavBarItem(props: { item: NavItem; highlightCurrent: boolean }) {
       href={item.href}
       className={clsx(
         isCurrentPage
-          ? "bg-rose-50 text-rose-400"
-          : "text-gray-400 hover:bg-gray-100",
+          ? "bg-brand-tint text-brand-fg"
+          : "text-fg-subtle hover:bg-surface-muted",
         "group flex gap-1 cursor-pointer items-center rounded-md px-3 py-2 text-sm font-medium"
       )}
     >
@@ -144,8 +144,8 @@ function SmallNavBarItem(props: { item: NavItem; highlightCurrent: boolean }) {
       href={item.href}
       className={clsx(
         isCurrentPage
-          ? "bg-rose-50 text-rose-400"
-          : "text-gray-400 hover:bg-gray-100",
+          ? "bg-brand-tint text-brand-fg"
+          : "text-fg-subtle hover:bg-surface-muted",
         "flex gap-2 rounded-md px-3 py-2 text-base font-medium"
       )}
     >

--- a/app/(site)/settings/account-security.tsx
+++ b/app/(site)/settings/account-security.tsx
@@ -11,7 +11,7 @@ import { PasswordManagerHint } from "@/app/password-manager-hint";
 type Mode = "password" | "disable";
 
 const inputClass =
-  "rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-rose-400 focus:border-transparent outline-none";
+  "rounded-md border border-line px-3 py-2 text-sm focus:ring-2 focus:ring-brand-accent focus:border-transparent outline-none";
 
 /**
  * Enable/disable account protection and change the password.
@@ -102,20 +102,20 @@ export function AccountSecurity({
     <section className="flex flex-col gap-2">
       <h2 className="text-lg font-semibold">Account security</h2>
       {authProtected ? (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-fg-subtle">
           Your name is protected: switching to it requires your password or a
           single-use code emailed to you. Forgot your password? Reset it with an
           emailed link.
         </p>
       ) : (
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-fg-subtle">
           Anyone can currently act under your name. Enable protection so
           switching to your name requires your password. We&apos;ll email you a
           link to set it.
         </p>
       )}
       {success && (
-        <p role="status" className="text-sm text-green-700">
+        <p role="status" className="text-sm text-success-fg">
           {success}
         </p>
       )}
@@ -128,7 +128,7 @@ export function AccountSecurity({
                 <button
                   type="button"
                   onClick={() => startMode("password")}
-                  className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm hover:bg-rose-500 active:bg-rose-500"
+                  className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm hover:bg-brand-hover active:bg-brand-hover"
                 >
                   Change password
                 </button>
@@ -136,14 +136,14 @@ export function AccountSecurity({
                   type="button"
                   onClick={() => void sendPasswordLink()}
                   disabled={busy}
-                  className="border border-gray-300 text-gray-700 font-semibold px-4 py-2 rounded text-sm hover:bg-gray-50 disabled:text-gray-400"
+                  className="border border-line text-fg-muted font-semibold px-4 py-2 rounded text-sm hover:bg-surface-sunken disabled:text-fg-subtle"
                 >
                   Forgot your password?
                 </button>
                 <button
                   type="button"
                   onClick={() => startMode("disable")}
-                  className="border border-gray-300 text-gray-700 font-semibold px-4 py-2 rounded text-sm hover:bg-gray-50"
+                  className="border border-line text-fg-muted font-semibold px-4 py-2 rounded text-sm hover:bg-surface-sunken"
                 >
                   Turn off protection
                 </button>
@@ -153,14 +153,14 @@ export function AccountSecurity({
                 type="button"
                 onClick={() => void sendPasswordLink()}
                 disabled={busy}
-                className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm hover:bg-rose-500 active:bg-rose-500 disabled:bg-gray-200 disabled:text-gray-400"
+                className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm hover:bg-brand-hover active:bg-brand-hover disabled:bg-surface-hover disabled:text-fg-subtle"
               >
                 Enable protection
               </button>
             )}
           </div>
           {info && (
-            <p role="status" className="text-sm text-green-700">
+            <p role="status" className="text-sm text-success-fg">
               {info}
             </p>
           )}
@@ -173,7 +173,7 @@ export function AccountSecurity({
             void submit();
           }}
         >
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-fg-muted">
             {mode === "password"
               ? "Enter your current password and choose a new one."
               : "Enter your current password to turn off protection. This also removes your password."}
@@ -181,7 +181,7 @@ export function AccountSecurity({
           <PasswordManagerHint username={guestName} />
           <label
             htmlFor="security-current-password"
-            className="text-sm font-medium text-gray-700"
+            className="text-sm font-medium text-fg-muted"
           >
             Current password
           </label>
@@ -197,7 +197,7 @@ export function AccountSecurity({
             <>
               <label
                 htmlFor="security-new-password"
-                className="text-sm font-medium text-gray-700"
+                className="text-sm font-medium text-fg-muted"
               >
                 New password (at least 8 characters)
               </label>
@@ -212,7 +212,7 @@ export function AccountSecurity({
             </>
           )}
           {error && (
-            <p role="alert" className="text-sm text-red-600">
+            <p role="alert" className="text-sm text-danger-fg">
               {error}
             </p>
           )}
@@ -224,7 +224,7 @@ export function AccountSecurity({
                 currentPassword.length === 0 ||
                 (mode === "password" && newPassword.length === 0)
               }
-              className="bg-rose-400 text-white font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500"
+              className="bg-brand text-on-brand font-semibold px-4 py-2 rounded shadow text-sm disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none hover:bg-brand-hover active:bg-brand-hover"
             >
               {mode === "password" ? "Change password" : "Turn off protection"}
             </button>
@@ -232,7 +232,7 @@ export function AccountSecurity({
               type="button"
               onClick={() => setMode(null)}
               disabled={busy}
-              className="text-sm text-gray-500 hover:text-gray-700 underline disabled:text-gray-400"
+              className="text-sm text-fg-subtle hover:text-fg-muted underline disabled:text-fg-subtle"
             >
               Cancel
             </button>

--- a/app/(site)/settings/page.tsx
+++ b/app/(site)/settings/page.tsx
@@ -14,14 +14,14 @@ export default async function SettingsPage() {
   if (!currentUser) {
     return (
       <div className="max-w-2xl mx-auto flex flex-col gap-4 px-4 sm:px-0">
-        <p className="text-gray-700">
+        <p className="text-fg-muted">
           You need to select who you are before changing your settings. Pick
           your name via the &ldquo;Select your name&rdquo; chip in the header at
           the top of the page.
         </p>
         <Link
           href="/guests"
-          className="bg-rose-400 text-white font-semibold py-2 rounded shadow hover:bg-rose-500 active:bg-rose-500 w-fit px-12"
+          className="bg-brand text-on-brand font-semibold py-2 rounded shadow hover:bg-brand-hover active:bg-brand-hover w-fit px-12"
         >
           Back to attendees
         </Link>
@@ -33,7 +33,7 @@ export default async function SettingsPage() {
 
   if (!guest) {
     return (
-      <p className="text-gray-600">Profile not found, please log in again.</p>
+      <p className="text-fg-muted">Profile not found, please log in again.</p>
     );
   }
 

--- a/app/(site)/settings/settings-form.tsx
+++ b/app/(site)/settings/settings-form.tsx
@@ -48,11 +48,11 @@ export function SettingsForm({
   return (
     <div className="max-w-2xl mx-auto flex flex-col gap-6 px-4 sm:px-0">
       <h1 className="text-2xl font-bold">Settings</h1>
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-fg-subtle">
         Everything here is private and never shown to other attendees. Your{" "}
         <Link
           href="/guests/edit"
-          className="text-rose-500 hover:text-rose-600 underline"
+          className="text-brand-fg hover:text-brand-fg-hover underline"
         >
           public profile
         </Link>{" "}
@@ -67,34 +67,34 @@ export function SettingsForm({
           <legend className="text-lg font-semibold mb-1">
             Email me when&hellip;
           </legend>
-          <p className="text-sm text-gray-500 mb-1">
+          <p className="text-sm text-fg-subtle mb-1">
             Notifications go to the email address the organizers have for you.
             Contact an organizer to change it.
           </p>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("rsvpChange")} />a session
             I&rsquo;ve RSVP&rsquo;d to changes time or location, or is deleted
           </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("hostChange")} />a session
             I&rsquo;m hosting changes time or location, or is deleted
           </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("cohostAdd")} />
             someone adds me as a session co-host
           </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("proposalComment")} />
             someone comments on a proposal I&rsquo;m hosting
           </label>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input type="checkbox" {...form.register("commentThread")} />
             someone comments on a proposal I&rsquo;ve commented on
           </label>
         </fieldset>
 
         {form.formState.errors.root && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md">
+          <div className="bg-danger-tint border border-danger-border text-danger-fg px-4 py-3 rounded-md">
             <p className="text-sm font-medium">
               Error: {form.formState.errors.root.message}
             </p>
@@ -104,13 +104,13 @@ export function SettingsForm({
         <div className="flex items-center gap-4">
           <button
             type="submit"
-            className="bg-rose-400 text-white font-semibold py-2 rounded shadow disabled:bg-gray-200 disabled:text-gray-400 disabled:shadow-none hover:bg-rose-500 active:bg-rose-500 px-12"
+            className="bg-brand text-on-brand font-semibold py-2 rounded shadow disabled:bg-surface-hover disabled:text-fg-subtle disabled:shadow-none hover:bg-brand-hover active:bg-brand-hover px-12"
             disabled={form.formState.isSubmitting}
           >
             {form.formState.isSubmitting ? "Saving..." : "Save"}
           </button>
           {saved && !form.formState.isDirty && (
-            <span role="status" className="text-sm text-green-700">
+            <span role="status" className="text-sm text-success-fg">
               Saved
             </span>
           )}

--- a/app/(site)/summary-page.tsx
+++ b/app/(site)/summary-page.tsx
@@ -29,7 +29,7 @@ export default function SummaryPage(props: {
           {sortedEvents.map((event) => (
             <div key={event.name}>
               <h1 className="sm:text-2xl text-xl font-bold">{event.name}</h1>
-              <div className="flex text-gray-500 text-xs mt-1 gap-5 font-medium">
+              <div className="flex text-fg-subtle text-xs mt-1 gap-5 font-medium">
                 <span className="flex gap-1 items-center">
                   <CalendarIcon className="3 w-3 stroke-2" />
                   <span>
@@ -52,12 +52,12 @@ export default function SummaryPage(props: {
                   </a>
                 )}
               </div>
-              <div className="text-gray-900 mt-2">
+              <div className="text-fg mt-2">
                 <Markdown>{event.description}</Markdown>
               </div>
               <Link
                 href={`/${event.slug}`}
-                className="font-semibold text-rose-400 hover:text-rose-500 flex gap-1 items-center text-sm justify-end mt-2"
+                className="font-semibold text-brand-fg hover:text-brand-fg-hover flex gap-1 items-center text-sm justify-end mt-2"
               >
                 View event
                 <ArrowRightIcon className="h-4 w-4" />

--- a/app/(site)/toast.tsx
+++ b/app/(site)/toast.tsx
@@ -73,14 +73,14 @@ function ToastItem({
   return (
     <div
       role="status"
-      className="pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-lg bg-gray-900 px-4 py-3 text-white shadow-lg"
+      className="pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-lg bg-bar px-4 py-3 text-bar-fg shadow-lg"
     >
       <p className="flex-1 text-sm">{message}</p>
       <button
         type="button"
         aria-label="Dismiss"
         onClick={() => onDismiss(id)}
-        className="shrink-0 rounded p-1 hover:bg-white/20 active:bg-white/30"
+        className="shrink-0 rounded p-1 hover:bg-bar-fg/20 active:bg-bar-fg/30"
       >
         <XMarkIcon className="h-5 w-5" />
       </button>

--- a/app/(site)/user-select.tsx
+++ b/app/(site)/user-select.tsx
@@ -51,7 +51,7 @@ export function UserSelect({
           selectMany={false}
           showProtected
         />
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-danger-fg">{error}</p>}
         {pendingGuest && (
           <GuestLoginForm
             guestId={pendingGuest.id}

--- a/app/admin/admin-header.tsx
+++ b/app/admin/admin-header.tsx
@@ -33,8 +33,8 @@ function NavLinks({ block }: { block?: boolean }) {
               "px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
               block && "block",
               active
-                ? "bg-white/15 text-white"
-                : "text-gray-300 hover:bg-white/10 hover:text-white"
+                ? "bg-bar-fg/15 text-bar-fg"
+                : "text-bar-fg-subtle hover:bg-bar-fg/10 hover:text-bar-fg"
             )}
           >
             {link.label}
@@ -53,11 +53,14 @@ export function AdminHeader({
   isAdmin: boolean;
 }) {
   return (
-    <Disclosure as="header" className="bg-gray-900 text-white">
+    <Disclosure as="header" className="bg-bar text-bar-fg">
       {({ open }) => (
         <>
           <div className="max-w-6xl mx-auto px-3 lg:px-8 py-3 flex items-center justify-between gap-4">
-            <Link href="/admin" className="font-semibold hover:text-gray-300">
+            <Link
+              href="/admin"
+              className="font-semibold hover:text-bar-fg-subtle"
+            >
               {title} Admin
             </Link>
 
@@ -72,7 +75,7 @@ export function AdminHeader({
                 {/* Mobile: collapse everything behind a hamburger */}
                 <Disclosure.Button
                   aria-label={open ? "Close admin menu" : "Open admin menu"}
-                  className="sm:hidden inline-flex items-center justify-center rounded-md p-2 text-gray-300 hover:bg-gray-800 hover:text-white"
+                  className="sm:hidden inline-flex items-center justify-center rounded-md p-2 text-bar-fg-subtle hover:bg-bar-fg/10 hover:text-bar-fg"
                 >
                   {open ? (
                     <XMarkIcon className="h-6 w-6" />
@@ -85,7 +88,7 @@ export function AdminHeader({
           </div>
 
           {isAdmin && (
-            <Disclosure.Panel className="sm:hidden border-t border-gray-800 px-3 py-3 space-y-3">
+            <Disclosure.Panel className="sm:hidden border-t border-bar-fg/20 px-3 py-3 space-y-3">
               <NavLinks block />
               <AdminLogoutButton />
             </Disclosure.Panel>

--- a/app/admin/buttons.ts
+++ b/app/admin/buttons.ts
@@ -1,6 +1,6 @@
 export const PRIMARY_BUTTON =
-  "px-3 py-2 text-sm font-medium rounded-md text-white bg-rose-600 hover:bg-rose-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+  "px-3 py-2 text-sm font-medium rounded-md text-on-brand bg-brand hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 export const SECONDARY_BUTTON =
-  "px-3 py-2 text-sm font-medium rounded-md text-gray-700 bg-gray-100 hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+  "px-3 py-2 text-sm font-medium rounded-md text-fg-muted bg-surface-muted hover:bg-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 export const DANGER_BUTTON =
-  "px-3 py-2 text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+  "px-3 py-2 text-sm font-medium rounded-md text-on-danger bg-danger hover:bg-danger-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed";

--- a/app/admin/data-table.tsx
+++ b/app/admin/data-table.tsx
@@ -72,18 +72,18 @@ export function BulkActionsBar({
     <div
       role="region"
       aria-label="Bulk actions"
-      className={`flex flex-wrap items-center gap-3 rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm ${
+      className={`flex flex-wrap items-center gap-3 rounded-md border border-line bg-surface-sunken px-3 py-2 text-sm ${
         selectedCount === 0 ? "invisible" : ""
       }`}
     >
-      <span className="font-medium text-gray-700">
+      <span className="font-medium text-fg-muted">
         {selectedCount} selected
       </span>
       <button
         type="button"
         onClick={onAssign}
         disabled={isPending}
-        className="px-3 py-1 rounded-md border border-gray-900 bg-gray-900 text-white disabled:opacity-50 hover:bg-gray-700"
+        className="px-3 py-1 rounded-md border border-line-strong bg-surface-inverse text-fg-inverse disabled:opacity-50 hover:bg-surface-inverse-hover"
       >
         Assign selected
       </button>
@@ -91,14 +91,14 @@ export function BulkActionsBar({
         type="button"
         onClick={onRemove}
         disabled={isPending}
-        className="px-3 py-1 rounded-md border border-gray-300 bg-white text-gray-700 disabled:opacity-50 hover:bg-gray-50"
+        className="px-3 py-1 rounded-md border border-line bg-surface-raised text-fg-muted disabled:opacity-50 hover:bg-surface-sunken"
       >
         Remove selected
       </button>
       <button
         type="button"
         onClick={onClear}
-        className="px-3 py-1 rounded-md text-gray-600 hover:text-gray-900"
+        className="px-3 py-1 rounded-md text-fg-muted hover:text-fg"
       >
         Clear
       </button>
@@ -188,11 +188,11 @@ export function DataTable<T>({
             defaultValue={searchQuery}
             placeholder={searchPlaceholder}
             aria-label="Search"
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 focus:border-gray-500 focus:outline-none"
+            className="px-3 py-1.5 text-sm rounded-md border border-line focus:border-line-strong focus:outline-none"
           />
           <button
             type="submit"
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+            className="px-3 py-1.5 text-sm rounded-md border border-line bg-surface-raised text-fg-muted hover:bg-surface-sunken"
           >
             Search
           </button>
@@ -203,9 +203,9 @@ export function DataTable<T>({
       {bulkBar}
 
       {rows.length === 0 ? (
-        <p className="text-sm text-gray-500">{emptyMessage}</p>
+        <p className="text-sm text-fg-subtle">{emptyMessage}</p>
       ) : listItem ? (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+        <ul className="divide-y divide-line-subtle border-t border-b border-line-subtle">
           {rows.map((row) => (
             <li key={rowKey(row)} className="py-3">
               {listItem(row)}
@@ -217,7 +217,7 @@ export function DataTable<T>({
           {/* Desktop: a table. */}
           <table className="hidden w-full text-sm sm:table">
             <thead>
-              <tr className="border-b border-gray-200 text-left text-gray-600">
+              <tr className="border-b border-line-subtle text-left text-fg-muted">
                 {selection && (
                   <th className="py-2 pr-4 font-medium">
                     <input
@@ -247,7 +247,7 @@ export function DataTable<T>({
             </thead>
             <tbody>
               {rows.map((row) => (
-                <tr key={rowKey(row)} className="border-b border-gray-100">
+                <tr key={rowKey(row)} className="border-b border-line-subtle">
                   {selection && (
                     <td className="py-2 pr-4">
                       <input
@@ -277,7 +277,7 @@ export function DataTable<T>({
             {rows.map((row) => (
               <li
                 key={rowKey(row)}
-                className="flex items-start gap-3 rounded-md border border-gray-200 p-3"
+                className="flex items-start gap-3 rounded-md border border-line-subtle p-3"
               >
                 {selection && (
                   <input
@@ -295,7 +295,7 @@ export function DataTable<T>({
         </>
       )}
 
-      <div className="flex items-center justify-between text-sm text-gray-600">
+      <div className="flex items-center justify-between text-sm text-fg-muted">
         <span>
           {total === 0
             ? "0 results"
@@ -307,7 +307,7 @@ export function DataTable<T>({
             onClick={() => setParams({ page: String(page - 1) })}
             disabled={page <= 1}
             aria-label="Previous page"
-            className="px-3 py-1 rounded-md border border-gray-300 bg-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50"
+            className="px-3 py-1 rounded-md border border-line bg-surface-raised disabled:opacity-40 disabled:cursor-not-allowed hover:bg-surface-sunken"
           >
             Prev
           </button>
@@ -319,7 +319,7 @@ export function DataTable<T>({
             onClick={() => setParams({ page: String(page + 1) })}
             disabled={page >= totalPages}
             aria-label="Next page"
-            className="px-3 py-1 rounded-md border border-gray-300 bg-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50"
+            className="px-3 py-1 rounded-md border border-line bg-surface-raised disabled:opacity-40 disabled:cursor-not-allowed hover:bg-surface-sunken"
           >
             Next
           </button>

--- a/app/admin/events/[id]/event-days-manager.tsx
+++ b/app/admin/events/[id]/event-days-manager.tsx
@@ -102,12 +102,12 @@ function AddDayForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="space-y-3 border border-gray-200 rounded-md p-4"
+      className="space-y-3 border border-line-subtle rounded-md p-4"
     >
-      <h3 className="font-medium text-gray-900">New day</h3>
+      <h3 className="font-medium text-fg">New day</h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1">
-          <label htmlFor="day-start" className="text-sm text-gray-600">
+          <label htmlFor="day-start" className="text-sm text-fg-muted">
             Start *
           </label>
           <Input
@@ -120,7 +120,7 @@ function AddDayForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="day-end" className="text-sm text-gray-600">
+          <label htmlFor="day-end" className="text-sm text-fg-muted">
             End *
           </label>
           <Input
@@ -133,7 +133,7 @@ function AddDayForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="day-sb" className="text-sm text-gray-600">
+          <label htmlFor="day-sb" className="text-sm text-fg-muted">
             Bookings open *
           </label>
           <Input
@@ -146,7 +146,7 @@ function AddDayForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="day-eb" className="text-sm text-gray-600">
+          <label htmlFor="day-eb" className="text-sm text-fg-muted">
             Bookings close *
           </label>
           <Input
@@ -252,8 +252,8 @@ function DayRow({
     const affected = day.affectedSessionTitles;
     return (
       <li className="py-3 space-y-2">
-        <p className="text-sm text-gray-700">{label}</p>
-        <p className="text-sm text-red-700">
+        <p className="text-sm text-fg-muted">{label}</p>
+        <p className="text-sm text-danger-fg">
           {affected.length === 0
             ? "Delete this day? No scheduled sessions fall within its time window."
             : `Delete this day? The following ${
@@ -263,7 +263,7 @@ function DayRow({
               } scheduled within its time window will also be deleted:`}
         </p>
         {affected.length > 0 && (
-          <ul className="list-disc list-inside text-sm text-red-700">
+          <ul className="list-disc list-inside text-sm text-danger-fg">
             {affected.map((title, i) => (
               <li key={`${title}-${i}`}>{title}</li>
             ))}
@@ -297,7 +297,7 @@ function DayRow({
             <div className="flex flex-col gap-1">
               <label
                 htmlFor={`day-start-${day.id}`}
-                className="text-sm text-gray-600"
+                className="text-sm text-fg-muted"
               >
                 Start *
               </label>
@@ -313,7 +313,7 @@ function DayRow({
             <div className="flex flex-col gap-1">
               <label
                 htmlFor={`day-end-${day.id}`}
-                className="text-sm text-gray-600"
+                className="text-sm text-fg-muted"
               >
                 End *
               </label>
@@ -329,7 +329,7 @@ function DayRow({
             <div className="flex flex-col gap-1">
               <label
                 htmlFor={`day-sb-${day.id}`}
-                className="text-sm text-gray-600"
+                className="text-sm text-fg-muted"
               >
                 Bookings open *
               </label>
@@ -345,7 +345,7 @@ function DayRow({
             <div className="flex flex-col gap-1">
               <label
                 htmlFor={`day-eb-${day.id}`}
-                className="text-sm text-gray-600"
+                className="text-sm text-fg-muted"
               >
                 Bookings close *
               </label>
@@ -383,7 +383,7 @@ function DayRow({
 
   return (
     <li className="py-3 flex items-center justify-between gap-3">
-      <p className="text-sm text-gray-700">{label}</p>
+      <p className="text-sm text-fg-muted">{label}</p>
       <div className="flex gap-2 shrink-0">
         <button
           onClick={() => setEditMode(true)}
@@ -417,14 +417,14 @@ export function EventDaysManager({
 
   return (
     <section aria-label="Days" className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Days</h2>
-      <p className="text-sm text-gray-500">
+      <h2 className="text-lg font-semibold text-fg">Days</h2>
+      <p className="text-sm text-fg-subtle">
         All times are in the event timezone ({timezone}).
       </p>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       {days.length > 0 && (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+        <ul className="divide-y divide-line-subtle border-t border-b border-line-subtle">
           {days.map((day) => (
             <DayRow
               key={day.id}

--- a/app/admin/events/[id]/event-detail-form.tsx
+++ b/app/admin/events/[id]/event-detail-form.tsx
@@ -80,10 +80,10 @@ export function EventDetailForm({ event }: { event: Event }) {
   return (
     <div className="space-y-8">
       <form onSubmit={handleSave} className="space-y-4">
-        <h2 className="text-lg font-semibold text-gray-900">Basic info</h2>
-        {saveError && <p className="text-sm text-red-600">{saveError}</p>}
+        <h2 className="text-lg font-semibold text-fg">Basic info</h2>
+        {saveError && <p className="text-sm text-danger-fg">{saveError}</p>}
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-name" className="text-sm text-gray-600">
+          <label htmlFor="ev-name" className="text-sm text-fg-muted">
             Name *
           </label>
           <Input
@@ -95,7 +95,7 @@ export function EventDetailForm({ event }: { event: Event }) {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-description" className="text-sm text-gray-600">
+          <label htmlFor="ev-description" className="text-sm text-fg-muted">
             Description
           </label>
           <MarkdownTextarea
@@ -107,7 +107,7 @@ export function EventDetailForm({ event }: { event: Event }) {
           <MarkdownHint />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-website" className="text-sm text-gray-600">
+          <label htmlFor="ev-website" className="text-sm text-fg-muted">
             Website
           </label>
           <Input
@@ -119,7 +119,7 @@ export function EventDetailForm({ event }: { event: Event }) {
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-start" className="text-sm text-gray-600">
+            <label htmlFor="ev-start" className="text-sm text-fg-muted">
               Start *
             </label>
             <Input
@@ -132,7 +132,7 @@ export function EventDetailForm({ event }: { event: Event }) {
             />
           </div>
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-end" className="text-sm text-gray-600">
+            <label htmlFor="ev-end" className="text-sm text-fg-muted">
               End *
             </label>
             <Input
@@ -147,7 +147,7 @@ export function EventDetailForm({ event }: { event: Event }) {
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-timezone" className="text-sm text-gray-600">
+            <label htmlFor="ev-timezone" className="text-sm text-fg-muted">
               Timezone *
             </label>
             <TimezoneSelect
@@ -157,7 +157,7 @@ export function EventDetailForm({ event }: { event: Event }) {
             />
           </div>
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-duration" className="text-sm text-gray-600">
+            <label htmlFor="ev-duration" className="text-sm text-fg-muted">
               Max session duration (min)
             </label>
             <Input
@@ -171,7 +171,7 @@ export function EventDetailForm({ event }: { event: Event }) {
             />
           </div>
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-break" className="text-sm text-gray-600">
+            <label htmlFor="ev-break" className="text-sm text-fg-muted">
               Break before each session (min)
             </label>
             <Input
@@ -185,14 +185,14 @@ export function EventDetailForm({ event }: { event: Event }) {
             />
           </div>
           <div className="flex flex-col gap-1">
-            <label htmlFor="ev-increment" className="text-sm text-gray-600">
+            <label htmlFor="ev-increment" className="text-sm text-fg-muted">
               Schedule increment (min)
             </label>
             <select
               id="ev-increment"
               value={form.slotIncrementMinutes}
               onChange={(e) => set("slotIncrementMinutes", e.target.value)}
-              className="w-full h-10 rounded-md border border-gray-300 bg-white px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-rose-400"
+              className="w-full h-10 rounded-md border border-line bg-surface-raised px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-accent"
             >
               {SLOT_INCREMENT_OPTIONS.map((opt) => (
                 <option key={opt} value={String(opt)}>
@@ -208,15 +208,15 @@ export function EventDetailForm({ event }: { event: Event }) {
             type="checkbox"
             checked={form.rsvpCapacityHardLimit ?? false}
             onChange={(e) => set("rsvpCapacityHardLimit", e.target.checked)}
-            className="mt-0.5 h-4 w-4 rounded border-gray-300 text-rose-500 focus:ring-rose-400"
+            className="mt-0.5 h-4 w-4 rounded border-line text-brand-fg focus:ring-brand-accent"
           />
-          <label htmlFor="ev-rsvp-hard-limit" className="text-sm text-gray-600">
+          <label htmlFor="ev-rsvp-hard-limit" className="text-sm text-fg-muted">
             Enforce session capacity as a hard limit — reject RSVPs once a
             session is full (capacity 0 means unlimited)
           </label>
         </div>
         <div className="flex flex-col gap-1">
-          <span className="text-sm text-gray-600">Icon</span>
+          <span className="text-sm text-fg-muted">Icon</span>
           <IconPicker
             label="Icon"
             value={form.icon ?? ""}
@@ -228,28 +228,28 @@ export function EventDetailForm({ event }: { event: Event }) {
             {isSaving ? "Saving..." : "Save changes"}
           </button>
           {saveSuccess && (
-            <span className="text-sm text-green-600">Saved!</span>
+            <span className="text-sm text-success-fg">Saved!</span>
           )}
         </div>
       </form>
 
       <section
         aria-label="Danger zone"
-        className="border-t border-red-200 pt-6 space-y-3"
+        className="border-t border-danger-border pt-6 space-y-3"
       >
-        <h2 className="text-lg font-semibold text-red-700">Danger zone</h2>
+        <h2 className="text-lg font-semibold text-danger-fg">Danger zone</h2>
         {!deleteMode ? (
           <button onClick={() => setDeleteMode(true)} className={DANGER_BUTTON}>
             Delete event
           </button>
         ) : (
-          <div className="space-y-3 rounded-md border border-red-200 p-4">
-            <p className="text-sm text-red-700">
+          <div className="space-y-3 rounded-md border border-danger-border p-4">
+            <p className="text-sm text-danger-fg">
               This will permanently delete the event and all associated days,
               proposals, sessions, RSVPs, and assignments.
             </p>
             <div className="flex flex-col gap-1">
-              <label htmlFor="delete-confirm" className="text-sm text-gray-700">
+              <label htmlFor="delete-confirm" className="text-sm text-fg-muted">
                 Type the event name to confirm
               </label>
               <Input

--- a/app/admin/events/[id]/event-guests-manager.tsx
+++ b/app/admin/events/[id]/event-guests-manager.tsx
@@ -163,7 +163,7 @@ export function EventGuestsManager({
 
   const columns: Column<GuestRow>[] = [
     { header: "Name", cell: (g) => g.name },
-    { header: "Email", cell: (g) => g.email, cellClassName: "text-gray-500" },
+    { header: "Email", cell: (g) => g.email, cellClassName: "text-fg-subtle" },
     { header: "Assigned", cell: assignedCheckbox },
   ];
 
@@ -181,8 +181,8 @@ export function EventGuestsManager({
           }
           className={`px-3 py-1 text-sm rounded-md border ${
             filter === f.value
-              ? "bg-gray-900 text-white border-gray-900"
-              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              ? "bg-surface-inverse text-fg-inverse border-line-strong"
+              : "bg-surface-raised text-fg-muted border-line hover:bg-surface-sunken"
           }`}
         >
           {f.label}
@@ -193,8 +193,8 @@ export function EventGuestsManager({
 
   return (
     <section aria-label="Guests" className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Guests</h2>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      <h2 className="text-lg font-semibold text-fg">Guests</h2>
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       <DataTable
         rows={guests}
@@ -212,8 +212,8 @@ export function EventGuestsManager({
         mobileCard={(g) => (
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="font-medium text-gray-900">{g.name}</p>
-              <p className="truncate text-gray-500">{g.email}</p>
+              <p className="font-medium text-fg">{g.name}</p>
+              <p className="truncate text-fg-subtle">{g.email}</p>
             </div>
             {assignedCheckbox(g)}
           </div>

--- a/app/admin/events/[id]/event-locations-manager.tsx
+++ b/app/admin/events/[id]/event-locations-manager.tsx
@@ -166,7 +166,7 @@ export function EventLocationsManager({
     {
       header: "Capacity",
       cell: (l) => l.capacity,
-      cellClassName: "text-gray-500",
+      cellClassName: "text-fg-subtle",
     },
     { header: "Assigned", cell: assignedCheckbox },
   ];
@@ -185,8 +185,8 @@ export function EventLocationsManager({
           }
           className={`px-3 py-1 text-sm rounded-md border ${
             filter === f.value
-              ? "bg-gray-900 text-white border-gray-900"
-              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              ? "bg-surface-inverse text-fg-inverse border-line-strong"
+              : "bg-surface-raised text-fg-muted border-line hover:bg-surface-sunken"
           }`}
         >
           {f.label}
@@ -197,8 +197,8 @@ export function EventLocationsManager({
 
   return (
     <section aria-label="Locations" className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Locations</h2>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      <h2 className="text-lg font-semibold text-fg">Locations</h2>
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       <DataTable
         rows={locations}
@@ -216,8 +216,8 @@ export function EventLocationsManager({
         mobileCard={(l) => (
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="font-medium text-gray-900">{l.name}</p>
-              <p className="text-gray-500">Capacity: {l.capacity}</p>
+              <p className="font-medium text-fg">{l.name}</p>
+              <p className="text-fg-subtle">Capacity: {l.capacity}</p>
             </div>
             {assignedCheckbox(l)}
           </div>

--- a/app/admin/events/[id]/event-phases-form.tsx
+++ b/app/admin/events/[id]/event-phases-form.tsx
@@ -57,13 +57,13 @@ export function EventPhasesForm({ event }: { event: Event }) {
 
   return (
     <form onSubmit={handleSave} className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Phases</h2>
-      <p className="text-sm text-gray-500">
+      <h2 className="text-lg font-semibold text-fg">Phases</h2>
+      <p className="text-sm text-fg-subtle">
         All times are in the event timezone ({event.timezone}). Leave fields
         empty to unset a phase. A phase with no end runs until the next phase
         starts; set an end earlier than the next start to leave an inactive gap.
       </p>
-      {saveError && <p className="text-sm text-red-600">{saveError}</p>}
+      {saveError && <p className="text-sm text-danger-fg">{saveError}</p>}
 
       {(
         [
@@ -85,10 +85,10 @@ export function EventPhasesForm({ event }: { event: Event }) {
         ] as const
       ).map(({ label, startKey, endKey }) => (
         <fieldset key={label}>
-          <legend className="text-sm font-medium text-gray-700">{label}</legend>
+          <legend className="text-sm font-medium text-fg-muted">{label}</legend>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
             <div className="flex flex-col gap-1">
-              <label htmlFor={startKey} className="text-sm text-gray-600">
+              <label htmlFor={startKey} className="text-sm text-fg-muted">
                 Start
               </label>
               <Input
@@ -100,7 +100,7 @@ export function EventPhasesForm({ event }: { event: Event }) {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <label htmlFor={endKey} className="text-sm text-gray-600">
+              <label htmlFor={endKey} className="text-sm text-fg-muted">
                 End
               </label>
               <Input
@@ -119,7 +119,7 @@ export function EventPhasesForm({ event }: { event: Event }) {
         <button type="submit" disabled={isSaving} className={PRIMARY_BUTTON}>
           {isSaving ? "Saving..." : "Save phases"}
         </button>
-        {saveSuccess && <span className="text-sm text-green-600">Saved!</span>}
+        {saveSuccess && <span className="text-sm text-success-fg">Saved!</span>}
       </div>
     </form>
   );

--- a/app/admin/events/[id]/event-proposals-manager.tsx
+++ b/app/admin/events/[id]/event-proposals-manager.tsx
@@ -128,8 +128,8 @@ function ProposalItem({
         : "";
     return (
       <div className="space-y-2">
-        <p className="font-medium text-gray-900">{proposal.title}</p>
-        <p className="text-sm text-red-700">
+        <p className="font-medium text-fg">{proposal.title}</p>
+        <p className="text-sm text-danger-fg">
           This will permanently delete the proposal, its {proposal.votesCount}{" "}
           {proposal.votesCount === 1 ? "vote" : "votes"} and{" "}
           {proposal.hosts.length}{" "}
@@ -139,7 +139,7 @@ function ProposalItem({
         <div className="flex flex-col gap-1">
           <label
             htmlFor={`prop-delete-${proposal.id}`}
-            className="text-sm text-gray-700"
+            className="text-sm text-fg-muted"
           >
             Type the proposal title to confirm
           </label>
@@ -179,8 +179,8 @@ function ProposalItem({
     return (
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1">
-          <p className="font-medium text-gray-900">{proposal.title}</p>
-          <p className="text-sm text-gray-500">
+          <p className="font-medium text-fg">{proposal.title}</p>
+          <p className="text-sm text-fg-subtle">
             Hosts: {hostLabel(proposal.hosts)} · {proposal.votesCount}{" "}
             {proposal.votesCount === 1 ? "vote" : "votes"}
           </p>
@@ -213,7 +213,7 @@ function ProposalItem({
       <div className="flex flex-col gap-1">
         <label
           htmlFor={`prop-title-${proposal.id}`}
-          className="text-sm text-gray-600"
+          className="text-sm text-fg-muted"
         >
           Title *
         </label>
@@ -228,7 +228,7 @@ function ProposalItem({
       <div className="flex flex-col gap-1">
         <label
           htmlFor={`prop-desc-${proposal.id}`}
-          className="text-sm text-gray-600"
+          className="text-sm text-fg-muted"
         >
           Description
         </label>
@@ -236,14 +236,14 @@ function ProposalItem({
           id={`prop-desc-${proposal.id}`}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
+          className="w-full rounded-md border border-line px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-line"
         />
         <MarkdownHint />
       </div>
       <div className="flex flex-col gap-1">
         <label
           htmlFor={`prop-duration-${proposal.id}`}
-          className="text-sm text-gray-600"
+          className="text-sm text-fg-muted"
         >
           Duration (minutes) — leave empty for undecided
         </label>
@@ -260,12 +260,12 @@ function ProposalItem({
       <div className="flex flex-col gap-1">
         <label
           htmlFor={`prop-hosts-${proposal.id}`}
-          className="text-sm text-gray-600"
+          className="text-sm text-fg-muted"
         >
           Hosts
         </label>
         {hostCandidates.length === 0 ? (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-fg-subtle">
             No guests assigned to this event yet.
           </p>
         ) : (
@@ -318,8 +318,8 @@ export function EventProposalsManager({
 
   return (
     <section aria-label="Proposals" className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Proposals</h2>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      <h2 className="text-lg font-semibold text-fg">Proposals</h2>
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       <DataTable
         rows={proposals}

--- a/app/admin/events/[id]/event-sessions-manager.tsx
+++ b/app/admin/events/[id]/event-sessions-manager.tsx
@@ -133,11 +133,11 @@ function SessionRsvps({
 
   return (
     <details className="text-sm">
-      <summary className="cursor-pointer text-gray-600">
+      <summary className="cursor-pointer text-fg-muted">
         RSVPs ({session.rsvps.length})
       </summary>
       {session.rsvps.length === 0 ? (
-        <p className="mt-2 text-gray-500">No RSVPs.</p>
+        <p className="mt-2 text-fg-subtle">No RSVPs.</p>
       ) : (
         <ul className="mt-2 space-y-1">
           {session.rsvps.map((r) => (
@@ -145,21 +145,21 @@ function SessionRsvps({
               key={r.guestId}
               className="flex items-center justify-between gap-3"
             >
-              <span className="text-gray-700">{r.name}</span>
+              <span className="text-fg-muted">{r.name}</span>
               {confirmingId === r.guestId ? (
                 <span className="flex items-center gap-2">
-                  <span className="text-red-700">Remove?</span>
+                  <span className="text-danger-fg">Remove?</span>
                   <button
                     onClick={() => remove(r.guestId)}
                     disabled={pendingId === r.guestId}
-                    className="text-red-600 hover:underline"
+                    className="text-danger-fg hover:underline"
                   >
                     Confirm
                   </button>
                   <button
                     onClick={() => setConfirmingId(null)}
                     disabled={pendingId === r.guestId}
-                    className="text-gray-500 hover:underline"
+                    className="text-fg-subtle hover:underline"
                   >
                     Cancel
                   </button>
@@ -167,7 +167,7 @@ function SessionRsvps({
               ) : (
                 <button
                   onClick={() => setConfirmingId(r.guestId)}
-                  className="text-red-600 hover:underline"
+                  className="text-danger-fg hover:underline"
                   aria-label={`Remove RSVP ${r.name}`}
                 >
                   Remove
@@ -245,7 +245,7 @@ function SessionForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
       <div className="flex flex-col gap-1">
-        <label htmlFor={`${idPrefix}-title`} className="text-sm text-gray-600">
+        <label htmlFor={`${idPrefix}-title`} className="text-sm text-fg-muted">
           Title *
         </label>
         <Input
@@ -257,14 +257,14 @@ function SessionForm({
         />
       </div>
       <div className="flex flex-col gap-1">
-        <label htmlFor={`${idPrefix}-desc`} className="text-sm text-gray-600">
+        <label htmlFor={`${idPrefix}-desc`} className="text-sm text-fg-muted">
           Description
         </label>
         <textarea
           id={`${idPrefix}-desc`}
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-gray-400"
+          className="w-full rounded-md border border-line px-3 py-2 text-sm shadow-sm resize-y h-24 focus:outline-none focus:ring-2 focus:ring-line"
         />
         <MarkdownHint />
       </div>
@@ -272,7 +272,7 @@ function SessionForm({
         <div className="flex flex-col gap-1">
           <label
             htmlFor={`${idPrefix}-start`}
-            className="text-sm text-gray-600"
+            className="text-sm text-fg-muted"
           >
             Start ({timezone}) — leave empty if not scheduled
           </label>
@@ -286,7 +286,7 @@ function SessionForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor={`${idPrefix}-end`} className="text-sm text-gray-600">
+          <label htmlFor={`${idPrefix}-end`} className="text-sm text-fg-muted">
             End ({timezone})
           </label>
           <Input
@@ -302,7 +302,7 @@ function SessionForm({
       <div className="flex flex-col gap-1">
         <label
           htmlFor={`${idPrefix}-capacity`}
-          className="text-sm text-gray-600"
+          className="text-sm text-fg-muted"
         >
           Capacity
         </label>
@@ -316,8 +316,8 @@ function SessionForm({
         />
       </div>
       <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Flags</legend>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        <legend className="text-sm text-fg-muted">Flags</legend>
+        <label className="flex items-center gap-2 text-sm text-fg-muted">
           <input
             type="checkbox"
             checked={blocker}
@@ -326,7 +326,7 @@ function SessionForm({
           />
           Blocker
         </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        <label className="flex items-center gap-2 text-sm text-fg-muted">
           <input
             type="checkbox"
             checked={closed}
@@ -335,7 +335,7 @@ function SessionForm({
           />
           Closed
         </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        <label className="flex items-center gap-2 text-sm text-fg-muted">
           <input
             type="checkbox"
             checked={adminManaged}
@@ -346,11 +346,11 @@ function SessionForm({
         </label>
       </fieldset>
       <div className="flex flex-col gap-1">
-        <label htmlFor={`${idPrefix}-hosts`} className="text-sm text-gray-600">
+        <label htmlFor={`${idPrefix}-hosts`} className="text-sm text-fg-muted">
           Hosts
         </label>
         {hostCandidates.length === 0 ? (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-fg-subtle">
             No guests assigned to this event yet.
           </p>
         ) : (
@@ -364,16 +364,16 @@ function SessionForm({
         )}
       </div>
       <fieldset className="flex flex-col gap-1">
-        <legend className="text-sm text-gray-600">Locations</legend>
+        <legend className="text-sm text-fg-muted">Locations</legend>
         {locationCandidates.length === 0 ? (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-fg-subtle">
             No locations assigned to this event yet.
           </p>
         ) : (
           locationCandidates.map((l) => (
             <label
               key={l.id}
-              className="flex items-center gap-2 text-sm text-gray-700"
+              className="flex items-center gap-2 text-sm text-fg-muted"
             >
               <input
                 type="checkbox"
@@ -478,8 +478,8 @@ function SessionItem({
   if (deleteMode) {
     return (
       <div className="space-y-2">
-        <p className="font-medium text-gray-900">{session.title}</p>
-        <p className="text-sm text-red-700">
+        <p className="font-medium text-fg">{session.title}</p>
+        <p className="text-sm text-danger-fg">
           This will permanently delete the session and its {session.numRsvps}{" "}
           {session.numRsvps === 1 ? "RSVP" : "RSVPs"}. Host and location links
           are removed; the guests and locations themselves are kept.
@@ -487,7 +487,7 @@ function SessionItem({
         <div className="flex flex-col gap-1">
           <label
             htmlFor={`sess-delete-${session.id}`}
-            className="text-sm text-gray-700"
+            className="text-sm text-fg-muted"
           >
             Type the session title to confirm
           </label>
@@ -528,11 +528,11 @@ function SessionItem({
       <div className="space-y-3">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
-            <p className="font-medium text-gray-900">{session.title}</p>
-            <p className="text-sm text-gray-500">
+            <p className="font-medium text-fg">{session.title}</p>
+            <p className="text-sm text-fg-subtle">
               {timeLabel(session, timezone)} · {joinNames(session.locations)}
             </p>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-fg-subtle">
               Hosts: {joinNames(session.hosts)} · {session.numRsvps} RSVPs
               {flagLabels(session).length > 0
                 ? ` · ${flagLabels(session).join(", ")}`
@@ -655,8 +655,8 @@ function AddSession({
   }
 
   return (
-    <div className="space-y-3 border border-gray-200 rounded-md p-4">
-      <h3 className="font-medium text-gray-900">New session</h3>
+    <div className="space-y-3 border border-line-subtle rounded-md p-4">
+      <h3 className="font-medium text-fg">New session</h3>
       <SessionForm
         initial={EMPTY_SESSION}
         idPrefix="sess-new"
@@ -704,11 +704,11 @@ export function EventSessionsManager({
 
   return (
     <section aria-label="Sessions" className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-900">Sessions</h2>
-      <p className="text-sm text-gray-500">
+      <h2 className="text-lg font-semibold text-fg">Sessions</h2>
+      <p className="text-sm text-fg-subtle">
         All times are in the event timezone ({timezone}).
       </p>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-danger-fg">{error}</p>}
 
       <AddSession
         eventId={eventId}

--- a/app/admin/events/[id]/event-tabs.tsx
+++ b/app/admin/events/[id]/event-tabs.tsx
@@ -18,7 +18,7 @@ export function EventTabs({ eventId }: { eventId: string }) {
   return (
     <nav
       aria-label="Event sections"
-      className="flex gap-1 border-b border-gray-200 overflow-x-auto"
+      className="flex gap-1 border-b border-line-subtle overflow-x-auto"
     >
       {tabs.map((tab) => {
         // Config is the base route, so it must match exactly; the others match
@@ -35,8 +35,8 @@ export function EventTabs({ eventId }: { eventId: string }) {
             className={clsx(
               "px-3 py-2 text-sm font-medium border-b-2 -mb-px whitespace-nowrap transition-colors",
               active
-                ? "border-gray-900 text-gray-900"
-                : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                ? "border-line-strong text-fg"
+                : "border-transparent text-fg-subtle hover:text-fg-muted hover:border-line"
             )}
           >
             {tab.label}

--- a/app/admin/events/[id]/layout.tsx
+++ b/app/admin/events/[id]/layout.tsx
@@ -22,7 +22,7 @@ export default async function AdminEventDetailLayout({
       <div>
         <BackLink href="/admin/events">Events</BackLink>
       </div>
-      <h1 className="text-2xl font-bold text-gray-900">{event.name}</h1>
+      <h1 className="text-2xl font-bold text-fg">{event.name}</h1>
       <EventTabs eventId={id} />
       {children}
     </div>

--- a/app/admin/events/[id]/page.tsx
+++ b/app/admin/events/[id]/page.tsx
@@ -37,11 +37,11 @@ export default async function AdminEventConfigPage({
       <div className="max-w-3xl">
         <EventDetailForm event={event} />
       </div>
-      <hr className="border-gray-200" />
+      <hr className="border-line-subtle" />
       <div className="max-w-3xl">
         <EventPhasesForm event={event} />
       </div>
-      <hr className="border-gray-200" />
+      <hr className="border-line-subtle" />
       <EventDaysManager days={days} eventId={id} timezone={event.timezone} />
     </div>
   );

--- a/app/admin/events/events-manager.tsx
+++ b/app/admin/events/events-manager.tsx
@@ -64,11 +64,11 @@ function AddEventForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="space-y-3 border border-gray-200 rounded-md p-4 max-w-2xl"
+      className="space-y-3 border border-line-subtle rounded-md p-4 max-w-2xl"
     >
-      <h2 className="font-medium text-gray-900">New event</h2>
+      <h2 className="font-medium text-fg">New event</h2>
       <div className="flex flex-col gap-1">
-        <label htmlFor="ev-name" className="text-sm text-gray-600">
+        <label htmlFor="ev-name" className="text-sm text-fg-muted">
           Name *
         </label>
         <Input
@@ -80,7 +80,7 @@ function AddEventForm({
         />
       </div>
       <div className="flex flex-col gap-1">
-        <label htmlFor="ev-description" className="text-sm text-gray-600">
+        <label htmlFor="ev-description" className="text-sm text-fg-muted">
           Description
         </label>
         <textarea
@@ -88,12 +88,12 @@ function AddEventForm({
           value={form.description}
           onChange={(e) => set("description", e.target.value)}
           rows={3}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm resize-y focus:outline-none focus:ring-2 focus:ring-gray-400"
+          className="w-full rounded-md border border-line px-3 py-2 text-sm shadow-sm resize-y focus:outline-none focus:ring-2 focus:ring-line"
         />
         <MarkdownHint />
       </div>
       <div className="flex flex-col gap-1">
-        <label htmlFor="ev-website" className="text-sm text-gray-600">
+        <label htmlFor="ev-website" className="text-sm text-fg-muted">
           Website
         </label>
         <Input
@@ -105,7 +105,7 @@ function AddEventForm({
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-start" className="text-sm text-gray-600">
+          <label htmlFor="ev-start" className="text-sm text-fg-muted">
             Start *
           </label>
           <Input
@@ -118,7 +118,7 @@ function AddEventForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-end" className="text-sm text-gray-600">
+          <label htmlFor="ev-end" className="text-sm text-fg-muted">
             End *
           </label>
           <Input
@@ -133,7 +133,7 @@ function AddEventForm({
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-timezone" className="text-sm text-gray-600">
+          <label htmlFor="ev-timezone" className="text-sm text-fg-muted">
             Timezone *
           </label>
           <TimezoneSelect
@@ -143,7 +143,7 @@ function AddEventForm({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label htmlFor="ev-duration" className="text-sm text-gray-600">
+          <label htmlFor="ev-duration" className="text-sm text-fg-muted">
             Max session duration (min)
           </label>
           <Input
@@ -183,7 +183,7 @@ export function EventsManager({ events }: { events: Event[] }) {
   return (
     <div className="space-y-4">
       {error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger-fg">
           {error}
         </p>
       )}
@@ -191,19 +191,17 @@ export function EventsManager({ events }: { events: Event[] }) {
       <AddEventForm onError={setError} />
 
       {events.length === 0 ? (
-        <p className="text-sm text-gray-500">No events yet.</p>
+        <p className="text-sm text-fg-subtle">No events yet.</p>
       ) : (
-        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+        <ul className="divide-y divide-line-subtle border-t border-b border-line-subtle">
           {events.map((event) => (
             <li
               key={event.id}
               className="py-3 flex items-center justify-between gap-3"
             >
               <div className="min-w-0">
-                <p className="font-medium text-gray-900 truncate">
-                  {event.name}
-                </p>
-                <p className="text-sm text-gray-500">
+                <p className="font-medium text-fg truncate">{event.name}</p>
+                <p className="text-sm text-fg-subtle">
                   {formatEventDate(event.start)} – {formatEventDate(event.end)}
                   {" · "}
                   {event.timezone}

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -10,7 +10,7 @@ export default async function AdminEventsPage() {
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Events</h1>
+      <h1 className="text-2xl font-bold text-fg">Events</h1>
       <section aria-label="Events" className="space-y-4">
         <EventsManager events={events} />
       </section>

--- a/app/admin/guests-manager.tsx
+++ b/app/admin/guests-manager.tsx
@@ -50,7 +50,7 @@ function AddGuestForm() {
         className="flex flex-col sm:flex-row gap-2 sm:items-center"
       >
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor="new-user-name" className="text-sm text-gray-600">
+          <label htmlFor="new-user-name" className="text-sm text-fg-muted">
             Name
           </label>
           <Input
@@ -59,12 +59,12 @@ function AddGuestForm() {
             {...form.register("name")}
             className="w-full h-10"
           />
-          <span className="text-rose-400 text-sm min-h-(--text-sm)">
+          <span className="text-brand-fg text-sm min-h-(--text-sm)">
             {form.formState.errors.name?.message}
           </span>
         </div>
         <div className="flex flex-col gap-1 flex-1">
-          <label htmlFor="new-user-email" className="text-sm text-gray-600">
+          <label htmlFor="new-user-email" className="text-sm text-fg-muted">
             Email
           </label>
           <Input
@@ -74,7 +74,7 @@ function AddGuestForm() {
             {...form.register("email")}
             className="w-full h-10"
           />
-          <span className="text-rose-400 text-sm min-h-(--text-sm)">
+          <span className="text-brand-fg text-sm min-h-(--text-sm)">
             {form.formState.errors.email?.message}
           </span>
         </div>
@@ -89,7 +89,7 @@ function AddGuestForm() {
         </div>
       </form>
       {form.formState.errors.root && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger-fg">
           {form.formState.errors.root.message}
         </p>
       )}
@@ -181,7 +181,7 @@ function GuestRow({
               {...form.register("name")}
               className="flex-1 h-10"
             />
-            <span className="text-rose-400 text-sm min-h-(--text-sm)">
+            <span className="text-brand-fg text-sm min-h-(--text-sm)">
               {form.formState.errors.name?.message}
             </span>
           </div>
@@ -193,7 +193,7 @@ function GuestRow({
               {...form.register("email")}
               className="flex-1 h-10"
             />
-            <span className="text-rose-400 text-sm min-h-(--text-sm)">
+            <span className="text-brand-fg text-sm min-h-(--text-sm)">
               {form.formState.errors.email?.message}
             </span>
           </div>
@@ -219,7 +219,7 @@ function GuestRow({
           </div>
         </form>
         {form.formState.errors.root && (
-          <p role="alert" className="text-sm text-red-600">
+          <p role="alert" className="text-sm text-danger-fg">
             {form.formState.errors.root.message}
           </p>
         )}
@@ -231,16 +231,16 @@ function GuestRow({
     <div>
       <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
         <div className="flex-1 min-w-0">
-          <p className="font-medium text-gray-900 truncate">{guest.name}</p>
-          <p className="text-sm text-gray-500 truncate">{guest.info.email}</p>
+          <p className="font-medium text-fg truncate">{guest.name}</p>
+          <p className="text-sm text-fg-subtle truncate">{guest.info.email}</p>
           {events.length > 0 && (
-            <p className="text-sm text-gray-500 truncate">
+            <p className="text-sm text-fg-subtle truncate">
               {events.map((event, i) => (
                 <Fragment key={event.id}>
                   {i > 0 && " · "}
                   <Link
                     href={`/admin/events/${event.id}`}
-                    className="underline hover:text-gray-700"
+                    className="underline hover:text-fg-muted"
                   >
                     {event.name}
                   </Link>
@@ -251,7 +251,7 @@ function GuestRow({
         </div>
         {mode === "delete" ? (
           <div className="flex gap-2 items-center">
-            <span className="text-sm text-red-700">Delete this user?</span>
+            <span className="text-sm text-danger-fg">Delete this user?</span>
             <button
               onClick={handleDelete}
               disabled={isDeleting}
@@ -289,7 +289,7 @@ function GuestRow({
               }}
               className={clsx(
                 SECONDARY_BUTTON,
-                "text-red-700 hover:bg-red-50 bg-red-50/50"
+                "text-danger-fg hover:bg-danger-tint bg-danger-tint/50"
               )}
             >
               Delete
@@ -298,7 +298,7 @@ function GuestRow({
         )}
       </div>
       {viewError && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger-fg">
           {viewError}
         </p>
       )}

--- a/app/admin/icon-picker.tsx
+++ b/app/admin/icon-picker.tsx
@@ -24,7 +24,7 @@ export function IconPicker({
         selected={value === ""}
         onSelect={() => onChange("")}
       >
-        <NoSymbolIcon className="h-5 w-5 text-gray-300" />
+        <NoSymbolIcon className="h-5 w-5 text-fg-faint" />
       </IconOption>
       {Object.entries(EVENT_ICONS).map(([name, Icon]) => (
         <IconOption
@@ -61,8 +61,8 @@ function IconOption({
       onClick={onSelect}
       className={clsx(
         selected
-          ? "border-rose-400 bg-rose-50 text-rose-500"
-          : "border-gray-300 text-gray-500 hover:bg-gray-100",
+          ? "border-brand-accent bg-brand-tint text-brand-fg"
+          : "border-line text-fg-subtle hover:bg-surface-muted",
         "flex h-10 w-10 items-center justify-center rounded-md border"
       )}
     >

--- a/app/admin/locations/page.tsx
+++ b/app/admin/locations/page.tsx
@@ -21,7 +21,7 @@ export default async function AdminLocationsPage() {
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Locations</h1>
+      <h1 className="text-2xl font-bold text-fg">Locations</h1>
       <section aria-label="Locations" className="space-y-4">
         <LocationsManager
           locations={locations}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -16,8 +16,8 @@ function AdminLoginForm() {
   return (
     <div className="max-w-md w-full space-y-8">
       <div className="text-center">
-        <h2 className="mt-6 text-3xl font-bold text-gray-900">Admin Access</h2>
-        <p className="mt-2 text-sm text-gray-600">
+        <h2 className="mt-6 text-3xl font-bold text-fg">Admin Access</h2>
+        <p className="mt-2 text-sm text-fg-muted">
           Please enter the admin password
         </p>
       </div>
@@ -48,8 +48,8 @@ function AdminLoginForm() {
           <button
             type="submit"
             className={clsx(
-              "group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-rose-500",
-              "bg-rose-600 hover:bg-rose-700"
+              "group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-md text-on-brand transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-accent",
+              "bg-brand hover:bg-brand-hover"
             )}
           >
             Access Admin

--- a/app/admin/logout-button.tsx
+++ b/app/admin/logout-button.tsx
@@ -14,7 +14,7 @@ export function AdminLogoutButton() {
       disabled={isPending}
       className={clsx(
         "flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors",
-        "text-gray-300 hover:text-white hover:bg-gray-800",
+        "text-bar-fg-subtle hover:text-bar-fg hover:bg-bar-fg/10",
         "disabled:opacity-50 disabled:cursor-not-allowed"
       )}
     >

--- a/app/admin/settings-manager.tsx
+++ b/app/admin/settings-manager.tsx
@@ -36,14 +36,14 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-2xl">
       {error && (
-        <p role="alert" className="text-sm text-red-600">
+        <p role="alert" className="text-sm text-danger-fg">
           {error}
         </p>
       )}
-      {saved && <p className="text-sm text-green-700">Settings saved.</p>}
+      {saved && <p className="text-sm text-success-fg">Settings saved.</p>}
 
       <div className="flex flex-col gap-1">
-        <label htmlFor="settings-title" className="text-sm text-gray-600">
+        <label htmlFor="settings-title" className="text-sm text-fg-muted">
           Title
         </label>
         <Input
@@ -56,7 +56,7 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
       </div>
 
       <div className="flex flex-col gap-1">
-        <label htmlFor="settings-description" className="text-sm text-gray-600">
+        <label htmlFor="settings-description" className="text-sm text-fg-muted">
           Description
         </label>
         <textarea
@@ -64,13 +64,13 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
           name="description"
           defaultValue={settings.description}
           rows={3}
-          className="rounded-md border border-gray-300 bg-white px-4 py-2 shadow-sm focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-none"
+          className="rounded-md border border-line bg-surface-raised px-4 py-2 shadow-sm focus:ring-2 focus:ring-brand-accent focus:outline-0 focus:border-none"
         />
         <MarkdownHint />
       </div>
 
       <div className="flex flex-col gap-1">
-        <label htmlFor="settings-map" className="text-sm text-gray-600">
+        <label htmlFor="settings-map" className="text-sm text-fg-muted">
           Map
         </label>
         {settings.mapImageUrl && !removeMap && (
@@ -79,7 +79,7 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
             alt="Current map"
             width={240}
             height={180}
-            className="rounded border border-gray-200"
+            className="rounded border border-line-subtle"
           />
         )}
         <input
@@ -89,17 +89,17 @@ export function SettingsManager({ settings }: { settings: SiteSettings }) {
           type="file"
           accept="image/jpeg,image/png,image/webp"
           disabled={removeMap}
-          className="text-sm text-gray-600 file:mr-3 file:rounded-md file:border-0 file:bg-gray-100 file:px-3 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200 disabled:opacity-50"
+          className="text-sm text-fg-muted file:mr-3 file:rounded-md file:border-0 file:bg-surface-muted file:px-3 file:py-2 file:text-sm file:font-medium file:text-fg-muted hover:file:bg-surface-hover disabled:opacity-50"
         />
-        <p className="text-xs text-gray-500">{MAP_REQUIREMENTS_HINT}</p>
+        <p className="text-xs text-fg-subtle">{MAP_REQUIREMENTS_HINT}</p>
         {settings.mapImageUrl && (
-          <label className="flex items-center gap-2 text-sm text-gray-600">
+          <label className="flex items-center gap-2 text-sm text-fg-muted">
             <input
               type="checkbox"
               name="removeMap"
               checked={removeMap}
               onChange={(e) => setRemoveMap(e.target.checked)}
-              className="rounded border-gray-300 text-rose-600 focus:ring-rose-400"
+              className="rounded border-line text-brand-fg focus:ring-brand-accent"
             />
             Remove current map
           </label>

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -9,7 +9,7 @@ export default async function AdminSettingsPage() {
 
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+      <h1 className="text-2xl font-bold text-fg">Settings</h1>
       <section aria-label="Site settings" className="space-y-4">
         <SettingsManager settings={settings} />
       </section>

--- a/app/admin/timezone-select.tsx
+++ b/app/admin/timezone-select.tsx
@@ -49,7 +49,7 @@ export function TimezoneSelect({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       required
-      className="w-full h-10 rounded-md border border-gray-300 bg-white px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-rose-400"
+      className="w-full h-10 rounded-md border border-line bg-surface-raised px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-accent"
     >
       {options.map((tz) => (
         <option key={tz} value={tz}>

--- a/app/admin/users/import/page.tsx
+++ b/app/admin/users/import/page.tsx
@@ -9,8 +9,8 @@ export default async function AdminUserImportPage() {
 
   return (
     <div className="w-full max-w-3xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold text-gray-900">Import users</h1>
-      <p className="text-sm text-gray-600">
+      <h1 className="text-2xl font-bold text-fg">Import users</h1>
+      <p className="text-sm text-fg-muted">
         Upload a CSV file with a header row containing <code>name</code> and{" "}
         <code>email</code> columns (extra columns are ignored). Users are
         matched by email: existing users are left unchanged, new ones are

--- a/app/admin/users/import/user-import-form.tsx
+++ b/app/admin/users/import/user-import-form.tsx
@@ -38,7 +38,7 @@ export function UserImportForm({ events }: { events: EventOption[] }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="flex flex-col gap-1">
-        <label htmlFor="import-csv-file" className="text-sm text-gray-600">
+        <label htmlFor="import-csv-file" className="text-sm text-fg-muted">
           CSV file
         </label>
         <input
@@ -50,12 +50,12 @@ export function UserImportForm({ events }: { events: EventOption[] }) {
             setFile(e.target.files?.[0] ?? null);
             setResult(null);
           }}
-          className="text-sm text-gray-700 file:mr-3 file:px-3 file:py-2 file:text-sm file:font-medium file:rounded-md file:border-0 file:text-gray-700 file:bg-gray-100 hover:file:bg-gray-200 file:cursor-pointer"
+          className="text-sm text-fg-muted file:mr-3 file:px-3 file:py-2 file:text-sm file:font-medium file:rounded-md file:border-0 file:text-fg-muted file:bg-surface-muted hover:file:bg-surface-hover file:cursor-pointer"
         />
       </div>
 
       <div className="flex flex-col gap-1">
-        <label htmlFor="import-events" className="text-sm text-gray-600">
+        <label htmlFor="import-events" className="text-sm text-fg-muted">
           Assign to events
         </label>
         <SelectHosts
@@ -68,7 +68,7 @@ export function UserImportForm({ events }: { events: EventOption[] }) {
       </div>
 
       {result && !result.ok && (
-        <div role="alert" className="text-sm text-red-600 space-y-1">
+        <div role="alert" className="text-sm text-danger-fg space-y-1">
           <p>{result.error}</p>
           {result.lineErrors && (
             <ul className="list-disc pl-5">
@@ -80,7 +80,7 @@ export function UserImportForm({ events }: { events: EventOption[] }) {
         </div>
       )}
       {result?.ok && (
-        <p role="status" className="text-sm text-green-700">
+        <p role="status" className="text-sm text-success-fg">
           {plural(result.created, "user")} created,{" "}
           {plural(result.existing, "user")} already existed (skipped, but still
           assigned to the selected events).

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -51,7 +51,7 @@ export default async function AdminUsersPage({
   return (
     <div className="w-full max-w-6xl mx-auto space-y-6">
       <div className="flex items-center justify-between gap-2">
-        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+        <h1 className="text-2xl font-bold text-fg">Users</h1>
         <Link href="/admin/users/import" className={SECONDARY_BUTTON}>
           Import CSV
         </Link>

--- a/app/components/back-link.tsx
+++ b/app/components/back-link.tsx
@@ -12,7 +12,7 @@ export function BackLink({
       // py/-my: a 14px line is a 20px tap target, under the 24px minimum a
       // thumb needs; the negative margin keeps the extra height from pushing
       // the content below it down.
-      className="inline-block py-1 -my-1 text-sm text-gray-500 hover:text-gray-700"
+      className="inline-block py-1 -my-1 text-sm text-fg-subtle hover:text-fg-muted"
       href={href}
     >
       ← {children}

--- a/app/components/form-error-summary.tsx
+++ b/app/components/form-error-summary.tsx
@@ -68,7 +68,7 @@ export function FormErrorSummary<
   return (
     <div
       role="alert"
-      className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md"
+      className="bg-danger-tint border border-danger-border text-danger-fg px-4 py-3 rounded-md"
     >
       <p className="text-sm font-medium">{heading(entries)}</p>
       <ul className="mt-1 ps-5 list-disc space-y-1 text-sm">
@@ -79,7 +79,7 @@ export function FormErrorSummary<
             ) : (
               <button
                 type="button"
-                className="text-start underline hover:text-red-900"
+                className="text-start underline hover:text-danger-fg-hover"
                 // Focusing scrolls the field into view; fields react-hook-form
                 // holds no ref for (custom inputs) simply don't move.
                 // setFocus defers by a tick, so onJump's re-render lands first.

--- a/app/components/markdown-textarea.tsx
+++ b/app/components/markdown-textarea.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/app/components/markdown-options";
 
 const TAB_STYLE =
-  "first:rounded-tl-md border-e-1 border-gray-400 p-2 hover:bg-gray-300 cursor-pointer";
+  "first:rounded-tl-md border-e-1 border-line p-2 hover:bg-surface-hover cursor-pointer";
 
 /**
  * A textarea with a Markdown toolbar and a preview tab.
@@ -61,20 +61,20 @@ export const MarkdownTextarea = forwardRef<
     <div
       className={clsx(
         wrapperClassName,
-        "flex flex-col shadow-sm rounded-md focus-within:outline-none border border-gray-300 focus-within:ring-2 focus-within:ring-rose-400 focus-within:outline-0 focus-within:border-rose-400"
+        "flex flex-col shadow-sm rounded-md focus-within:outline-none border border-line focus-within:ring-2 focus-within:ring-brand-accent focus-within:outline-0 focus-within:border-brand-accent"
       )}
     >
-      <div className="flex flex-row rounded-md rounded-b-none border-b border-gray-400 bg-gray-200 text-sm items-center">
+      <div className="flex flex-row rounded-md rounded-b-none border-b border-line bg-surface-muted text-sm items-center">
         <button
           type="button"
-          className={clsx(TAB_STYLE, preview === null && "bg-gray-300")}
+          className={clsx(TAB_STYLE, preview === null && "bg-surface-hover")}
           onClick={() => setPreview(null)}
         >
           Edit
         </button>
         <button
           type="button"
-          className={clsx(TAB_STYLE, preview !== null && "bg-gray-300")}
+          className={clsx(TAB_STYLE, preview !== null && "bg-surface-hover")}
           onClick={() => setPreview(textarea.current?.value ?? "")}
         >
           Preview
@@ -84,7 +84,7 @@ export const MarkdownTextarea = forwardRef<
             <button
               key={option.label}
               type="button"
-              className="last:m-1 my-1 p-1 h-fit cursor-pointer active:border-rose-400 border-solid border border-transparent hover:bg-gray-300 rounded-md"
+              className="last:m-1 my-1 p-1 h-fit cursor-pointer active:border-brand-accent border-solid border border-transparent hover:bg-surface-hover rounded-md"
               onClick={() => {
                 if (textarea.current) {
                   applyToTextarea(option.template, textarea.current);
@@ -106,7 +106,7 @@ export const MarkdownTextarea = forwardRef<
         ref={setTextareaRefs}
         onKeyDown={onKeyDown}
         className={clsx(
-          "w-full font-(family-name:--font-mono) rounded-t-none rounded-md text-sm resize-y h-40 border-none ring-0 outline-0 bg-white px-4 py-2 placeholder-gray-400 transition-colors",
+          "w-full font-(family-name:--font-mono) rounded-t-none rounded-md text-sm resize-y h-40 border-none ring-0 outline-0 bg-surface-raised px-4 py-2 placeholder-fg-subtle transition-colors",
           props.className,
           preview !== null && "hidden"
         )}

--- a/app/footer.tsx
+++ b/app/footer.tsx
@@ -12,7 +12,7 @@ export default function Footer({ inline }: { inline?: boolean }) {
   const content = (
     // Wrapping matters on narrow phones: the version can be a long dev string
     // (`a1b2c3d4-dirty`), and three links plus it no longer fit on one line.
-    <div className="px-3 flex flex-wrap gap-x-2 justify-between items-center text-xs text-gray-500">
+    <div className="px-3 flex flex-wrap gap-x-2 justify-between items-center text-xs text-fg-subtle">
       <span className="flex gap-1">
         <span className="hidden sm:block">Version: </span>
         {appVersion}
@@ -23,7 +23,7 @@ export default function Footer({ inline }: { inline?: boolean }) {
           href="https://schellingboard.org"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
+          className="text-link hover:underline"
         >
           SchellingBoard
         </a>
@@ -32,7 +32,7 @@ export default function Footer({ inline }: { inline?: boolean }) {
           href="https://docs.schellingboard.org"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
+          className="text-link hover:underline"
         >
           Help
         </a>
@@ -41,7 +41,7 @@ export default function Footer({ inline }: { inline?: boolean }) {
           href="https://github.com/LWCW-Europe/schellingboard/issues"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
+          className="text-link hover:underline"
         >
           Report a Bug
         </a>
@@ -50,11 +50,11 @@ export default function Footer({ inline }: { inline?: boolean }) {
   );
 
   return inline ? (
-    <footer className="bg-gray-50 border-t border-gray-200 py-2">
+    <footer className="bg-surface-sunken border-t border-line-subtle py-2">
       <div className="sticky left-0 max-w-[100dvw]">{content}</div>
     </footer>
   ) : (
-    <footer className="lg:fixed bottom-0 left-0 right-0 bg-gray-50 border-t border-gray-200 py-2 z-20 mt-auto">
+    <footer className="lg:fixed bottom-0 left-0 right-0 bg-surface-sunken border-t border-line-subtle py-2 z-20 mt-auto">
       {content}
     </footer>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,7 @@
   /* Decorative only — separators, disabled glyphs. Never carries meaning. */
   --fg-faint: #9ca3af;
   --fg-inverse: #ffffff;
+  --fg-inverse-muted: #d1d5db;
 
   /* Draws text inputs and selects, hence the 3:1 floor of WCAG 1.4.11. */
   --line: #868e9c;
@@ -63,6 +64,7 @@
   --brand: #e11d48;
   --brand-hover: #be123c;
   --brand-fg: #be123c;
+  --brand-fg-hover: #9f1239;
   /* Rings and borders, which only need 3:1 — a lighter rose than text may use. */
   --brand-accent: #f43f5e;
   --brand-tint: #fff1f2;
@@ -72,6 +74,7 @@
   --danger: #dc2626;
   --danger-hover: #b91c1c;
   --danger-fg: #b91c1c;
+  --danger-fg-hover: #7f1d1d;
   --danger-tint: #fef2f2;
   --danger-border: #fca5a5;
   --on-danger: #ffffff;
@@ -123,6 +126,7 @@
     --fg-subtle: #8c94a3;
     --fg-faint: #6b7280;
     --fg-inverse: #16181d;
+    --fg-inverse-muted: #4b5563;
 
     --line: #6a7382;
     --line-subtle: #2c313b;
@@ -132,11 +136,13 @@
     --brand: #be123c;
     --brand-hover: #e11d48;
     --brand-fg: #fb7185;
+    --brand-fg-hover: #fda4af;
     --brand-accent: #fb7185;
     --brand-tint: #3b1220;
     --brand-tint-hover: #4d1727;
 
     --danger-fg: #fca5a5;
+    --danger-fg-hover: #fecaca;
     --danger-tint: #3f1515;
     --danger-border: #7f1d1d;
 
@@ -181,6 +187,7 @@
   --color-fg-subtle: var(--fg-subtle);
   --color-fg-faint: var(--fg-faint);
   --color-fg-inverse: var(--fg-inverse);
+  --color-fg-inverse-muted: var(--fg-inverse-muted);
 
   --color-line: var(--line);
   --color-line-subtle: var(--line-subtle);
@@ -189,6 +196,7 @@
   --color-brand: var(--brand);
   --color-brand-hover: var(--brand-hover);
   --color-brand-fg: var(--brand-fg);
+  --color-brand-fg-hover: var(--brand-fg-hover);
   --color-brand-accent: var(--brand-accent);
   --color-brand-tint: var(--brand-tint);
   --color-brand-tint-hover: var(--brand-tint-hover);
@@ -197,6 +205,7 @@
   --color-danger: var(--danger);
   --color-danger-hover: var(--danger-hover);
   --color-danger-fg: var(--danger-fg);
+  --color-danger-fg-hover: var(--danger-fg-hover);
   --color-danger-tint: var(--danger-tint);
   --color-danger-border: var(--danger-border);
   --color-on-danger: var(--on-danger);
@@ -360,6 +369,35 @@ html {
 /* Admin's colour preview — the hue itself, with no text on it. */
 @utility loc-swatch {
   background-color: var(--loc);
+}
+
+/*
+ * `@tailwindcss/forms` paints every field, select, checkbox and radio a literal
+ * `#fff`, which stays white in dark mode. Its rules land at the end of `base`,
+ * so out-ranking them by source order or specificity is not an option; the
+ * `components` layer beats `base` wholesale while still yielding to a `bg-*`
+ * utility on an individual field.
+ *
+ * That same bluntness is why the exclusions are listed by hand: the plugin
+ * skips the button-like and native-widget types, and a ticked box takes its
+ * fill from `currentColor` in a `base` rule this would otherwise cover.
+ */
+@layer components {
+  input:where(
+      :not(
+        [type="file"],
+        [type="range"],
+        [type="color"],
+        [type="submit"],
+        [type="reset"],
+        [type="button"],
+        [type="image"]
+      )
+    ):not(:checked, :indeterminate),
+  textarea,
+  select {
+    background-color: var(--surface-raised);
+  }
 }
 
 html {

--- a/app/input.tsx
+++ b/app/input.tsx
@@ -16,16 +16,16 @@ export const Input = forwardRef(
         <input
           ref={ref}
           className={clsx(
-            "h-12 rounded-md border bg-white px-4 shadow-sm transition-colors invalid:border-red-500 invalid:text-red-900 invalid:placeholder-red-300 focus:outline-none disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500",
+            "h-12 rounded-md border bg-surface-raised px-4 shadow-sm transition-colors invalid:border-danger invalid:text-danger-fg invalid:placeholder-danger-border focus:outline-none disabled:cursor-not-allowed disabled:border-line-subtle disabled:bg-surface-sunken disabled:text-fg-subtle",
             error
-              ? "border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500" // matches invalid: styles
-              : "border-gray-300 placeholder-gray-400 focus:ring-2 focus:ring-rose-400 focus:outline-0 focus:border-transparent",
+              ? "border-danger-border text-danger-fg placeholder-danger-border focus:border-danger focus:ring-danger" // matches invalid: styles
+              : "border-line placeholder-fg-subtle focus:ring-2 focus:ring-brand-accent focus:outline-0 focus:border-transparent",
             className
           )}
           {...rest}
         />
         {error && errorMessage && (
-          <span className="text-xs text-red-500">{errorMessage}</span>
+          <span className="text-xs text-danger-fg">{errorMessage}</span>
         )}
       </>
     );

--- a/app/select-hosts.tsx
+++ b/app/select-hosts.tsx
@@ -31,14 +31,14 @@ export function SelectHosts<
 
   const comboboxContent = (
     <div className="relative mt-1">
-      <div className="relative w-full min-h-12 h-fit rounded-md border transition-colors border-gray-300 bg-white py-2 pl-3 pr-10 focus-within:ring-2 focus-within:ring-rose-400 focus-within:border-transparent">
+      <div className="relative w-full min-h-12 h-fit rounded-md border transition-colors border-line bg-surface-raised py-2 pl-3 pr-10 focus-within:ring-2 focus-within:ring-brand-accent focus-within:border-transparent">
         <div className="flex flex-wrap gap-1 items-center">
           {hosts.length > 0 && (
             <>
               {hosts.map((host) => (
                 <span
                   key={host.id}
-                  className="py-1 px-2 bg-gray-100 rounded text-nowrap text-sm flex items-center gap-1"
+                  className="py-1 px-2 bg-surface-muted rounded text-nowrap text-sm flex items-center gap-1"
                 >
                   {host.name}
                   <button
@@ -49,7 +49,7 @@ export function SelectHosts<
                     }}
                     aria-label={`Remove ${host.name}`}
                   >
-                    <XMarkIcon className="h-4 w-4 text-gray-400 hover:text-gray-700" />
+                    <XMarkIcon className="h-4 w-4 text-fg-subtle hover:text-fg-muted" />
                   </button>
                 </span>
               ))}
@@ -59,12 +59,12 @@ export function SelectHosts<
             id={id}
             onChange={(event) => setQuery(event.target.value)}
             value={query}
-            className="border-none focus:ring-0 px-0 py-1 text-sm flex-1 min-w-8 bg-transparent placeholder:text-gray-400 outline-none"
+            className="border-none focus:ring-0 px-0 py-1 text-sm flex-1 min-w-8 bg-transparent placeholder:text-fg-subtle outline-none"
           />
         </div>
       </div>
       <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-        <ChevronUpDownIcon className="h-5 w-5 text-gray-400" />
+        <ChevronUpDownIcon className="h-5 w-5 text-fg-subtle" />
       </Combobox.Button>
       <Transition
         as={Fragment}
@@ -73,9 +73,9 @@ export function SelectHosts<
         leaveTo="opacity-0"
         afterLeave={() => setQuery("")}
       >
-        <Combobox.Options className="absolute mt-1 max-h-60 z-10 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+        <Combobox.Options className="absolute mt-1 max-h-60 z-10 w-full overflow-auto rounded-md bg-surface-raised py-1 text-base shadow-lg ring-1 ring-line-subtle focus:outline-none sm:text-sm">
           {filteredGuests.length === 0 && query !== "" ? (
-            <div className="relative cursor-default select-none px-4 py-2 text-gray-700">
+            <div className="relative cursor-default select-none px-4 py-2 text-fg-muted">
               Nothing found.
             </div>
           ) : (
@@ -86,8 +86,8 @@ export function SelectHosts<
                   clsx(
                     "relative cursor-pointer select-none py-2 pl-10 pr-4 z-10",
                     active
-                      ? "bg-rose-100 text-rose-900"
-                      : "text-gray-900 bg-white"
+                      ? "bg-brand-tint-hover text-brand-fg"
+                      : "text-fg bg-surface-raised"
                   )
                 }
                 value={guest}
@@ -98,19 +98,19 @@ export function SelectHosts<
                       className={clsx(
                         "flex items-center gap-1.5 truncate",
                         selected ? "font-medium" : "font-normal",
-                        disabled ? "text-gray-400" : "text-gray-900"
+                        disabled ? "text-fg-subtle" : "text-fg"
                       )}
                     >
                       <span className="truncate">{guest.name}</span>
                       {showProtected && guest.authProtected && (
                         <LockIcon
-                          className="h-3.5 w-3.5 shrink-0 text-gray-400"
+                          className="h-3.5 w-3.5 shrink-0 text-fg-subtle"
                           title="Protected — password or emailed code needed"
                         />
                       )}
                     </span>
                     {selected ? (
-                      <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-rose-400">
+                      <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-brand-fg">
                         <CheckIcon className="h-5 w-5" />
                       </span>
                     ) : null}

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
+import path from "path";
 import {
   GLOBALS_CSS_PATH,
   contrastRatio,
@@ -35,6 +36,7 @@ const TEXT_PAIRS: [fg: string, bg: string, min: number][] = [
   ["--fg-subtle", "--surface-raised", 4.5],
   ["--fg-subtle", "--surface-sunken", 4.5],
   ["--fg-inverse", "--surface-inverse", 4.5],
+  ["--fg-inverse-muted", "--surface-inverse", 4.5],
   // A filled brand button keeps white lettering in both themes, so the text on
   // it is its own token rather than `--fg-inverse`, which flips with the theme.
   ["--on-brand", "--brand", 4.5],
@@ -45,12 +47,17 @@ const TEXT_PAIRS: [fg: string, bg: string, min: number][] = [
   ["--fg-inverse", "--surface-inverse-hover", 4.5],
   ["--brand-fg", "--surface", 4.5],
   ["--brand-fg", "--surface-raised", 4.5],
+  ["--brand-fg", "--surface-muted", 4.5],
   ["--brand-fg", "--brand-tint", 4.5],
   ["--brand-fg", "--brand-tint-hover", 4.5],
+  ["--brand-fg-hover", "--surface", 4.5],
+  ["--brand-fg-hover", "--surface-raised", 4.5],
+  ["--brand-fg-hover", "--surface-muted", 4.5],
   ["--danger-fg", "--surface", 4.5],
   ["--danger-fg", "--surface-raised", 4.5],
   ["--danger-fg", "--surface-sunken", 4.5],
   ["--danger-fg", "--danger-tint", 4.5],
+  ["--danger-fg-hover", "--danger-tint", 4.5],
   ["--success-fg", "--surface", 4.5],
   ["--success-fg", "--surface-raised", 4.5],
   ["--warning-fg", "--surface", 4.5],
@@ -100,6 +107,61 @@ describe.each(["light", "dark"] as const)("theme tokens — %s", (theme) => {
       ).toBeGreaterThanOrEqual(min);
     }
   );
+});
+
+// A colour a component picks for itself escapes the rule above entirely: it
+// keeps its light-mode value in dark mode, and no pair here can catch it. Both
+// spellings count — an arbitrary `bg-[#f2f2f2]` and a palette shade like
+// `bg-gray-100`, which is the one that gets typed by accident.
+const HUES = [
+  "slate",
+  "gray",
+  "zinc",
+  "neutral",
+  "stone",
+  "red",
+  "orange",
+  "amber",
+  "yellow",
+  "lime",
+  "green",
+  "emerald",
+  "teal",
+  "cyan",
+  "sky",
+  "blue",
+  "indigo",
+  "violet",
+  "purple",
+  "fuchsia",
+  "pink",
+  "rose",
+];
+// `\b` only guards the bare names; after the `]` of an arbitrary value there is
+// no word boundary to find.
+const LITERAL_COLOR = new RegExp(
+  `[\\w-]+-(?:\\[#[0-9a-fA-F]{3,8}\\]|(?:(?:${HUES.join("|")})-\\d{2,3}|white|black)\\b)`,
+  "g"
+);
+
+describe("components", () => {
+  const sources = function* (dir: string): Generator<string> {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) yield* sources(full);
+      else if (/\.tsx?$/.test(entry.name)) yield full;
+    }
+  };
+
+  it("name a token rather than a literal colour", () => {
+    const root = path.join(__dirname, "../../app");
+    const offenders = [...sources(root)].flatMap((file) =>
+      [...readFileSync(file, "utf8").matchAll(LITERAL_COLOR)].map(
+        ([match]) => `${path.relative(root, file)}: ${match}`
+      )
+    );
+    expect(offenders).toEqual([]);
+  });
 });
 
 describe("dark theme", () => {


### PR DESCRIPTION
Every `bg-gray-100`/`text-white` in app/ becomes the token for the role it
plays, so the two theme blocks in globals.css are the only place a colour is
chosen and no component has to remember a `dark:` variant. A unit test holds
app/ to it, rejecting a palette shade and an arbitrary `bg-[#f2f2f2]` alike:
both are invisible to the contrast contract and would have stayed light in
dark mode.

`@tailwindcss/forms` needs the same treatment from outside — it paints every
field a literal `#fff`. Its rules land at the end of `base`, so the override
sits in `components`, which outranks that layer wholesale but still yields to
a `bg-*` utility on an individual field.

<!-- jip:pushed-commit=49e03c0ccea4baef6886aa2b8f50a43caec5e379 -->