### PR TITLE
fix: Improve profile navigation with smoother sliding transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Moving between attendee profiles slides instead of jumping**: Prev, Next and the arrow keys now slide one profile
+  out as the next slides in, the way a swipe already moves between them
+
+### Fixed
+
+- **Interrupting a profile slide no longer restarts it**: pressing Next or Prev (or swiping again) while a profile was
+  still sliding into place used to snap the card back to the start and replay the whole slide, putting off the arrival a
+  little more with every press. Repeated presses in the same direction now let the first slide simply finish, a press
+  the other way turns the card around smoothly from wherever it is, and catching a sliding card with a finger picks it
+  up where it is instead of teleporting it
+
 ## [3.4.1] - 2026-08-21
 
 ### Fixed

--- a/app/(site)/guests/profile-modal.tsx
+++ b/app/(site)/guests/profile-modal.tsx
@@ -23,8 +23,10 @@ import {
   type ProfileActivity,
 } from "@/app/(site)/guests/profile-activity";
 import {
+  catchSwipe,
+  pressSlide,
+  type Slide,
   startSwipe,
-  type Swipe,
   swipeCommit,
   type SwipeEnds,
   swipeOffset,
@@ -34,10 +36,7 @@ import {
 /** How long the profile takes to finish a swipe the finger has let go of. */
 const SETTLE_MS = 200;
 
-type Drag = { guestId: string; width: number } & (
-  | { phase: "tracking"; swipe: Swipe }
-  | { phase: "settling"; offset: number; commit: -1 | 0 | 1 }
-);
+type Drag = { guestId: string; width: number } & Slide;
 
 /**
  * A guest's profile, read over the list it was opened from. Always a modal:
@@ -99,6 +98,7 @@ export function ProfileModal({
   }, [guestId]);
 
   const viewport = useRef<HTMLDivElement>(null);
+  const row = useRef<HTMLDivElement>(null);
   const [dragged, setDrag] = useState<Drag | null>(null);
   // A drag belongs to the profile it started on, and a finished one is left
   // standing until the URL it asked for arrives: dropping it on the timer
@@ -114,7 +114,16 @@ export function ProfileModal({
     // A second finger is a pinch, the enlarged photo owns the gesture, and a
     // profile outside the collection has nowhere to go.
     if (zoomed || index < 0 || e.touches.length !== 1) return;
-    const swipe = startSwipe(e.touches[0]);
+    const point = e.touches[0];
+    // A finger landing mid-settle picks the card up where it visibly is;
+    // starting the gesture from rest would teleport it under the finger.
+    const settling =
+      dragged?.guestId === guestId && dragged.phase === "settling"
+        ? dragged
+        : null;
+    const swipe = settling
+      ? catchSwipe(point, rowOffset(settling))
+      : startSwipe(point);
     if (!swipe) return;
     setDrag({
       guestId,
@@ -122,6 +131,18 @@ export function ProfileModal({
       swipe,
       width: viewport.current?.clientWidth ?? 0,
     });
+  };
+
+  // How far the settling card actually is, in px past the profile on screen:
+  // the style declares where it is going, the computed matrix holds where the
+  // frame has got to. The row also carries the mounted before-panel, which is
+  // layout, not travel.
+  const rowOffset = (settling: Extract<Drag, { phase: "settling" }>) => {
+    const el = row.current;
+    if (!el) return 0;
+    const matrix = getComputedStyle(el).transform;
+    const tx = matrix === "none" ? 0 : new DOMMatrixReadOnly(matrix).e;
+    return tx + (ends.canPrev ? settling.width : 0);
   };
 
   const onTouchMove = (e: ReactTouchEvent) => {
@@ -163,29 +184,59 @@ export function ProfileModal({
       if (!collection[index + offset]) return;
 
       const width = viewport.current?.clientWidth ?? 0;
-      // The neighbour mounts in one frame and the slide starts in the next: a
-      // settle in the same breath as the mount transitions from the pre-mount
-      // transform, so every press slides the same way. Two rAFs, not
-      // one: a single one can still beat the mounting frame's style pass.
+      const press = pressSlide(
+        dragged?.guestId === guestId ? dragged : null,
+        offset,
+        width
+      );
+      // Already sliding there: restarting would only snap the card backwards
+      // and put off the arrival it is most of the way through.
+      if (press.kind === "arrived") return;
+      // Mid-slide the neighbours are on screen, so the transition retargets
+      // from wherever the card is right now.
+      if (press.kind === "slide") {
+        setDrag({
+          guestId,
+          width,
+          phase: "settling",
+          offset: press.offset,
+          commit: press.commit,
+        });
+        return;
+      }
+
+      // From rest they have to be mounted first: the neighbour mounts in one
+      // frame and the slide starts in the next — a settle in the same breath
+      // as the mount transitions from the pre-mount transform, so every press
+      // slides the same way. Two rAFs, not one: a single one can still beat
+      // the mounting frame's style pass. The guard keeps a stale callback from
+      // clobbering whatever — a caught card, a retarget — happened meanwhile.
       setDrag({
         guestId,
         phase: "tracking",
+        arming: true,
         swipe: { startX: 0, startY: 0, axis: "x", dx: 0 },
         width,
       });
       requestAnimationFrame(() =>
         requestAnimationFrame(() => {
-          setDrag({
-            guestId,
-            phase: "settling",
-            offset: -offset * width,
-            commit: offset,
-            width,
-          });
+          setDrag((prev) =>
+            prev?.guestId === guestId &&
+            prev.phase === "tracking" &&
+            prev.arming
+              ? {
+                  guestId,
+                  width,
+                  phase: "settling",
+                  offset: -offset * width,
+                  commit: offset,
+                }
+              : prev
+          );
         })
       );
     },
-    [collection, index, guestId]
+    [collection, index, guestId, dragged]
   );
 
   useEffect(() => {
@@ -314,6 +365,7 @@ export function ProfileModal({
             // here resolves to auto and the profile is clipped instead of
             // scrolled.
             <div
+              ref={row}
               className="flex min-h-0 flex-1"
               style={{
                 transform: `translateX(${(before ? -width : 0) + offset}px)`,

--- a/app/(site)/guests/swipe.ts
+++ b/app/(site)/guests/swipe.ts
@@ -82,3 +82,44 @@ export function swipeCommit(
 function pulling(swipe: Swipe, ends: SwipeEnds): boolean {
   return swipe.dx < 0 ? ends.canNext : ends.canPrev;
 }
+
+/** One card's slide between profiles: following a finger, or finishing one. */
+export type Slide =
+  | { phase: "tracking"; swipe: Swipe; arming?: true }
+  | { phase: "settling"; offset: number; commit: -1 | 0 | 1 };
+
+/**
+ * What a Prev/Next press means for a slide that may already be running.
+ * Already headed there: nothing — restarting would snap the card backwards
+ * and delay the arrival it is most of the way through. Moving otherwise:
+ * retarget from wherever the card is, which the neighbours being on screen
+ * allows. From rest: mount the neighbours first.
+ */
+export function pressSlide(
+  slide: Slide | null,
+  dir: 1 | -1,
+  width: number
+):
+  | { kind: "arrived" }
+  | { kind: "slide"; offset: number; commit: -1 | 0 | 1 }
+  | { kind: "arm" } {
+  if (slide?.phase === "settling" && slide.commit === dir)
+    return { kind: "arrived" };
+  if (slide) return { kind: "slide", offset: -dir * width, commit: dir };
+  return { kind: "arm" };
+}
+
+/**
+ * A finger landing on a card that is settling takes the gesture over from
+ * where the card visibly is, instead of snapping it back to rest. Seeded
+ * with the travel it inherits, and locked to the x axis: telling a scroll
+ * from a swipe is a decision for gestures that start at rest.
+ */
+export function catchSwipe(point: SwipePoint, offsetPx: number): Swipe {
+  return {
+    startX: point.clientX - offsetPx,
+    startY: point.clientY,
+    axis: "x",
+    dx: offsetPx,
+  };
+}

--- a/tests/unit/profile-swipe.test.ts
+++ b/tests/unit/profile-swipe.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
+  catchSwipe,
+  pressSlide,
   startSwipe,
+  type Swipe,
   swipeCommit,
   swipeOffset,
   trackSwipe,
-  type Swipe,
 } from "@/app/(site)/guests/swipe";
 
 const BOTH_WAYS = { canPrev: true, canNext: true };
@@ -67,5 +69,52 @@ describe("profile swipe", () => {
     expect(swipeCommit(past, WIDTH, ends)).toBe(0);
     // The other direction is unaffected: only the missing end resists.
     expect(swipeOffset(past, BOTH_WAYS)).toBe(-300);
+  });
+
+  const settlingNext = {
+    phase: "settling",
+    offset: -WIDTH,
+    commit: 1,
+  } as const;
+
+  it("lets a card already headed to the next profile arrive", () => {
+    expect(pressSlide(settlingNext, 1, WIDTH)).toEqual({ kind: "arrived" });
+  });
+
+  it("reverses from wherever the card is instead of starting over", () => {
+    expect(pressSlide(settlingNext, -1, WIDTH)).toEqual({
+      kind: "slide",
+      offset: WIDTH,
+      commit: -1,
+    });
+  });
+
+  it("takes over from a finger still holding the card", () => {
+    const held = drag([200, 300], [150, 300]);
+    expect(pressSlide({ phase: "tracking", swipe: held }, 1, WIDTH)).toEqual({
+      kind: "slide",
+      offset: -WIDTH,
+      commit: 1,
+    });
+  });
+
+  it("mounts the neighbours first when starting from rest", () => {
+    expect(pressSlide(null, 1, WIDTH)).toEqual({ kind: "arm" });
+  });
+
+  it("catches a settling card where it visibly is, not back at rest", () => {
+    const point = { clientX: 210, clientY: 300 };
+    const caught = catchSwipe(point, -160);
+    expect(swipeOffset(caught, BOTH_WAYS)).toBe(-160);
+
+    // And follows on from there, rather than restarting the travel.
+    const moved = trackSwipe(caught, { clientX: 180, clientY: 302 });
+    expect(swipeOffset(moved, BOTH_WAYS)).toBe(-190);
+  });
+
+  it("judges a catch by the travel it inherited", () => {
+    // Already most of the way to the next profile: letting go lands it.
+    const caught = catchSwipe({ clientX: 200, clientY: 300 }, -160);
+    expect(swipeCommit(caught, WIDTH, BOTH_WAYS)).toBe(1);
   });
 });


### PR DESCRIPTION
- Profiles now slide smoothly when using Prev, Next, or arrow keys.
- Fixed interruptions during sliding to prevent restarts and ensure seamless transitions.
- Issue: virtualisation blocks successive profile sliding

Issue #845

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>