### PR TITLE
docs: turn off the docmd AI assistant

### DIFF
--- a/docmd.config.json
+++ b/docmd.config.json
@@ -95,6 +95,9 @@
     }
   ],
   "plugins": {
+    "ai": {
+      "enabled": false
+    },
     "git": {
       "commitHistory": true,
       "maxCommits": 5


### PR DESCRIPTION
It ships enabled by default but we have no API key configured, so the
widget could only fail.

<!-- jip:pushed-commit=c1ad37d0dead28bfeb21e771330449c5f736b3e7 -->