### PR TITLE
fix: give the chosen vote a hue rather than an inverted surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The vote you picked is now unmistakable**: a chosen vote button was marked only by a pale blue tint, which was nearly invisible to attendees using a dark-mode browser extension and to anyone who has trouble telling colours apart — so it was impossible to see whether you had voted at all, let alone which of the three you had chosen. The chosen button is now filled in solid blue with a check mark on it, and screen readers announce it as selected. Blue rather than the site's usual red: the buttons are labelled with emoji, and a red heart on a red button was hard to make out
 - **Room colours on the schedule are readable**: a session's block was filled with its room's colour at full strength and lettered in white, which on a yellow, lime or amber room left the title all but invisible. A block is now a light wash of the room's colour with a strong border in that colour, lettered in the ordinary text colour — the room is still recognisable at a glance, and all 22 room colours read equally well. The room name shown beside a session in the list view is derived the same way
-- **The vote you picked is now unmistakable**: a chosen vote button was marked only by a pale blue tint, which was nearly invisible to attendees using a dark-mode browser extension and to anyone who has trouble telling colours apart — so it was impossible to see whether you had voted at all, let alone which of the three you had chosen. The chosen button is now filled in dark with a check mark on it, and screen readers announce it as selected
 
 ### Added
 

--- a/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
+++ b/app/(site)/[eventSlug]/proposals/voting-buttons.tsx
@@ -164,8 +164,10 @@ const VOTE_OPTIONS = [
 // The chosen vote must stay recognisable without perceiving hue: a light tint
 // against white collapsed into "no visible difference" under the Dark Reader
 // extension and for colourblind attendees (issue #802). Hence three redundant
-// cues — aria-pressed, a dark fill that keeps its luminance gap under any
-// recolouring, and a check mark — rather than a background colour alone.
+// cues — aria-pressed, a solid `vote-chosen` fill that keeps its luminance gap
+// from the page under any recolouring, and a check mark — rather than a
+// background colour alone. Why that fill is a hue rather than a neutral is at
+// the token in `globals.css`.
 function VoteButton({
   emoji,
   label,
@@ -194,7 +196,7 @@ function VoteButton({
           : "px-1 py-1",
         !votingEnabled && "opacity-50 cursor-not-allowed grayscale",
         selected
-          ? "bg-surface-inverse border-line-strong text-fg-inverse ring-2 ring-line-strong"
+          ? "bg-vote-chosen border-line-strong text-on-vote-chosen ring-2 ring-line-strong"
           : "bg-surface-raised border-line-strong text-fg-muted",
         !selected && votingEnabled && "hover:bg-surface-muted"
       )}
@@ -204,7 +206,7 @@ function VoteButton({
       {selected && (
         <span
           aria-hidden="true"
-          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-surface-raised bg-surface-inverse text-[9px] leading-none text-fg-inverse"
+          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-surface-raised bg-bar text-[9px] leading-none text-bar-fg"
         >
           ✓
         </span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -91,6 +91,18 @@
   --info-hover: #1e3a8a;
   --on-info: #ffffff;
 
+  /*
+   * The vote you picked. A hue rather than a neutral because neither neutral
+   * works: `surface-inverse` flips to near-white in dark mode and swallows the
+   * emoji labelling those buttons (colour glyphs, so their own colours never
+   * follow the theme), and an always-dark fill like `bar` sits 1.06:1 from the
+   * near-black dark page. Not `brand` either — a red heart on rose was the
+   * clash; blue is the one hue far enough from all three (❤️ ⭐ 👋🏽). It holds
+   * `info`'s value today, but the two are free to part.
+   */
+  --vote-chosen: #1d4ed8;
+  --on-vote-chosen: #ffffff;
+
   --overlay: #00000080;
 
   /*
@@ -155,6 +167,9 @@
     --link-hover: #bfdbfe;
     --info: #2563eb;
     --info-hover: #3b82f6;
+
+    /* Lighter here so it separates from a near-black page, not from white. */
+    --vote-chosen: #2563eb;
 
     --overlay: #000000b3;
 
@@ -221,6 +236,9 @@
   --color-info: var(--info);
   --color-info-hover: var(--info-hover);
   --color-on-info: var(--on-info);
+
+  --color-vote-chosen: var(--vote-chosen);
+  --color-on-vote-chosen: var(--on-vote-chosen);
 
   --color-overlay: var(--overlay);
 

--- a/tests/unit/theme-contrast.test.ts
+++ b/tests/unit/theme-contrast.test.ts
@@ -44,6 +44,7 @@ const TEXT_PAIRS: [fg: string, bg: string, min: number][] = [
   ["--on-danger", "--danger", 4.5],
   ["--on-danger", "--danger-hover", 4.5],
   ["--on-info", "--info", 4.5],
+  ["--on-vote-chosen", "--vote-chosen", 4.5],
   ["--fg-inverse", "--surface-inverse-hover", 4.5],
   ["--brand-fg", "--surface", 4.5],
   ["--brand-fg", "--surface-raised", 4.5],
@@ -86,6 +87,11 @@ const NON_TEXT_PAIRS: [fg: string, bg: string, min: number][] = [
   ["--brand-accent", "--surface-sunken", 3],
   ["--danger", "--surface", 3],
   ["--danger", "--surface-raised", 3],
+  // A filled vote button has to be told apart from the page it sits on, which
+  // is the one thing a neutral dark fill failed at in dark mode: `bar` sat
+  // 1.06:1 from a near-black page.
+  ["--vote-chosen", "--surface", 3],
+  ["--vote-chosen", "--surface-raised", 3],
 ];
 
 const THEMES = readThemes(readFileSync(GLOBALS_CSS_PATH, "utf8"));
@@ -137,10 +143,32 @@ const HUES = [
   "pink",
   "rose",
 ];
+// The utilities that take a colour, optionally with the side or axis some of
+// them accept (`border-t-`, `divide-x-`). Anchoring on them is what keeps prose
+// out: a comment describing a token as "near-white" is not a class name.
+const COLOR_UTILITIES = [
+  "bg",
+  "text",
+  "border",
+  "divide",
+  "outline",
+  "ring",
+  "ring-offset",
+  "shadow",
+  "accent",
+  "caret",
+  "decoration",
+  "placeholder",
+  "fill",
+  "stroke",
+  "from",
+  "via",
+  "to",
+];
 // `\b` only guards the bare names; after the `]` of an arbitrary value there is
 // no word boundary to find.
 const LITERAL_COLOR = new RegExp(
-  `[\\w-]+-(?:\\[#[0-9a-fA-F]{3,8}\\]|(?:(?:${HUES.join("|")})-\\d{2,3}|white|black)\\b)`,
+  `\\b(?:${COLOR_UTILITIES.join("|")})(?:-[trblxyse])?-(?:\\[#[0-9a-fA-F]{3,8}\\]|(?:(?:${HUES.join("|")})-\\d{2,3}|white|black)\\b)`,
   "g"
 );
 
@@ -152,6 +180,15 @@ describe("components", () => {
       else if (/\.tsx?$/.test(entry.name)) yield full;
     }
   };
+
+  it("tell a class name from prose", () => {
+    expect(
+      "bg-gray-100 dark:text-white border-t-[#abcdef]".match(LITERAL_COLOR)
+    ).toEqual(["bg-gray-100", "text-white", "border-t-[#abcdef]"]);
+    expect("a fill that is near-white in dark mode".match(LITERAL_COLOR)).toBe(
+      null
+    );
+  });
 
   it("name a token rather than a literal colour", () => {
     const root = path.join(__dirname, "../../app");


### PR DESCRIPTION
`surface-inverse` flips to near-white in dark mode, which swallowed the emoji
on the buttons — they are colour glyphs, so their own colours never follow the
theme. A neutral dark fill is no alternative either: the dark page is already
near-black, and `bar` sat 1.06:1 from it. Blue is the one hue far enough from
❤️ ⭐ 👋🏽 to clear 3:1 against both pages while carrying white lettering.

The literal-colour guard now anchors on the utilities that take a colour. It
matched any `<word>-white`, so a comment about a near-white fill failed it.

<!-- jip:pushed-commit=f3043a4b34c8db65720c847684f274a4bb9c9df1 -->