### PR TITLE
fix: only offer and accept locations attendees may book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Only the event's own rooms can be booked**: the location list when adding or editing a session offered every bookable room in the system, so a session scheduled from the proposal list could end up in a room belonging to another event — and then never appear on the schedule. Attendees are now offered exactly the rooms assigned to that event, that are bookable and not hidden, and a session saved in any other room is refused
+- **The session form says why it was refused**: adding or editing a session that the site turned down showed only "Failed to update session". It now shows the actual reason, such as the name protection or room message
+
+### Security
+
+- **A session's capacity always comes from its room**: the session form sent the room's capacity along with the session, so a hand-crafted request could claim any capacity and get past a hard RSVP limit. Capacity is now read from the room itself
+
 ## [3.4.1] - 2026-08-21
 
 ### Fixed

--- a/app/(site)/[eventSlug]/session-form-page.tsx
+++ b/app/(site)/[eventSlug]/session-form-page.tsx
@@ -21,11 +21,9 @@ export async function renderSessionForm(props: {
     repos.days.listByEvent(event.id),
     repos.sessions.listByEvent(event.id),
     repos.guests.list(),
-    repos.locations.listBookable(),
+    repos.locations.listBookableByEvent(event.id),
     repos.sessionProposals.listByEvent(event.id),
   ]);
-
-  const filteredLocations = locations;
 
   const currentUserProposals = allProposals.filter(
     (p) => currentUser && p.hosts.some((h) => h.id === currentUser)
@@ -38,7 +36,7 @@ export async function renderSessionForm(props: {
         <SessionForm
           event={event}
           days={days}
-          locations={filteredLocations}
+          locations={locations}
           sessions={sessions}
           guests={guests}
           proposals={proposals}

--- a/app/(site)/[eventSlug]/session-form.tsx
+++ b/app/(site)/[eventSlug]/session-form.tsx
@@ -36,7 +36,7 @@ import { MarkdownHint } from "@/app/(site)/markdown";
 import { MarkdownTextarea } from "@/app/components/markdown-textarea";
 
 interface ErrorResponse {
-  message: string;
+  error?: string;
 }
 
 export function SessionForm(props: {
@@ -113,9 +113,11 @@ export function SessionForm(props: {
   );
   const [closed, setClosed] = useState(session.closed);
   const [day, setDay] = useState(initDay ?? days[0]);
+  // Only preselect a location the picker offers: an existing session may sit in
+  // one that has since been unassigned, hidden or closed to self-booking.
   const [locationId, setLocationId] = useState<string | undefined>(
     locations.find((l) => l.name === initLocation)?.id ??
-      session.locations[0]?.id
+      locations.find((l) => l.id === session.locations[0]?.id)?.id
   );
   const startTimes = getAvailableStartTimes(
     day,
@@ -291,7 +293,7 @@ export function SessionForm(props: {
       let errorMessage = "Failed to update session";
       try {
         const errorData = (await res.json()) as ErrorResponse;
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.error || errorMessage;
       } catch {
         errorMessage = res.statusText || `Server error (${res.status})`;
       }
@@ -324,7 +326,7 @@ export function SessionForm(props: {
       let errorMessage = "Failed to delete session";
       try {
         const errorData = (await res.json()) as ErrorResponse;
-        errorMessage = errorData.message || errorMessage;
+        errorMessage = errorData.error || errorMessage;
       } catch {
         errorMessage = res.statusText || `Server error (${res.status})`;
       }

--- a/app/api/add-session/route.ts
+++ b/app/api/add-session/route.ts
@@ -36,6 +36,21 @@ export async function POST(req: NextRequest) {
       { status: 403 }
     );
   }
+  // Exactly the set the session form offers: assigned to the event, not
+  // hidden, and open to self-booking.
+  const bookable = new Map(
+    (await repos.locations.listBookableByEvent(event.id)).map((l) => [l.id, l])
+  );
+  const chosen = input.locationIds.flatMap((id) => bookable.get(id) ?? []);
+  if (chosen.length !== input.locationIds.length || chosen.length === 0) {
+    return Response.json(
+      { error: "A location cannot be booked for this event" },
+      { status: 403 }
+    );
+  }
+  // The payload carries the client's copy of the location; capacity gates the
+  // RSVP hard limit, so take it from the stored row instead.
+  input.capacity = chosen[0].capacity;
   const existingSessions = (await repos.sessions.listScheduled()).filter(
     (s) => s.eventId === input.eventId
   );

--- a/app/api/update-session/route.ts
+++ b/app/api/update-session/route.ts
@@ -54,6 +54,21 @@ export async function POST(req: NextRequest) {
       { status: 403 }
     );
   }
+  // Exactly the set the session form offers: assigned to the event, not
+  // hidden, and open to self-booking.
+  const bookable = new Map(
+    (await repos.locations.listBookableByEvent(event.id)).map((l) => [l.id, l])
+  );
+  const chosen = input.locationIds.flatMap((id) => bookable.get(id) ?? []);
+  if (chosen.length !== input.locationIds.length || chosen.length === 0) {
+    return Response.json(
+      { error: "A location cannot be booked for this event" },
+      { status: 403 }
+    );
+  }
+  // The payload carries the client's copy of the location; capacity gates the
+  // RSVP hard limit, so take it from the stored row instead.
+  input.capacity = chosen[0].capacity;
   const existingSessions = allSessions.filter((ses) => ses.id !== params.id);
   const sessionValid = validateSession(input, existingSessions);
   if (sessionValid) {

--- a/db/repositories/interfaces.ts
+++ b/db/repositories/interfaces.ts
@@ -428,7 +428,11 @@ export interface LocationsRepository {
   ): Promise<EventLocationPage>;
   /** Visible locations assigned to the given event, ordered by sortIndex. */
   listVisibleByEvent(eventId: string): Promise<Location[]>;
-  listBookable(): Promise<Location[]>;
+  /**
+   * Visible, bookable locations assigned to the given event, ordered by
+   * sortIndex — what attendees may pick when scheduling a session.
+   */
+  listBookableByEvent(eventId: string): Promise<Location[]>;
   findById(id: string): Promise<Location | undefined>;
   create(data: Omit<Location, "id">): Promise<Location>;
   update(id: string, data: Omit<Location, "id">): Promise<Location | undefined>;

--- a/db/repositories/sqlite/locations.ts
+++ b/db/repositories/sqlite/locations.ts
@@ -127,19 +127,24 @@ export class SqliteLocationsRepository implements LocationsRepository {
       .map((row) => rowToLocation(row.locations));
   }
 
-  async listBookable(): Promise<Location[]> {
+  async listBookableByEvent(eventId: string): Promise<Location[]> {
     return this.db
       .select()
       .from(schema.locations)
+      .innerJoin(
+        schema.eventLocations,
+        eq(schema.locations.id, schema.eventLocations.locationId)
+      )
       .where(
         and(
+          eq(schema.eventLocations.eventId, eventId),
           eq(schema.locations.hidden, false),
           eq(schema.locations.bookable, true)
         )
       )
-      .orderBy(schema.locations.sortIndex)
+      .orderBy(schema.locations.sortIndex, schema.locations.id)
       .all()
-      .map(rowToLocation);
+      .map((row) => rowToLocation(row.locations));
   }
 
   async findById(id: string): Promise<Location | undefined> {

--- a/docs/public/organizers/admin-guide.md
+++ b/docs/public/organizers/admin-guide.md
@@ -57,13 +57,19 @@ assigned to multiple events. The event's "Locations" tab only
 assigns/unassigns from this pool; it doesn't create new ones.
 
 - **Name, Capacity, Description, Area description, Color** (schedule grid).
-- **Bookable** — whether attendees can self-book blank slots here.
-- **Hidden** — excludes it from the visible grid without deleting it.
+- **Bookable** — whether attendees can self-book blank slots here. A location
+  that isn't bookable still shows on the grid and you can schedule sessions
+  into it yourself; attendees just can't pick it.
+- **Hidden** — excludes it from the visible grid without deleting it, and from
+  everything attendees can book.
 - **Image** — JPEG/PNG/WebP, max 5 MB, min 400px wide, **must be 4:3**
   (±2% tolerance).
 - **Sort order** — controls column order in the grid.
 - **Deleting a location** requires typing the name to confirm; the dialog
   shows how many sessions/events reference it before it cascades.
+
+Attendees are only ever offered the locations assigned to the event they are
+in, that are bookable and not hidden — everything else is refused.
 
 ## Guests / Users
 

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -122,9 +122,11 @@ export async function createLocation(opts?: {
   bookable?: boolean;
   hidden?: boolean;
   sortIndex?: number;
+  /** When set, the location is also assigned to this event. */
+  eventId?: string;
 }): Promise<Location> {
   const { locations } = getRepositories();
-  return locations.create({
+  const location = await locations.create({
     name: opts?.name ?? `Test Room ${Date.now()}`,
     imageUrl: "",
     description: "",
@@ -134,6 +136,10 @@ export async function createLocation(opts?: {
     bookable: opts?.bookable ?? true,
     sortIndex: opts?.sortIndex ?? 0,
   });
+  if (opts?.eventId) {
+    await locations.assignToEvent(opts.eventId, [location.id]);
+  }
+  return location;
 }
 
 export async function createDay(

--- a/tests/integration/add-session.test.ts
+++ b/tests/integration/add-session.test.ts
@@ -104,7 +104,7 @@ describe("POST /api/add-session", () => {
       email: "cohost@test.example",
       eventId: event.id,
     });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(
@@ -122,7 +122,7 @@ describe("POST /api/add-session", () => {
   it("creates a session and returns success", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(makeReq(buildPayload(guest, location, day)));
@@ -145,7 +145,7 @@ describe("POST /api/add-session", () => {
   it("rejects overlap in same location; only the pre-existing session remains", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const r1 = await POST(
@@ -172,8 +172,14 @@ describe("POST /api/add-session", () => {
   it("accepts overlap in different location; both sessions are listed", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const locA = await createLocation({ name: "Workshop Room" });
-    const locB = await createLocation({ name: "Garden Terrace" });
+    const locA = await createLocation({
+      name: "Workshop Room",
+      eventId: event.id,
+    });
+    const locB = await createLocation({
+      name: "Garden Terrace",
+      eventId: event.id,
+    });
     const day = await createDay(event.id);
 
     const r1 = await POST(
@@ -192,7 +198,7 @@ describe("POST /api/add-session", () => {
   it("rejects session with start time in the past", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const pastDay = await createDay(event.id, {
       start: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
     });
@@ -207,7 +213,7 @@ describe("POST /api/add-session", () => {
   it("rejects session with empty title", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(
@@ -219,7 +225,7 @@ describe("POST /api/add-session", () => {
   it("rejects session with no hosts", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(
@@ -231,7 +237,7 @@ describe("POST /api/add-session", () => {
   it("rejects session with missing location id", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(
@@ -243,7 +249,7 @@ describe("POST /api/add-session", () => {
   it("rejects a host who is not part of the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const outsider = await createGuest(); // not assigned to the event
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(makeReq(buildPayload(outsider, location, day)));
@@ -253,11 +259,68 @@ describe("POST /api/add-session", () => {
     expect(sessions).toHaveLength(0);
   });
 
+  it("rejects a location that is not part of the event", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const outsideLocation = await createLocation(); // not assigned to the event
+    const day = await createDay(event.id);
+
+    const res = await POST(makeReq(buildPayload(guest, outsideLocation, day)));
+    expect(res.status).toBe(403);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("rejects a location attendees may not self-book", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({
+      bookable: false,
+      eventId: event.id,
+    });
+    const day = await createDay(event.id);
+
+    const res = await POST(makeReq(buildPayload(guest, location, day)));
+    expect(res.status).toBe(403);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("rejects a hidden location", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ hidden: true, eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(makeReq(buildPayload(guest, location, day)));
+    expect(res.status).toBe(403);
+
+    const sessions = await getRepositories().sessions.listByEvent(event.id);
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("takes capacity from the stored location, not the payload", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const guest = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 10, eventId: event.id });
+    const day = await createDay(event.id);
+
+    const res = await POST(
+      makeReq(buildPayload(guest, { ...location, capacity: 9999 }, day))
+    );
+    expect(res.ok).toBe(true);
+
+    const [session] = await getRepositories().sessions.listByEvent(event.id);
+    expect(session.capacity).toBe(10);
+  });
+
   it("rejects creating as a protected guest without a verified session", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
     await protectGuest(guest.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(
@@ -275,7 +338,7 @@ describe("POST /api/add-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
     await protectGuest(guest.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const res = await POST(

--- a/tests/integration/delete-session.test.ts
+++ b/tests/integration/delete-session.test.ts
@@ -111,7 +111,7 @@ describe("POST /api/delete-session", () => {
   it("deleted session is absent from listByEvent", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, guest, location, day);
@@ -126,7 +126,7 @@ describe("POST /api/delete-session", () => {
   it("rejects delete outside the scheduling phase", async () => {
     const event = await createEvent({ phase: "voting" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
 
     // Create an editable (attendee-scheduled, non-blocker) session directly,
     // bypassing add-session's phase gate.
@@ -157,7 +157,7 @@ describe("POST /api/delete-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ name: "Host", eventId: event.id });
     const attendee = await createGuest({ name: "Attendee" });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const sessionId = await createScheduledSession(
@@ -197,7 +197,7 @@ describe("POST /api/delete-session", () => {
       name: "Attendee",
       email: "attendee@test.example",
     });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const sessionId = await createScheduledSession(
       event.id,
@@ -236,7 +236,7 @@ describe("POST /api/delete-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     const nonHost = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -250,7 +250,7 @@ describe("POST /api/delete-session", () => {
   it("rejects deleting with no acting guest at all", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -265,7 +265,7 @@ describe("POST /api/delete-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await protectGuest(host.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -280,7 +280,7 @@ describe("POST /api/delete-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await protectGuest(host.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 

--- a/tests/integration/locations-by-event.test.ts
+++ b/tests/integration/locations-by-event.test.ts
@@ -47,3 +47,56 @@ describe("locations.listVisibleByEvent", () => {
     expect(result.map((l) => l.id)).toEqual([first.id, second.id]);
   });
 });
+
+describe("locations.listBookableByEvent", () => {
+  beforeAll(() => setupTestDb());
+  beforeEach(() => resetTestDb());
+
+  it("returns only bookable, visible locations assigned to the event", async () => {
+    const { locations } = getRepositories();
+    const event = await createEvent();
+    const otherEvent = await createEvent();
+
+    const bookable = await createLocation({
+      name: "Bookable Room",
+      eventId: event.id,
+    });
+    await createLocation({
+      name: "Other Event Room",
+      eventId: otherEvent.id,
+    });
+    await createLocation({ name: "Unassigned Room" });
+    await createLocation({
+      name: "Hidden Room",
+      hidden: true,
+      eventId: event.id,
+    });
+    await createLocation({
+      name: "Not Bookable Room",
+      bookable: false,
+      eventId: event.id,
+    });
+
+    const result = await locations.listBookableByEvent(event.id);
+    expect(result.map((l) => l.id)).toEqual([bookable.id]);
+  });
+
+  it("orders locations by sortIndex", async () => {
+    const { locations } = getRepositories();
+    const event = await createEvent();
+
+    const second = await createLocation({
+      name: "Second",
+      sortIndex: 5,
+      eventId: event.id,
+    });
+    const first = await createLocation({
+      name: "First",
+      sortIndex: 1,
+      eventId: event.id,
+    });
+
+    const result = await locations.listBookableByEvent(event.id);
+    expect(result.map((l) => l.id)).toEqual([first.id, second.id]);
+  });
+});

--- a/tests/integration/mutating-surface-guard.test.ts
+++ b/tests/integration/mutating-surface-guard.test.ts
@@ -95,7 +95,7 @@ const VERIFIERS: Record<string, Verifier> = {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
     await protectGuest(guest.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const res = await POST(
       new NextRequest("http://test/api/add-session", {
@@ -121,7 +121,7 @@ const VERIFIERS: Record<string, Verifier> = {
     const { POST } = await import("@/app/api/update-session/route");
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const session = await createSession(event.id, {
       hostIds: [host.id],
@@ -155,7 +155,7 @@ const VERIFIERS: Record<string, Verifier> = {
     const { POST } = await import("@/app/api/delete-session/route");
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const session = await createSession(event.id, {
       hostIds: [host.id],
       locationIds: [location.id],

--- a/tests/integration/phase-gating.test.ts
+++ b/tests/integration/phase-gating.test.ts
@@ -67,7 +67,7 @@ async function voteOnProposalIn(phase: "proposal" | "voting" | "scheduling") {
 async function addSessionIn(phase: "proposal" | "voting" | "scheduling") {
   const event = await createEvent({ phase });
   const guest = await createGuest({ eventId: event.id });
-  const location = await createLocation();
+  const location = await createLocation({ eventId: event.id });
   const day = await createDay(event.id);
 
   const payload: SessionParams = {

--- a/tests/integration/update-session.test.ts
+++ b/tests/integration/update-session.test.ts
@@ -129,7 +129,7 @@ describe("POST /api/update-session", () => {
       email: "rsvper@test.example",
       eventId: event.id,
     });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day, {
       startTimeMinutes: 10 * 60,
@@ -163,7 +163,7 @@ describe("POST /api/update-session", () => {
       email: "promoted@test.example",
       eventId: event.id,
     });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day, {
       startTimeMinutes: 10 * 60,
@@ -201,7 +201,7 @@ describe("POST /api/update-session", () => {
   it("changes time without conflict; re-fetched session reflects new time", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, guest, location, day, {
@@ -229,7 +229,7 @@ describe("POST /api/update-session", () => {
   it("rejects move to colliding slot; session remains unchanged", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     await createScheduledSession(event.id, guest, location, day, {
@@ -270,7 +270,7 @@ describe("POST /api/update-session", () => {
   it("does not collide with itself when re-saved with the same slot", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, guest, location, day);
@@ -287,7 +287,7 @@ describe("POST /api/update-session", () => {
   it("rejects update outside the scheduling phase", async () => {
     const event = await createEvent({ phase: "voting" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     // Create an editable (attendee-scheduled, non-blocker) session directly,
@@ -327,7 +327,7 @@ describe("POST /api/update-session", () => {
   it("rejects a host who is not part of the event", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const guest = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, guest, location, day);
@@ -350,7 +350,7 @@ describe("POST /api/update-session", () => {
     const host = await createGuest({ eventId: event.id });
     const rsvper = await createGuest({ eventId: event.id });
     const otherRsvper = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
     await getRepositories().rsvps.create({
@@ -380,8 +380,16 @@ describe("POST /api/update-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host1 = await createGuest({ name: "Host 1", eventId: event.id });
     const host2 = await createGuest({ name: "Host 2", eventId: event.id });
-    const loc1 = await createLocation({ name: "Workshop Room", capacity: 20 });
-    const loc2 = await createLocation({ name: "Garden Terrace", capacity: 50 });
+    const loc1 = await createLocation({
+      name: "Workshop Room",
+      capacity: 20,
+      eventId: event.id,
+    });
+    const loc2 = await createLocation({
+      name: "Garden Terrace",
+      capacity: 50,
+      eventId: event.id,
+    });
     const day = await createDay(event.id);
 
     const id = await createScheduledSession(event.id, host1, loc1, day);
@@ -400,11 +408,74 @@ describe("POST /api/update-session", () => {
     expect(updated.capacity).toBe(50);
   });
 
+  it("takes capacity from the stored location, not the payload", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ capacity: 10, eventId: event.id });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, { ...location, capacity: 9999 }, day), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.ok).toBe(true);
+
+    const updated = (await getRepositories().sessions.findById(id))!;
+    expect(updated.capacity).toBe(10);
+  });
+
+  it("rejects moving the session to a location that is not part of the event", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const outsideLocation = await createLocation({ name: "Outside Room" });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, outsideLocation, day), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.locations[0].id).toBe(location.id);
+  });
+
+  it("rejects moving the session to a location attendees may not self-book", async () => {
+    const event = await createEvent({ phase: "scheduling" });
+    const host = await createGuest({ eventId: event.id });
+    const location = await createLocation({ eventId: event.id });
+    const staffOnly = await createLocation({
+      name: "Staff Room",
+      bookable: false,
+      eventId: event.id,
+    });
+    const day = await createDay(event.id);
+    const id = await createScheduledSession(event.id, host, location, day);
+
+    const res = await POST(
+      makeUpdateReq(
+        { ...basePayload(host, staffOnly, day), id },
+        { editorGuestId: host.id }
+      )
+    );
+    expect(res.status).toBe(403);
+
+    const unchanged = (await getRepositories().sessions.findById(id))!;
+    expect(unchanged.locations[0].id).toBe(location.id);
+  });
+
   it("rejects a non-host attempting to edit", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     const nonHost = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -423,7 +494,7 @@ describe("POST /api/update-session", () => {
   it("rejects editing with no acting guest at all", async () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -443,7 +514,7 @@ describe("POST /api/update-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await protectGuest(host.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 
@@ -463,7 +534,7 @@ describe("POST /api/update-session", () => {
     const event = await createEvent({ phase: "scheduling" });
     const host = await createGuest({ eventId: event.id });
     await protectGuest(host.id);
-    const location = await createLocation();
+    const location = await createLocation({ eventId: event.id });
     const day = await createDay(event.id);
     const id = await createScheduledSession(event.id, host, location, day);
 


### PR DESCRIPTION
The session form listed every bookable location in the install, so a session
scheduled from the proposal list could land in a location belonging to another
event — where it then never showed up on the schedule. Neither add-session nor
update-session checked the submitted location at all.

Both now accept exactly what the form offers: assigned to the event, not
hidden, bookable. Capacity is read from that stored location instead of the
client's copy of it, which could otherwise be forged past a hard RSVP limit.

The form also reports the server's reason for a refusal: it read `message`
from the error body, but every route replies with `error`, so every refusal
showed the generic fallback.

<!-- jip:pushed-commit=7cee1a04833c6149057fcb7990ecabb89bdea3d3 -->