### PR TITLE
docs: cut the public guides down to something skimmable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Searching and filtering the attendee directory is instant**: it no longer reloads the list from the server and drops you at the top. The address bar still carries what you are looking at, so a filtered or searched list can be bookmarked and shared as before
 - **The attendee directory is wider on a large screen**: update times no longer crowd the names. On a phone the update time sits under the name, and a "Session host" badge no longer squeezes the name into two lines
 - **"Back to attendees" is now a small link, not a big red button**: on the edit-profile and settings pages it is a quiet "← Attendees" link in the corner, the same as everywhere else
+- **The documentation is shorter and easier to skim**: walls of prose became bullet lists, the important warnings — an RSVP is a commitment, the name picker is not a login, don't copy a live database — are now highlighted boxes, and the background on how the attendance prediction was fitted is down to a sentence. The attendee guide is a fifth shorter without losing anything you need to use the app. See [the documentation](https://docs.schellingboard.org/)
 - **Attendee search now looks at the whole profile**: it also matches the contact details attendees chose to publish (handles, usernames, websites, and the service they belong to) and the prompt questions themselves, not only their answers. Private email addresses are never searched
 
 ### Internal

--- a/docs/public/attendee-guide.md
+++ b/docs/public/attendee-guide.md
@@ -6,117 +6,101 @@ type: guide
 
 # Using SchellingBoard as an attendee
 
-## The three phases
+Open the event link, enter the site password if asked, and pick your name from
+the list. What you can do next depends on the event's phase.
 
-An event moves through up to three phases, and what you can do depends on
-which one it is in. Buttons that belong to another phase are greyed out rather
-than hidden — hover one to see when it opens.
+| Phase          | What you can do                                                                        |
+| -------------- | -------------------------------------------------------------------------------------- |
+| **Proposal**   | Propose sessions, edit your own, comment on any of them                                |
+| **Voting**     | All of the above, plus vote. Counts stay hidden                                        |
+| **Scheduling** | Counts become visible; schedule sessions, book slots, RSVP. Proposing and voting close |
 
-| Phase          | What you can do                                                                                                       |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Proposal**   | Propose sessions, edit your own, and comment on any of them. Voting is not open yet.                                  |
-| **Voting**     | All of the above, plus vote on proposals. Vote counts stay hidden.                                                    |
-| **Scheduling** | Vote counts become visible; put proposals on the schedule, book empty slots, and RSVP. Proposing and voting are over. |
+Buttons belonging to another phase are greyed out rather than hidden — hover
+one to see when it opens. Organizers can skip phases, and an event with no
+phase dates at all is always in the scheduling phase.
 
-Nothing you do before the scheduling phase commits you to anything: proposing
-a session is not a promise to give it, and voting is not a promise to attend.
-**RSVPs are the exception** — see [RSVP](#rsvp).
-
-Organizers can skip phases, and an event with no phase dates at all is simply
-always in the scheduling phase.
+:::info "Only an RSVP commits you to anything"
+Proposing a session is not a promise to give it, and voting is not a promise
+to attend. [RSVPs are the exception](#rsvp).
+:::
 
 ## Pick your name
 
-Open the event link, enter the site password if asked, then pick your name
-from the list. By default this isn't a login — anyone can pick any name — so
-please only pick your own. If you'd rather it _were_ a login, see
-[Protect your name](#protect-your-name) below.
+By default this isn't a login — anyone can pick any name — so please pick only
+your own. If you'd rather it _were_ a login, see
+[Protect your name](#protect-your-name).
 
 ## Propose a session
 
-You can browse, search, and sort existing proposals at any time. Search covers
-titles, hosts and the full description — a tool or prerequisite mentioned deep
-in a proposal is enough to find it — and while you are searching, results stay
-ordered by how well they match. During the **proposal** phase, click "Add
-Proposal" to suggest a session: title, description, and optionally co-hosts.
-You can edit your own proposals until scheduling starts. Proposing is not a commitment — a proposal only becomes a
-real session once someone puts it on the schedule.
+During the **proposal** phase, click **Add Proposal** and give a title, a
+description, and optionally co-hosts. You can edit your own proposals until
+scheduling starts. A proposal only becomes a real session once someone puts it
+on the schedule.
 
-A proposal doesn't need a host. Leaving the host field empty is a way of
-saying "I'd like someone to offer this" rather than "I'll give this" — a
-request instead of an offer. Anyone who can give such a session takes it on by
-editing the proposal and adding themselves as a host; nobody's permission is
-needed.
-
-Description fields accept Markdown. A small toolbar above the box adds bold,
-italics, links, lists, quotes and code for you, and a **Preview** tab shows
-how the text will look before you save.
+- **A proposal doesn't need a host.** An empty host field says "I'd like
+  someone to offer this" rather than "I'll give this". Anyone who can give
+  such a session takes it on by editing the proposal and adding themselves —
+  nobody's permission needed.
+- **Descriptions accept Markdown.** The toolbar above the box adds bold,
+  italics, links, lists, quotes and code; the **Preview** tab shows how it
+  will look.
+- **You can browse, search and sort proposals in any phase.** Search covers
+  titles, hosts and full descriptions, so a tool or prerequisite mentioned
+  deep in a proposal is enough to find it. While you search, results stay
+  ordered by how well they match.
 
 ![Session proposal form with title, description, hosts, and duration fields](../screenshots/proposal-edit.webp)
 
 ## Discuss a proposal
 
-Open a proposal to see its comments. Pick your name first, then leave a
-comment or reply to someone else's — a good place to ask what background is
+Open a proposal to see its comments — a good place to ask what background is
 assumed, offer to co-host, or work out whether two proposals should merge.
-Replies are threaded, and the `[-]` next to a comment folds it and everything
-under it away.
+Pick your name first, then comment or reply.
 
-Like a comment to agree with it without adding another comment to the thread.
-Click the like count next to the button to see who liked it, and click "Liked"
-again to take your like back.
-
-You can edit or delete your own comments. Deleting is permanent — there is no
-history and no undo. If the comment already has replies, a "Comment deleted"
-placeholder stays behind so the replies still make sense.
-
-Each comment's timestamp links to that comment alone, so you can point
-someone at one particular remark.
+- Replies are threaded; `[-]` folds a comment and everything under it away.
+- **Like** a comment to agree without adding another to the thread. Click the
+  count to see who liked it, or "Liked" again to take yours back.
+- You can edit or delete your own comments. Deleting is permanent — no history,
+  no undo. If there are replies, a "Comment deleted" placeholder stays behind.
+- Each timestamp links to that comment alone, so you can point someone at one
+  particular remark.
 
 ## Vote
 
 During the **voting** phase, react to each proposal with ❤️ Interested,
-⭐ Maybe, or 👋 Skip. Click your choice again to remove it. Voting is not a
-commitment: when you vote you have no idea what else will be running at the
-same time, so nobody reads your votes as a promise to turn up.
+⭐ Maybe, or 👋 Skip. Click your choice again to remove it.
 
-![Proposal list with Interested / Maybe / Skip vote buttons](../screenshots/proposals-vote.webp)
-
-### The fastest way to vote
-
-Click **"Go to Quick Voting!"** on the proposals page. It shows you one
-proposal at a time, skipping the ones you have already voted on, and counts
-down how many are left.
+The fastest way is **"Go to Quick Voting!"** on the proposals page: one
+proposal at a time, skipping the ones you've already voted on, counting down
+how many are left.
 
 ![Quick Voting screen showing one proposal with large Interested / Maybe / Skip buttons](../screenshots/quick-voting.webp)
 
-You can see and change your own votes at any time while voting is open: your
-choice is highlighted on each proposal, and the **"Only voted"** and
-**"Only unvoted"** filters on the proposals page narrow the list to either
-group. You don't vote on your own proposals — the buttons aren't shown there.
+You can change your votes at any time while voting is open — your choice is
+highlighted on each proposal, and the **"Only voted"** / **"Only unvoted"**
+filters narrow the list to either group. You don't vote on your own proposals.
 
-### Why the vote buttons are greyed out
-
-Greyed-out vote buttons mean voting isn't available to you _right now_. Hover
-one to see why:
-
-- **"Voting will be enabled at …"** — the event is still in the proposal
-  phase. Add and discuss proposals now; come back to vote when it opens.
-- **"Select a user first"** — you haven't picked your name yet.
-- **"The voting phase is over"** — scheduling has started. Vote counts are
-  visible now.
+![Proposal list with Interested / Maybe / Skip vote buttons](../screenshots/proposals-vote.webp)
 
 ### Results stay hidden until voting closes
 
-Nobody can see the vote counts while voting is running, so early votes can't
-sway later ones. The counts appear for everyone when the scheduling phase
-starts.
+Nobody sees vote counts while voting runs, so early votes can't sway later
+ones. The counts appear for everyone when scheduling starts.
 
-**Only the counts are ever shown — never who voted which way.** Your own votes
-are visible to you alone; a host sees how many people were interested in their
-proposal, not their names, and neither does anyone else, organizers included.
-Hosts get the fuller picture of their own proposal — see
-[How many people to expect](#how-many-people-to-expect).
+**Only counts are ever shown — never who voted which way.** Your own votes are
+visible to you alone; a host sees how many people were interested, not their
+names, and neither does anyone else, organizers included.
+
+### Why the vote buttons are greyed out
+
+Greyed-out buttons mean voting isn't available to you _right now_. Hover one
+to see why:
+
+- **"Voting will be enabled at …"** — still the proposal phase. Add and
+  discuss proposals now; come back when voting opens.
+- **"Select a user first"** — you haven't picked your name yet.
+- **"The voting phase is over"** — scheduling has started, and vote counts are
+  visible now.
 
 ## The schedule
 
@@ -129,53 +113,41 @@ Proposing and voting close.
 
 Two ways, whichever you find first:
 
-- **From the proposal.** Click **"Proposals"** at the top of the schedule,
-  then **"Schedule"** — either in the proposals table or on the proposal's own
-  page. Pick a room and a time slot, and save.
-- **From the grid.** Click an empty slot in a bookable room, then use the
-  **"Pre-fill from proposal"** dropdown to fill the form from one of your
-  proposals. You can also ignore it and just book the slot with a brand-new
-  session that was never proposed.
+- **From the proposal** — click **"Proposals"** at the top of the schedule,
+  then **"Schedule"**, either in the table or on the proposal's own page. Pick
+  a room and a time slot, and save.
+- **From the grid** — click an empty slot in a bookable room, then use
+  **"Pre-fill from proposal"** to fill the form from one of your proposals. Or
+  ignore it and book the slot with a brand-new session that was never proposed.
 
 ![Form for adding a session to the schedule, with a Pre-fill from proposal dropdown](../screenshots/add-session.webp)
 
-Two things worth knowing:
-
-- **Proposals with no host are up for grabs.** Anyone can schedule one — no
-  permission needed. They show up in your "Pre-fill from proposal" dropdown
-  alongside your own.
-- **The same proposal can be scheduled more than once**, for instance in two
-  slots if interest is high and you're happy to give it twice.
+Worth knowing: **proposals with no host are up for grabs** — anyone can
+schedule one, and they appear in your "Pre-fill from proposal" dropdown
+alongside your own. And **the same proposal can be scheduled more than once**,
+for instance twice if interest is high.
 
 ### How many people to expect
 
-Vote counts become visible when scheduling opens. They tell you roughly how
-much interest there is — not how many people will walk in, since voters didn't
-know what would end up running against your session.
+Vote counts show how much interest there is, not how many people will walk in
+— voters didn't know what would end up running against your session.
 
-Open your own proposal during scheduling and it shows a **vote breakdown**:
-how many attendees voted and how many didn't, how the votes split between
-❤️, ⭐ and 👋🏽, and how many people to expect if you host it.
+Open your own proposal during scheduling to see a **vote breakdown**: how many
+attendees voted and how many didn't, how the votes split across ❤️ ⭐ 👋, and
+how many people to expect if you host it — a range, like "expect 8–17 people".
 
-The expectation is a **range**, not a number — "expect 8–17 people" — and even
-that is **a very rough guess**. Where it comes from: at one event, thirteen
-hosts were asked afterwards roughly how many people had come to their session,
-and those recollections were compared against the votes. The formula that came
-out of it takes a proposal's ❤️ count relative to the other proposals at the
-event and scales it by the number of attendees.
+:::warning "The range is a very rough guess"
+It comes from a single event where thirteen hosts recalled roughly how many
+people came to their session, so it can be well out in either direction. Use
+it to pick a room, nothing more. No figure is shown at all if fewer than 10%
+of attendees voted on the proposal, or if nobody voted ❤️.
+:::
 
-That is hardly any data to build on, so the range can be well out in either
-direction — use it to pick a room, nothing more. Expect it to change: the
-formula will be reworked as more events are recorded, and the assumptions
-behind it (currently a fixed guess at how many sessions run at the same time)
-will become settings an organizer can adjust per event. If fewer than 10% of
-attendees voted on the proposal, or nobody voted ❤️, no figure is given at all.
+**Keep voting ⭐ Maybe.** Today's formula happens not to use ⭐ votes, but that
+rests on the same thirteen sessions — and hosts read your ⭐ as real interest
+regardless.
 
-**Keep voting ⭐ Maybe.** Today's formula happens not to use ⭐ votes — at that
-one event they didn't visibly improve the guess — but thirteen sessions prove
-very little, and hosts read your ⭐ as real interest regardless.
-
-The breakdown is for the hosts: on a proposal nobody hosts yet, anyone can see
+The breakdown is for the hosts; on a proposal nobody hosts yet, anyone can see
 it, since anyone may still take it on.
 
 ![Proposals list in the scheduling phase, with a Your vote column and heart and star vote counts per proposal](../screenshots/proposals-results.webp)
@@ -186,113 +158,97 @@ Click a session to see its details and **RSVP**.
 
 ![Session detail popup with host, location, time, attendee list, and full description](../screenshots/session-details.webp)
 
-Unlike votes, **an RSVP is a commitment** — hosts plan around it. If you
-change your mind, take it back with "Un-RSVP": someone else may want the
-place. You'll be warned if you RSVP to two sessions that overlap.
+:::warning "An RSVP is a commitment"
+Unlike votes, hosts plan around it. If you change your mind, take it back with
+"Un-RSVP" — someone else may want the place.
+:::
 
-Depending on how the organizers set the event up, a session's capacity is
-either advisory or a hard limit; with a hard limit the button reads "Session
-full" and no further RSVPs are accepted. A session marked **closed** warns
-that you can be at most five minutes late, but doesn't block your RSVP.
+- You'll be warned if you RSVP to two sessions that overlap.
+- Capacity is either advisory or a hard limit, depending on how the organizers
+  set the event up. With a hard limit the button reads "Session full".
+- A session marked **closed** warns that you can be at most five minutes late,
+  but doesn't block your RSVP.
 
 ## Attendee directory & profiles
 
-Every attendee gets a profile with their bio, proposals, and the sessions
-they're hosting — click any name wherever it appears to see it. It opens over
-the attendee directory rather than replacing it, so from the directory,
-closing a profile puts you back exactly where you were, search and filters
-intact. **Prev** and **Next** at the top move through the attendees one after
-another without going back to the list in between — the arrow keys do the same,
-and on a phone you can swipe sideways from one profile to the next.
-They follow whatever the list is showing, so a search or a filter narrows what
-you read through, and the count at the top says where you are. Escape closes
-the profile. The photo is shown large, since that is how you recognise
-someone; click it to see it larger still. On a wide window it stays beside you
-as you scroll, together with the name, pronouns, location and languages. The
-attendee directory lists everyone at the event on a single page, each with
-their photo and the first couple of lines of their bio — or the first
-conversation starter they answered, if they haven't written a bio — so you can
-read through who is coming without opening anything. Search covers everything on a profile — names, pronouns, bios,
-languages, where someone is based, prompts and their answers, and any contact
-details they published — so a remembered handle, a service name like "Signal",
-or a shared interest is enough to find someone.
-Your private email address is never part of a profile and is never searched.
-
-Two filters narrow the list, and they combine: **Session host** keeps the
-people hosting a session, **Has profile** keeps the people who have filled
-something in — a bio, pronouns, where they're based, languages, a photo, an
-answered conversation starter or a contact detail.
-
-The list is alphabetical by default; **Sort by → Recently updated** puts the
-profiles that changed most recently first, which is the quick way to see who
-has filled theirs in since you last looked. Each row shows when that profile
-was last edited; profiles that are still empty show no date and come last.
-While you are searching, results stay ordered by how well they match, so the
-sort choice is unavailable.
+The directory lists everyone at the event on a single page — photo and the
+first couple of lines of their bio, or their first answered conversation
+starter if they haven't written one — so you can read who is coming without
+opening anything.
 
 ![Searchable attendee directory with avatars, bios, and Session host badges](../screenshots/attendees.webp)
 
+- **Search covers everything on a profile**: names, pronouns, bios, languages,
+  where someone is based, prompts and answers, and any contact details they
+  published. A remembered handle, a service name like "Signal", or a shared
+  interest is enough to find someone. Your private email address is never part
+  of a profile and is never searched.
+- **Two filters, which combine**: **Session host**, and **Has profile**
+  (anyone who filled in a bio, pronouns, location, languages, photo, an
+  answered conversation starter or a contact detail).
+- **Sort by → Recently updated** is the quick way to see who has filled theirs
+  in since you last looked. Each row shows when the profile last changed;
+  empty profiles show no date and come last. While searching, results stay
+  ordered by match instead, so the sort choice is unavailable.
+
+Click any name, wherever it appears, to open that person's profile — bio,
+proposals, and the sessions they're hosting. It opens _over_ the directory
+rather than replacing it, so closing it puts you back exactly where you were,
+search and filters intact.
+
+- **Prev** and **Next** at the top move through attendees without going back
+  to the list — so do the arrow keys, and a sideways swipe on a phone. They
+  follow whatever the list is showing, so a search or filter narrows what you
+  read through, and the count at the top says where you are.
+- **Escape** closes the profile.
+- The photo is shown large, since that's how you recognise someone; click it
+  for larger still. On a wide window it stays beside you as you scroll,
+  together with name, pronouns, location and languages.
+
 ## Your profile
 
-After picking your name, open "Edit profile" to set your About me,
-pronouns, and avatar. These are visible to other attendees wherever your
-name appears (proposals, hosting, RSVPs).
+After picking your name, open **"Edit profile"** to set your About me,
+pronouns, and avatar. These are visible to other attendees wherever your name
+appears — proposals, hosting, RSVPs.
 
-About me, the answers to the conversation starters, and your contact details
-all accept Markdown, so you can add bold text or a named link — and a web
-address or email address you paste in becomes clickable on its own.
+About me, conversation-starter answers, and contact details all accept
+Markdown, and a web or email address you paste in becomes clickable on its own.
 
 ![Edit profile form with name, pronouns, avatar, and a Markdown-supported about-me field](../screenshots/edit-profile.webp)
 
 ## Protect your name
 
-Normally anyone on the site can pick your name and act as you. If you'd
-rather that took a login, open **Settings → Account security** and click
-**Enable protection**. You'll be emailed an 8-character code, valid for 10
-minutes; type it in to confirm. You can optionally set a password at the same
-time.
+Normally anyone on the site can pick your name and act as you. To require a
+login instead, open **Settings → Account security** and click **Enable
+protection**. You'll be emailed an 8-character code, valid for 10 minutes;
+type it in to confirm. You can set a password at the same time.
 
 ![Settings page with email notification checkboxes and an Enable protection button](../screenshots/user-settings.webp)
 
-Once protected, picking your name from the list asks for your password or a
-fresh emailed code. Anything done as you — voting, RSVPing, editing your
-profile, creating or changing your sessions — needs that login. It lasts a
-week, or until you switch to a different name.
-
-To turn protection off or change your password, use either your current
-password or a fresh emailed code — whichever you have to hand. You'll get an
-email letting you know the change happened.
-
-Two things worth knowing:
+Once protected, picking your name asks for that password or a fresh emailed
+code. The login lasts a week, or until you switch to a different name, and
+covers everything done as you: voting, RSVPing, editing your profile, creating
+or changing sessions. Turning protection off or changing the password needs
+either the current password or a fresh code, and you'll get an email telling
+you it happened.
 
 - **Codes go to the email address the organizers have on file for you.** If
   you can't receive it, ask them to check the address. If the event has no
-  email set up at all, protection isn't available.
-- **Protecting your name is what makes your sessions yours.** Only a
-  session's hosts can edit or delete it — but if you haven't protected your
-  name, anyone can pick your name and edit as you. Protection is what closes
-  that gap.
+  email set up, protection isn't available.
+- **Protection is what makes your sessions yours.** Only a session's hosts can
+  edit or delete it — but an unprotected name can be picked by anyone, who then
+  edits as you.
+- **Lost both your password and your email?** Ask an organizer to update the
+  address on file; codes then go to the new one.
 
-Lost access to both your password and your email? Ask an organizer to update
-the email address they have on file for you — codes then go to the new
-address, and you can unlock from there.
+## Settings
 
-## Email settings
-
-If the event has email enabled, Settings also controls which notifications
-you get: when a session you host or RSVP'd to is moved or deleted, when
-someone adds you as a co-host, and when someone comments on a proposal you're
-hosting. These are on by default and can be turned off independently. One
-further setting is off by default: emails about every new comment on a
-proposal you have commented on yourself.
-
-## Dark mode
-
-The switch at the very bottom of every page — System, Light, Dark — chooses
-how the site looks. **System** follows whatever your phone or laptop is set
-to, so the site turns dark in the evening if your device does. The same switch
-is on the settings page under "Appearance".
-
-The choice is remembered on the device you made it on, not on your name: you
-can read the schedule in the dark on your phone while your laptop stays light,
-and it works before you have picked your name.
+- **Email notifications** (if the event has email) — when a session you host
+  or RSVP'd to is moved or deleted, when someone adds you as a co-host, and
+  when someone comments on a proposal you host. All on by default, each can be
+  turned off. Emails about every new comment on a proposal _you_ commented on
+  are off by default.
+- **Appearance** — System, Light or Dark, also available at the very bottom of
+  every page. **System** follows your phone or laptop, so the site turns dark
+  in the evening if your device does. The choice is remembered per device, not
+  per name, and works before you've picked a name.

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -14,27 +14,28 @@ schedule.
 
 ## For attendees
 
-- [Attendee guide](attendee-guide.md) — pick your name, propose a session,
-  vote, RSVP, and protect your name so nobody else can act as you.
+- [Attendee guide](attendee-guide.md) — pick your name, propose, vote, RSVP,
+  and protect your name so nobody else can act as you.
 
-Organizers: this is the page worth sharing with your attendees.
+:::note "Organizers"
+The attendee guide is the page worth sharing with your attendees.
+:::
 
 ## For organizers
 
-- [How it works](organizers/how-it-works.md) — the phase model, who may
-  change what, voting and scheduling rules, kiosk mode, multi-event installs,
-  and exactly which emails get sent.
-- [Admin UI guide](organizers/admin-guide.md) — every setting in `/admin` and
-  why it's there: events, days, locations, guests, proposals, and sessions.
+- [How it works](organizers/how-it-works.md) — phases, who may change what,
+  voting and scheduling rules, kiosk mode, multi-event installs, and which
+  emails get sent.
+- [Admin UI guide](organizers/admin-guide.md) — every setting in `/admin`:
+  events, days, locations, guests, proposals, and sessions.
 
 ## Self-hosting
 
-- [Deployment](self-hosting/deployment.md) — running SchellingBoard with
-  Docker or `docker compose`.
-- [Configuration](self-hosting/configuration.md) — every environment
-  variable, plus how to set up email.
-- [Backup and restore](self-hosting/backup.md) — what to back up, how to do
-  it without stopping the site, and how to restore.
+- [Deployment](self-hosting/deployment.md) — Docker or `docker compose`.
+- [Configuration](self-hosting/configuration.md) — every environment variable,
+  plus how to set up email.
+- [Backup and restore](self-hosting/backup.md) — what to back up, without
+  stopping the site.
 
 SchellingBoard is open source (MIT). The code lives on
 [GitHub](https://github.com/LWCW-Europe/schellingboard).

--- a/docs/public/organizers/admin-guide.md
+++ b/docs/public/organizers/admin-guide.md
@@ -6,17 +6,16 @@ type: guide
 
 # Admin UI guide
 
-The admin UI lives at `/admin`, gated by `ADMIN_PASSWORD`. It is completely
-independent from `SITE_PASSWORD` — the admin password doesn't grant access to
-the attendee site and vice versa. Without `ADMIN_PASSWORD` set, `/admin`
-returns a 404 rather than a login prompt. There's a single shared admin
-password, not per-admin accounts.
+The admin UI lives at `/admin`, gated by a single shared `ADMIN_PASSWORD` (no
+per-admin accounts). It is completely independent from `SITE_PASSWORD` —
+neither password grants access to the other side. Unset, `/admin` returns a
+404 rather than a login prompt.
 
-Both gates also need `AUTH_SECRET` — it signs the login cookies. Changing
-`AUTH_SECRET` logs everyone out (attendees included); changing
-`SITE_PASSWORD` or `ADMIN_PASSWORD` does **not** — existing sessions stay
-valid for up to a week. If you need to revoke access immediately, rotate
-`AUTH_SECRET` as well.
+:::warning "Changing a password does not log anyone out"
+Both gates sign their cookies with `AUTH_SECRET`, and existing sessions stay
+valid for up to a week. To revoke access immediately, rotate `AUTH_SECRET`
+too — which logs out everyone, attendees included.
+:::
 
 ## Site settings
 
@@ -88,15 +87,15 @@ assignment on the event's "Guests" tab.
 ### Attendees who protect their name
 
 Any attendee can opt into
-[name protection](how-it-works.md#attendee-identity) from their own settings,
-turning the name picker into a real login for them. There is no admin control
-over this: you can't require it, and you can't turn it off for someone.
+[name protection](how-it-works.md#attendee-identity) from their own settings.
+There is no admin control over this: you can't require it, and you can't turn
+it off for someone.
 
 The one thing you _can_ do is fix a lockout. Protection is anchored to the
-guest's email address, so an attendee who's lost both their password and
-their mailbox is stuck until you **change their email address here** — codes
-then go to the new address and they can unlock themselves. Verify who you're
-talking to first; this is effectively a password reset.
+guest's email address, so an attendee who's lost both their password and their
+mailbox is stuck until you **change their email address here** — codes then go
+to the new address and they can unlock themselves. **Verify who you're talking
+to first; this is effectively a password reset.**
 
 Deleting and recreating the guest also clears protection, but discards their
 votes, RSVPs, and profile — prefer changing the email.

--- a/docs/public/organizers/how-it-works.md
+++ b/docs/public/organizers/how-it-works.md
@@ -8,43 +8,36 @@ type: concept
 
 ## Attendee identity
 
-By default there's no per-attendee login. After entering the site password
+By default there is no per-attendee login. After entering the site password
 (if set), attendees pick their own name from the guest list assigned to that
-event. This is a convenience selector, **not authentication** — anyone who
-knows the site password can select any attendee's name and vote/RSVP/edit
-proposals as them.
+event.
 
-Any attendee who wants more can **protect their name** from their own
-settings page (see the [attendee guide](../attendee-guide.md#protect-your-name)).
-Protection is opt-in and per-person; there is no way to require it
-event-wide. Once a name is protected:
+:::warning "The name picker is not authentication"
+Anyone who knows the site password can select any attendee's name and
+vote, RSVP, or edit proposals as them.
+:::
 
-- Picking it from the name list asks for a password or an emailed code.
-- Acting as that person — voting, RSVPing, editing their profile, creating
-  or changing sessions — requires that verified browser session.
-- Turning protection off, or changing the password, needs either the current
-  password or an emailed code. The code path means a forgotten password is
-  never a dead end.
+Any attendee who wants more can **protect their name** from their own settings
+page (see the [attendee guide](../attendee-guide.md#protect-your-name)).
+Protection is opt-in and per-person; there is no way to require it event-wide.
+Once a name is protected, picking it asks for a password or an emailed code,
+and acting as that person needs that verified browser session. Turning
+protection off or changing the password needs either the current password or a
+fresh code, so a forgotten password is never a dead end.
 
-Protection needs `AUTH_SECRET`, and enabling it needs working email
-([SMTP settings](../self-hosting/configuration.md#environment-variables)) so the attendee can
-receive a code.
+Protection needs `AUTH_SECRET` and working email
+([SMTP settings](../self-hosting/configuration.md#environment-variables)), so
+the attendee can receive a code.
 
 ## Who can change a session or proposal
 
-Only its hosts. Editing and deleting a session or proposal is restricted to
-the people listed as hosts, with two exceptions: a proposal with no hosts at
-all can be edited by anyone (so unclaimed ideas can be picked up), and an
-admin-managed session can only be changed from the admin UI, not by its
-hosts.
+Only its hosts, with two exceptions: a proposal with **no** hosts can be
+edited by anyone, so unclaimed ideas can be picked up; and an **admin-managed**
+session can only be changed from the admin UI.
 
 Name protection doesn't change _who_ may edit — it changes how hard it is to
-_be_ that person. If a host hasn't protected their name, anyone can select it
-and edit as them; that's the same trade-off as everywhere else in the app. If
-a host has protected their name, editing as them requires their login.
-
-So a session whose hosts are all unprotected is still effectively open to
-anyone willing to pick one of their names. Attendees who want their sessions
+_be_ that person. A session whose hosts are all unprotected is effectively open
+to anyone willing to pick one of their names. Attendees who want their sessions
 to really be theirs need to protect their name.
 
 ## The three phases
@@ -58,74 +51,75 @@ the admin UI:
 | **Voting**     | Vote on proposals (Interested / Maybe / Skip); proposals can still be added/edited |
 | **Scheduling** | Place proposals on the grid, book open slots, RSVP to sessions                     |
 
-Rules:
-
-- A phase with no explicit end runs until the _next_ configured phase's
-  start. Giving a phase an earlier explicit end creates a dead gap where
-  nothing is active.
-- **If no phase dates are set at all**, the event is always in the
-  scheduling phase — useful for a simple fixed schedule with no
-  proposal/voting step.
-- All gating is enforced server-side, not just hidden in the UI — attendees
-  can't act out of phase via an old bookmarked link.
+- A phase with no explicit end runs until the _next_ configured phase's start.
+  Giving a phase an earlier explicit end creates a dead gap where nothing is
+  active.
+- **No phase dates at all** means the event is always in the scheduling phase
+  — useful for a fixed schedule with no proposal/voting step.
+- All gating is enforced server-side, so attendees can't act out of phase via
+  an old bookmarked link.
 
 ## Proposals, voting, and scheduling
 
 - Voting has three choices (Interested / Maybe / Skip), one per guest per
-  proposal; clicking the current choice again removes the vote. "Quick
-  Voting" walks through unvoted proposals one at a time.
+  proposal; clicking the current choice again removes the vote. "Quick Voting"
+  walks through unvoted proposals one at a time.
 - A proposal's host can click "Schedule" (scheduling phase only) to place it
-  on the grid as a real session. The same proposal can be scheduled more
-  than once.
-- During scheduling, a host opening their own proposal sees a vote breakdown:
-  turnout among the event's attendees, the split across the three choices, and
-  a predicted range of attendees (withheld below 10% turnout, or with no ❤️
-  votes). Proposals with no host show the breakdown to everybody, since anyone
-  may still take them on.
-- **Treat that prediction as a very rough guess**, and say so if attendees ask.
-  It rests on one event where thirteen hosts recalled roughly how many people
-  came, and it can be well out either way. The formula will be reworked as
-  more events are recorded, and its assumptions — today a fixed nine sessions
-  running at once, and an attendee list that has to be set up for the
-  prediction to appear at all — are meant to become per-event settings. Don't
-  tell attendees that ⭐ Maybe votes are worthless: today's formula doesn't use
-  them, but that rests on the same thirteen sessions and is far from settled.
+  on the grid. The same proposal can be scheduled more than once.
 - Attendees can also book a blank slot directly in a "bookable" location
   during that day's booking window, without going through a proposal.
-- RSVPs are only possible during the scheduling phase, only for guests
-  assigned to the event. If the event enforces capacity as a hard limit,
-  RSVPs are rejected once a session is full; otherwise capacity is
-  advisory only.
+- RSVPs happen only during the scheduling phase, and only for guests assigned
+  to the event. If the event enforces capacity as a hard limit, RSVPs are
+  rejected once a session is full; otherwise capacity is advisory.
+
+### The attendance prediction
+
+During scheduling, a host opening their own proposal sees a vote breakdown:
+turnout among the event's attendees, the split across the three choices, and a
+predicted range of attendees (withheld below 10% turnout, or with no ❤️ votes).
+Proposals with no host show the breakdown to everybody, since anyone may still
+take them on.
+
+:::warning "Treat the prediction as a very rough guess, and say so if attendees ask"
+It rests on one event where thirteen hosts recalled roughly how many people
+came, and it can be well out either way.
+:::
+
+The formula will be reworked as more events are recorded, and its assumptions
+— today a fixed nine sessions running at once, and an attendee list that has
+to be set up for the prediction to appear at all — are meant to become
+per-event settings. **Don't tell attendees that ⭐ Maybe votes are worthless**:
+today's formula doesn't use them, but that rests on the same thirteen sessions
+and is far from settled.
 
 ## Kiosk mode
 
 Append `?kiosk=1` to a schedule URL for an unattended screen at the venue: a
 red line marks the current time, the view auto-scrolls back to it after a
 minute of no interaction, the screen is kept awake, and the page refreshes
-periodically. It stays fully interactive. Once set, kiosk mode sticks as
-visitors browse the site — clicking through to Proposals and back keeps the
-display in kiosk mode — until you turn it off with `?kiosk=0`. Add
-`&loc=Main+Hall` (repeatable) to show only specific locations — handy for a
-kiosk in one room or a shareable filtered link.
+periodically. It stays fully interactive, and sticks as visitors browse the
+site until you turn it off with `?kiosk=0`. Add `&loc=Main+Hall` (repeatable)
+to show only specific locations — handy for a kiosk in one room, or a
+shareable filtered link.
 
 ![Schedule grid in kiosk mode with a red line marking the current time](../../screenshots/kiosk-mode.webp)
 
 ## Multi-event installs
 
-One deployment can host multiple events. If more than one event exists, the
-root URL shows a list of all events using the global site title/description/
-map (set in [Site settings](admin-guide.md#site-settings)). With exactly one
-event it redirects straight to it. Each event lives entirely under its own
-`/{slug}` route — there's no cross-event attendee state beyond the shared
-guest pool and the picked name.
+One deployment can host multiple events. With more than one event, the root
+URL lists them all using the global site title/description/map (set in
+[Site settings](admin-guide.md#site-settings)); with exactly one it redirects
+straight to it. Each event lives entirely under its own `/{slug}` route —
+there's no cross-event attendee state beyond the shared guest pool and the
+picked name.
 
 ![Home page listing multiple events, each with its dates, phase, and quick links](../../screenshots/home-multi-event.webp)
 
 ## Email
 
-Email is optional. With SMTP unconfigured, SchellingBoard sends nothing at
-all and the features below are simply unavailable. When it is configured,
-these are the only messages ever sent:
+Email is optional. With SMTP unconfigured, SchellingBoard sends nothing at all
+and the features below are simply unavailable. When it is configured, these
+are the only messages ever sent:
 
 | Email                | Sent to                                                               | Opt-out                         |
 | -------------------- | --------------------------------------------------------------------- | ------------------------------- |
@@ -136,9 +130,9 @@ these are the only messages ever sent:
 | **New comment**      | A proposal's hosts, and earlier commenters who opted in               | Per-attendee, in their settings |
 | **Test email**       | One guest, from the admin Users page                                  | n/a                             |
 
-Nothing is emailed on votes, RSVPs, phase transitions, or edits to a
-session's title or description. Whoever made a change is never emailed about
-their own change.
+Nothing is emailed on votes, RSVPs, phase transitions, or edits to a session's
+title or description. Whoever made a change is never emailed about their own
+change.
 
 Enabling email requires `SITE_URL` as well as the SMTP settings, so the
 messages can link back to the site.

--- a/docs/public/self-hosting/backup.md
+++ b/docs/public/self-hosting/backup.md
@@ -10,9 +10,11 @@ Everything SchellingBoard stores lives in one Docker volume, mounted at
 `/data`: the database (`/data/data.db`) and any files uploaded through the
 admin UI, such as guest avatars and the venue map (`/data/uploads`).
 
-Your `.env` is **not** in that volume. Back it up separately — it holds
-`AUTH_SECRET`, `SITE_PASSWORD`, `ADMIN_PASSWORD` and your SMTP credentials,
-and restoring the data without the same `AUTH_SECRET` logs everyone out.
+:::warning "Back up your `.env` separately"
+It is **not** in that volume, and it holds `AUTH_SECRET`, `SITE_PASSWORD`,
+`ADMIN_PASSWORD` and your SMTP credentials. Restoring the data without the
+same `AUTH_SECRET` logs everyone out.
+:::
 
 ## Find the volume
 
@@ -27,10 +29,13 @@ VOL=schellingboard_data
 
 ## Back up without stopping the site
 
-Don't copy `data.db` with `cp` or `tar` while the site is running — a write in
-progress leaves you with a truncated file that looks fine until you try to
-restore it. Use SQLite's own backup command, which takes a consistent snapshot
-of a database that is being written to:
+:::warning "Never `cp` or `tar` a live `data.db`"
+A write in progress leaves you with a truncated file that looks fine until you
+try to restore it.
+:::
+
+Use SQLite's own backup command instead, which takes a consistent snapshot of
+a database that is being written to:
 
 ```bash
 mkdir -p ./backups
@@ -80,14 +85,12 @@ docker run --rm -v "$VOL:/data" -v "$PWD/backups:/backup" alpine sh -c "
 docker compose start app
 ```
 
-The `chown` matters: SchellingBoard runs as user `1001` inside the container,
-but the helper above writes as `root`, so without it the app cannot open its
-own database.
-
-Restoring into a **newer** version of SchellingBoard works — it migrates the
-database on startup. Restoring into an **older** one does not, so pin
-`SCHELLINGBOARD_VERSION` to the version the backup came from if you are
-rolling back.
-
-Check the restore afterwards by opening the site: the events, proposals and
-sessions should be there, and the venue map and guest avatars should load.
+- **The `chown` matters.** SchellingBoard runs as user `1001` inside the
+  container but the helper above writes as `root`, so without it the app
+  cannot open its own database.
+- **Restoring into a newer version works** — it migrates the database on
+  startup. Restoring into an **older** one does not, so pin
+  `SCHELLINGBOARD_VERSION` to the version the backup came from if you are
+  rolling back.
+- **Check afterwards** by opening the site: events, proposals and sessions
+  should be there, and the venue map and guest avatars should load.


### PR DESCRIPTION
Attendees and organizers were not getting through walls of prose, so the
guides lead with bullets and tables and the six things a reader must not
miss are callouts. The attendee guide loses a fifth of its words, mostly
the provenance of the attendance formula and the roadmap for it — both
stay on the organizer page, where they are actionable.

Note for later: ::: tip is a tooltip in docmd 0.9.2, not a callout.

<!-- jip:pushed-commit=4a415011e00474f74c351e6a30593bbab5a3555c -->